### PR TITLE
Upgrade to Jena 5.1.0

### DIFF
--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractDockerDebugCliTests.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractDockerDebugCliTests.java
@@ -42,6 +42,7 @@ import io.telicent.smart.cache.sources.kafka.sinks.KafkaSink;
 import io.telicent.smart.cache.sources.memory.SimpleEvent;
 import io.telicent.smart.cache.sources.offsets.file.AbstractJacksonOffsetStore;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.sys.JenaSystem;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -60,6 +61,11 @@ import java.util.Objects;
 import static io.telicent.smart.cache.cli.commands.debug.TestLogUtil.enableSpecificLogging;
 
 public class AbstractDockerDebugCliTests extends AbstractCommandTests {
+
+    static {
+        JenaSystem.init();
+    }
+
     protected final KafkaTestCluster kafka = new KafkaTestCluster();
 
     public static void verifyEvents(String format) {

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliCaptureCommand.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliCaptureCommand.java
@@ -144,7 +144,7 @@ public class DockerTestDebugCliCaptureCommand extends AbstractDockerDebugCliTest
         verifyCapturedEvents(captureDir, PlainTextFormat.NAME, "Event %,d");
     }
 
-    @Test(retryAnalyzer = FlakyKafkaTest.class)
+    @Test//(retryAnalyzer = FlakyKafkaTest.class)
     public void givenInputsAndCaptureDirectoryAndRdfFormat_whenRunningCaptureCommand_thenEventsAreCapturedInRdfFormat() throws IOException {
         // Given
         generateKafkaEvents("<http://subject> <http://predicate> \"%d\" .");

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/serializers/TestPayloadDeserializer.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/serializers/TestPayloadDeserializer.java
@@ -58,7 +58,7 @@ public class TestPayloadDeserializer {
             for (int i = 0; i < size; i++) {
                 dataset.add(new Quad(graphName, NodeFactory.createURI("urn:subjects:" + i),
                                      NodeFactory.createURI("urn:predicate"),
-                                     NodeFactory.createLiteral(Integer.toString(i), XSDDatatype.XSDinteger)));
+                                     NodeFactory.createLiteralDT(Integer.toString(i), XSDDatatype.XSDinteger)));
             }
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <dependency.commons-lang>3.14.0</dependency.commons-lang>
         <dependency.jackson>2.17.2</dependency.jackson>
         <dependency.jakarta-inject>2.0.1</dependency.jakarta-inject>
-        <dependency.jena>5.0.0</dependency.jena>
+        <dependency.jena>5.1.0</dependency.jena>
         <dependency.jersey>3.1.7</dependency.jersey>
         <dependency.jetty>12.0.11</dependency.jetty>
         <dependency.jwt-auth>0.15.2</dependency.jwt-auth>

--- a/pom.xml
+++ b/pom.xml
@@ -143,12 +143,24 @@
                 <artifactId>apache-jena-libs</artifactId>
                 <version>${dependency.jena}</version>
                 <type>pom</type>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-suite-engine</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
                 <groupId>org.apache.jena</groupId>
                 <artifactId>jena-arq</artifactId>
                 <version>${dependency.jena}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-suite-engine</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- One minor code change around use of deprecated APIs
- Dependency exclusion to fix bug apache/jena#2593 