### PR TITLE
Fixes to Dockerfile (CORE-342)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,9 @@ RUN apt-get update && \
 WORKDIR /app
 RUN mkdir -p /app/ /app/lib/ /app/agents/ /opt/telicent/sbom/
 
+RUN useradd -Mg root telicent-service
+USER telicent-service
+
 ARG PROJECT_VERSION
 COPY cli/cli-common.sh cli/cli-entrypoint.sh /app/
 


### PR DESCRIPTION
Explicitly create and use a non-root user account for running the image