### PR TITLE
FallbackExceptionMapper logs stack traces (CORE-288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# 0.20.1
+
+- JAX-RS Base Server Improvements:
+    - `FallbackExceptionMapper` explicitly logs the stack trace for otherwise unhandled exceptions to aid in diagnosis 
+      of the underlying issue
+
 # 0.20.0
 
 - Build improvements:

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/FallbackExceptionMapper.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/FallbackExceptionMapper.java
@@ -20,12 +20,16 @@ import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Maps otherwise unhandled errors into RFC 7807 Problem responses
  */
 @Provider
 public class FallbackExceptionMapper implements ExceptionMapper<Exception> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FallbackExceptionMapper.class);
 
     private String buildDetail(Throwable e) {
         StringBuilder builder = new StringBuilder();
@@ -54,6 +58,9 @@ public class FallbackExceptionMapper implements ExceptionMapper<Exception> {
                                webEx.getClass().getCanonicalName()).toResponse();
             //@formatter:on
         }
+
+        // Explicitly log the error with its stack trace for diagnostic purposes
+        LOGGER.error("Unhandled exception, see stack trace for more detail:", exception);
 
         // For any other error just translate into a 500 Internal Server Error
         //@formatter:off


### PR DESCRIPTION
The `FallbackExceptionMapper` exists to capture exceptions that aren't otherwise handled by a JAX-RS application and map them into nice JSON responses.  However, in some cases where the error message is very succint, or generic, it doesn't help developers pinpoint where that error actually occurred in their code so they can debug and fix it.

The mapper is modified to now explicitly log the stack trace for the error at `ERROR` level in the logs to aid developers in diagnosing the root cause of such errors.

# Related Issues and PRs

- Should help debugging CORE-288