### PR TITLE
Changes default server hostname to 0.0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+# 0.22.0
+
+- JAX-RS Base Server improvements:
+    - `ServerBuilder` now defaults to listening on `0.0.0.0`, i.e. all interfaces, rather than `localhost` which reduces
+      inadvertent configuration errors where the server only listens on `localhost` and isn't accessible in some
+      deployment scenarios e.g. running in a container.
+    - New `allInterfaces()` method to make it explicit that you want to listen on all interfaces
+    - New `RandomPortProvider` in `tests` module to make it easier to manage generating a sequence of psuedo-random port
+      numbers to avoid port collisions between tests
+- Build improvements:
+    - Removed unnecessary `logback.xml` from some library modules as these could conflict with application provided
+      logging configurations
+
 # 0.21.2
 
 - Build improvements:
@@ -7,7 +20,7 @@
     - Apache Jena upgraded to 5.1.0
     - Apache Kafka upgraded to 3.8.0
     - Jetty upgraded to 12.0.12
-    - JWT Servlet Auth upgraded to 0.15.3 
+    - JWT Servlet Auth upgraded to 0.15.3
     - OpenTelemetry Agent upgraded to 1.33.5
     - OpenTelemetry Semantic Conventions upgraded to 1.26.0-alpha
     - RDF ABAC upgraded to 0.71.4
@@ -48,13 +61,13 @@
 # 0.20.2
 
 - Build Improvements:
-    - Nexus Staging plugin is now defined in a profile `telicent-oss` allowing it to be disabled for projects using
-      this as a parent which don't wish to deploy via Sonatype OSS repositories
+    - Nexus Staging plugin is now defined in a profile `telicent-oss` allowing it to be disabled for projects using this
+      as a parent which don't wish to deploy via Sonatype OSS repositories
 
 # 0.20.1
 
 - JAX-RS Base Server Improvements:
-    - `FallbackExceptionMapper` explicitly logs the stack trace for otherwise unhandled exceptions to aid in diagnosis 
+    - `FallbackExceptionMapper` explicitly logs the stack trace for otherwise unhandled exceptions to aid in diagnosis
       of the underlying issues
 - Build Improvements:
     - Upgraded various plugins to latest available
@@ -62,14 +75,14 @@
 # 0.20.0
 
 - Build improvements:
-   - Reverted target JDK to 17 to increase portability
-   - Upgraded JWT Servlet Auth to 0.15.0
+    - Reverted target JDK to 17 to increase portability
+    - Upgraded JWT Servlet Auth to 0.15.0
 
 # 0.19.0
 
 - First public release to Maven Central
 - Build improvements:
-   - Added Maven GPG Plugin and Sonatype Nexus Plugin to facilitate release to Maven Central 
+    - Added Maven GPG Plugin and Sonatype Nexus Plugin to facilitate release to Maven Central
 
 # 0.18.1
 
@@ -86,8 +99,8 @@
 # 0.18.0
 
 - Bug Fixes:
-    - Fixed a bug with how `PropertiesSource` resolves configuration values in some cases that could cause configuration 
-      to not be picked up correctly 
+    - Fixed a bug with how `PropertiesSource` resolves configuration values in some cases that could cause configuration
+      to not be picked up correctly
 - Build improvements:
     - Target JDK is now 21
     - JWT Servlet Auth upgraded to 0.12.0
@@ -137,7 +150,6 @@
       `-Dlogback.configurationFile=logback-debug.xml`
 - Build improvements:
     - Various plugins and test dependencies upgraded to latest available
-    
 
 # 0.15.0
 
@@ -145,7 +157,7 @@
     - Malformed `RdfPayload`'s can also be written back to a Kafka topic as-is allowing them to be pushed to a DLQ for
       further analysis.
 - CLI improvements:
-    - **BREAKING** Type signature for `AbstractProjectorCommand.prepareDeadLetterSink()` changed to better reflect 
+    - **BREAKING** Type signature for `AbstractProjectorCommand.prepareDeadLetterSink()` changed to better reflect
       intended API usage and permit for creating multiple sinks for different points in the pipeline where desired.
 - Build improvements:
     - Various dependencies upgraded:
@@ -157,9 +169,9 @@
 # 0.14.1
 
 - Event Source improvements:
-   - `RdfPayload`'s are now lazily deserialized to avoid Kafka Head-of-Line blocking.  
+    - `RdfPayload`'s are now lazily deserialized to avoid Kafka Head-of-Line blocking.
 - Internal improvements:
-    - Micro-optimisation of some internal logic to use more optimal code paths 
+    - Micro-optimisation of some internal logic to use more optimal code paths
 - CLI improvements:
     - Some debugging scripts renamed to have explicit `.sh` extensions
 - JAX-RS Base Server improvements:
@@ -181,7 +193,7 @@
 - Build improvements:
     - Various dependencies upgraded:
         - Apache Jena upgraded to 5.0.0-RC1
-        - Jetty upgraded to 12.0.6 
+        - Jetty upgraded to 12.0.6
         - JWT Servlet Auth upgraded to 0.8.0
         - OpenTelemetry upgraded to 1.35.0
         - RDF ABAC upgraded to 0.70.0
@@ -213,8 +225,7 @@
 
 # 0.13.1
 
-**NOTE** Due to a Maven plugin issue that causes mvn release:perform to fail 
-0.13.1 is not published as a release
+**NOTE** Due to a Maven plugin issue that causes mvn release:perform to fail 0.13.1 is not published as a release
 
 - Build improvements:
     - Various dependencies upgraded:
@@ -252,10 +263,10 @@
 # 0.12.5
 
 - JAX-RS Base Server improvements:
-    - Adds a new default filter into `AbstractApplication` declared classes so that any request failure (status >= 400) 
+    - Adds a new default filter into `AbstractApplication` declared classes so that any request failure (status >= 400)
       is explicitly logged with the failure reason (if available)
-- Add CLI configuration parameters for DLQ topic, and provide a default implementation sink for indexing errors, when 
-  configured. 
+- Add CLI configuration parameters for DLQ topic, and provide a default implementation sink for indexing errors, when
+  configured.
 
 # 0.12.4
 
@@ -270,7 +281,7 @@
 # 0.12.3
 
 - Observability
-    - Add events model to allow components' behaviour to be observed.  
+    - Add events model to allow components' behaviour to be observed.
     - Add metrics model so components' processing can be observed as metrics.
     - Create `OpenTelemetryMetricsAdapter` to bridge our observable metrics to [Open
       Telemetry](https://opentelemetry.io/).
@@ -307,8 +318,8 @@
       instance where necessary.
 - CLI Improvements:
     - `SmartCacheCommand` now provides `--verbose`, `--trace` and `--quiet` options that can reconfigure the root
-      logging level at runtime.  These are automatically provided to and honoured by any command that uses the
-      `SmartCacheCommand` API to run itself.  Since only the root logger level is changed any application logging 
+      logging level at runtime. These are automatically provided to and honoured by any command that uses the
+      `SmartCacheCommand` API to run itself. Since only the root logger level is changed any application logging
       configuration that explicitly sets the level for another logger remains honoured.
     - `SmartCacheCommand` processing will now dump runtime environment information (Memory, Java Version and OS) during
       command startup unless disabled via new `--no-runtime-info` option.
@@ -317,8 +328,8 @@
     - **BREAKING** Deprecated `Defaults` class in favour of new `Configurator` API
 - JAX-RS Base Server improvements:
     - Added `Accept`, `Content-Disposition` and `Content-Type` into `Access-Control-Allowed-Headers` response to CORS
-      requests.  While `Accept` and `Content-Type` were implicitly permitted due to the CORS safe-list not all values
-      for those headers were permitted which prevented some APIs being called from a browser.
+      requests. While `Accept` and `Content-Type` were implicitly permitted due to the CORS safe-list not all values for
+      those headers were permitted which prevented some APIs being called from a browser.
     - **BREAKING** Deprecated `CorsResponseFilter` in favour of `CrossOriginFilter` (from Jetty)
     - Added new `CorsConfigurationBuilder` for configuring CORS as desired.  `ServerBuilder` gains new `withCors()` and
       `withoutCors()` methods for passing in/manipulating this configuration as needed.
@@ -334,8 +345,8 @@
 # 0.11.2
 
 - Fix `KafkaEventSource` shutdown interruption being overly aggressive preventing actual graceful shutdown
-- JaCoCo Code Coverage plugin configuration in parent `pom.xml` sets `append` to true so modules that run their 
-  tests via multiple independent Maven SureFire/FailSafe invocations have all their coverage collected and reported
+- JaCoCo Code Coverage plugin configuration in parent `pom.xml` sets `append` to true so modules that run their tests
+  via multiple independent Maven SureFire/FailSafe invocations have all their coverage collected and reported
 
 # 0.11.1
 
@@ -359,7 +370,7 @@
 - New `live-reporter` module
     - Provides a `LiveReporter` for reporting application status heartbeats for use by our Telicent Live monitoring
       application.
-    - Provides a `LiveErrorReporter` for reporting application errors for use by our Telicent Live monitoring 
+    - Provides a `LiveErrorReporter` for reporting application errors for use by our Telicent Live monitoring
       application.
 - Event Source changes:
     - **BREAKING**: `event-source-file` module has refactored the internal implementation of `YamlEventSource` to reuse
@@ -370,10 +381,10 @@
           format and no key support)
         - Added new `FileEventFormatProvider` interface driven by JVM `ServiceLoader` with `FileEventFormats` registry
 - Projector Driver changes:
-  - **BREAKING**: `ProjectorDriver` no longer has a public constructor and must now be built using a Builder pattern via
-    `ProjectorDriver.create()`
-  - **BREAKING**: Moved all driver related classes into `driver` package to avoid split package between this module and
-    `projectors-core`
+    - **BREAKING**: `ProjectorDriver` no longer has a public constructor and must now be built using a Builder pattern
+      via `ProjectorDriver.create()`
+    - **BREAKING**: Moved all driver related classes into `driver` package to avoid split package between this module
+      and `projectors-core`
 - CLI improvements:
     - Added new `--live-reporter`/`--no-live-reporter` option to relevant commands for enabling/disabling the new Live
       Reporter feature.
@@ -386,8 +397,8 @@
     - Added new `--source-file` option for providing a single file as an event source
     - Improved `--source-format` and `--capture-format` options to more actively reflect supported event file formats
 - Base Server improvements:
-    - Added new `RequestIdFilter` to the base application specification. This adds a `Request-ID` header to all
-      HTTP requests and places it into the Logging `MDC` so logging configuration can include it in their patterns.
+    - Added new `RequestIdFilter` to the base application specification. This adds a `Request-ID` header to all HTTP
+      requests and places it into the Logging `MDC` so logging configuration can include it in their patterns.
     - `CorsResponseFilter` now permits additional headers in pre-flight requests and responses.
     - When running in blocking mode on a background thread ensures that the server is stopped when that background
       thread is cancelled/interrupted
@@ -420,14 +431,14 @@
 ## 0.10.2
 
 - Entity Collector changes:
-    - `MetadataConverter` can now exclude the usage of `GeneratedAtConverter` which can lead to making every
-      generated document unique leading to unnecessary document processing
+    - `MetadataConverter` can now exclude the usage of `GeneratedAtConverter` which can lead to making every generated
+      document unique leading to unnecessary document processing
 
 ## 0.10.1
 
 - Entity Collector changes:
-    - `Ies4DocumentProviderV1` and `Ies4DocumentProviderV2` documentation updated to reflect some practical
-      experience of their usage.
+    - `Ies4DocumentProviderV1` and `Ies4DocumentProviderV2` documentation updated to reflect some practical experience
+      of their usage.
 
 ## 0.10.0
 
@@ -445,13 +456,13 @@
     - New `EntityToMapOutputConverter` implementations for adding metadata to generated documents
 - CLI improvements:
     - `AbstractKafkaRdfProjectionCommand` now defined in terms of `RdfPayload` instead of `DatasetGraph`
-    - `SmartCacheCommandTester` now captures standard output and error for each test to files, or optionally tee's
-      them directly to actual standard output and error to aid in debugging failing tests
+    - `SmartCacheCommandTester` now captures standard output and error for each test to files, or optionally tee's them
+      directly to actual standard output and error to aid in debugging failing tests
 
 ## 0.9.0
 
-- Removed Prometheus Metrics in favour of Open Telemetry, added a new `observability-core` module to provide some
-  helper utilities around this
+- Removed Prometheus Metrics in favour of Open Telemetry, added a new `observability-core` module to provide some helper
+  utilities around this
 - Added a new `/version-info` endpoint to the `jaxrs-base-server`
 - `entity-collector` improvements:
     - Added `hasAnyLiterals()` method to `Entity` class
@@ -459,12 +470,12 @@
 - CLI improvements:
     - `cli-core` tests classifier artifact now provides a framework for writing unit test cases around CLI commands via
       `SmartCacheCommandTester`
-    - Projector commands now have a configurable `--poll-timeout` option available to configure how long to wait on
-      each `poll()` call to the underlying `EventSource`
+    - Projector commands now have a configurable `--poll-timeout` option available to configure how long to wait on each
+      `poll()` call to the underlying `EventSource`
 - `event-source-kafka` improvements:
     - Added a `KafkaSink` for writing `Event` instances back to Kafka
-    - Added a `KafkaTestCluster` into the tests classifier artifact that provides a simple test Kafka cluster via
-      Test Containers
+    - Added a `KafkaTestCluster` into the tests classifier artifact that provides a simple test Kafka cluster via Test
+      Containers
     - Fixed a bug where offsets were not correctly committed on `close()` if a `KafkaEventSource` was in auto-commit
       mode and the source was closed precisely when its internal events buffer was empty
 
@@ -474,8 +485,8 @@
 
 ## 0.8.6
 
-- Fix bug with default labels not being fully realised in entity to document conversions which can potentially result
-  in subsequent overwriting of default labels
+- Fix bug with default labels not being fully realised in entity to document conversions which can potentially result in
+  subsequent overwriting of default labels
     - Also ensures `PrimaryNameConverter` includes fine-grained security labels in its output
 
 ## 0.8.5
@@ -484,9 +495,8 @@
 
 ## 0.8.4
 
-- The `AbstractHealthResource` in `jaxrs-base-server` module now protects against bad derived implementations that
-  fail to generate a suitable `HealthStatus` object generating an appropriate 503 Service Unavailable when this is
-  the case
+- The `AbstractHealthResource` in `jaxrs-base-server` module now protects against bad derived implementations that fail
+  to generate a suitable `HealthStatus` object generating an appropriate 503 Service Unavailable when this is the case
 - Upgrade rdf-abac dependency to 0.6.0
 
 ## 0.8.3
@@ -529,8 +539,8 @@
 
 ## 0.7.1
 
-- Ensure default security labels are stored with each portion of the document so if defaults change in future events
-  the previously applied labels are not overridden
+- Ensure default security labels are stored with each portion of the document so if defaults change in future events the
+  previously applied labels are not overridden
 
 ## 0.7.0
 
@@ -565,8 +575,8 @@
     - `KafkaEventSource` (and derived types) report poll timings, fetch sizes (in number of events) and current lag
     - `cli-core` module now includes `PrometheusOptions` on `SmartCacheCommand` that allows any CLI to opt into exposing
       Prometheus metrics
-    - `jaxrs-base-server` module has opt-in support for collecting HTTP request metrics and exporting Prometheus
-      metrics from the server
+    - `jaxrs-base-server` module has opt-in support for collecting HTTP request metrics and exporting Prometheus metrics
+      from the server
 - Fluent API Improvements
     - `ThroughputTracker`'s are now defined via a fluent builder interface
     - `KafkaEventSource` (and derived types) are now defined via a fluent builder interface

--- a/cli/cli-debug/pom.xml
+++ b/cli/cli-debug/pom.xml
@@ -44,6 +44,14 @@
         </dependency>
 
         <dependency>
+            <groupId>io.telicent.smart-caches</groupId>
+            <artifactId>jaxrs-base-server</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>kafka</artifactId>
             <version>${dependency.testcontainers}</version>

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliHealthProbes.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliHealthProbes.java
@@ -18,6 +18,7 @@ package io.telicent.smart.cache.cli.commands.debug;
 import io.telicent.smart.cache.cli.commands.SmartCacheCommandTester;
 import io.telicent.smart.cache.cli.commands.projection.debug.Capture;
 import io.telicent.smart.cache.server.jaxrs.model.HealthStatus;
+import io.telicent.smart.cache.server.jaxrs.utils.RandomPortProvider;
 import io.telicent.smart.cache.sources.kafka.FlakyKafkaTest;
 import io.telicent.smart.cache.sources.kafka.KafkaTestCluster;
 import jakarta.ws.rs.client.Client;
@@ -33,17 +34,14 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class DockerTestDebugCliHealthProbes extends AbstractDockerDebugCliTests {
 
     private final Client client = ClientBuilder.newClient();
-    private static final Random RANDOM = new Random();
-    private static final AtomicInteger RANDOM_PORT = new AtomicInteger(13333 + RANDOM.nextInt(50));
+    private static final RandomPortProvider RANDOM_PORT = new RandomPortProvider(13333);
 
     @BeforeClass
     @Override
@@ -95,7 +93,7 @@ public class DockerTestDebugCliHealthProbes extends AbstractDockerDebugCliTests 
                     "--capture-dir",
                     captureDir.getAbsolutePath(),
                     "--health-probe-port",
-                    Integer.toString(RANDOM_PORT.incrementAndGet())
+                    Integer.toString(RANDOM_PORT.newPort())
 
             }));
             try {
@@ -106,10 +104,10 @@ public class DockerTestDebugCliHealthProbes extends AbstractDockerDebugCliTests 
 
             // Then
             verifyCommandUsed(Capture.class);
-            WebTarget target = client.target("http://localhost:" + RANDOM_PORT.get() + "/version-info");
+            WebTarget target = client.target("http://localhost:" + RANDOM_PORT.getPort() + "/version-info");
             Response response = target.request(MediaType.APPLICATION_JSON_TYPE).get();
             Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-            target = client.target("http://localhost:" + RANDOM_PORT.get() + "/healthz");
+            target = client.target("http://localhost:" + RANDOM_PORT.getPort() + "/healthz");
             HealthStatus status = target.request(MediaType.APPLICATION_JSON_TYPE).get(HealthStatus.class);
             Assert.assertTrue(status.isHealthy());
 

--- a/cli/cli-probe-server/pom.xml
+++ b/cli/cli-probe-server/pom.xml
@@ -25,6 +25,14 @@
 
         <!-- Test Dependencies -->
         <dependency>
+            <groupId>io.telicent.smart-caches</groupId>
+            <artifactId>jaxrs-base-server</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/Server.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/Server.java
@@ -21,6 +21,7 @@ import org.glassfish.grizzly.servlet.WebappContext;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -32,7 +33,7 @@ public class Server implements AutoCloseable {
 
     private final HttpServer server;
     private final WebappContext webapp;
-    private final URI baseUri;
+    private final URI baseUri, localhostUri;
 
     private final String displayName;
 
@@ -49,6 +50,12 @@ public class Server implements AutoCloseable {
         this.webapp = webapp;
         this.baseUri = baseUri;
         this.displayName = displayName;
+
+        if (Objects.equals(this.baseUri.getHost(), ServerBuilder.DEFAULT_HOSTNAME)) {
+            this.localhostUri = URI.create(String.format("http://localhost:%d", this.baseUri.getPort()));
+        } else {
+            this.localhostUri = null;
+        }
     }
 
     /**
@@ -147,7 +154,7 @@ public class Server implements AutoCloseable {
      * @return Base URI
      */
     public String getBaseUri() {
-        String base = this.baseUri.toString();
+        String base = this.localhostUri != null ? this.localhostUri.toString() : this.baseUri.toString();
         return base + this.webapp.getContextPath();
     }
 

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/ServerBuilder.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/ServerBuilder.java
@@ -60,10 +60,10 @@ import java.util.function.Function;
  * </p>
  * <h2>Defaults</h2>
  * <p>
- * Some default values are set and need not be explicitly specified, the above example did not call
- * {@link #hostname(String)} since the built server will listen on {@code localhost} by default.  Similarly the web
- * application will by default be deployed on the root context i.e. {@code /}, but you could deploy to an alternative
- * context by calling {@link #contextPath(String)} to set a desired context e.g. {@code /app/}
+ * Some sensible default values are automatically set and need not be explicitly specified, the above example did not
+ * call {@link #hostname(String)} so the built server will listen on {@code 0.0.0.0}, aka all interfaces, by default.
+ * Similarly the web application will by default be deployed on the root context i.e. {@code /}, but you could deploy to
+ * an alternative context by calling {@link #contextPath(String)} to set a desired context e.g. {@code /app/}
  * </p>
  */
 public class ServerBuilder {
@@ -74,14 +74,26 @@ public class ServerBuilder {
      */
     public static final String ROOT_CONTEXT = "/";
 
-    private String hostname = "localhost", displayName, contextPath = ROOT_CONTEXT;
+    /**
+     * The default hostname on which the server should listen, this is {@code 0.0.0.0} which means it listens on all
+     * interfaces and hostnames on the host upon which it is run by default
+     */
+    public static final String DEFAULT_HOSTNAME = "0.0.0.0";
+
+    /**
+     * The hostname for listening only on localhost, this will prevent connecting to the server from other hosts,
+     * including when the server is run inside a container
+     */
+    public static final String LOCALHOST = "localhost";
+
+    private String hostname = DEFAULT_HOSTNAME, displayName, contextPath = ROOT_CONTEXT;
     private int port = Integer.MIN_VALUE;
     private Class<? extends Application> applicationClass;
     private final List<Class<? extends ServletContextListener>> listeners = new ArrayList<>();
     private final List<PathExclusion> authExclusions = new ArrayList<>();
     private CorsConfigurationBuilder corsBuilder = new CorsConfigurationBuilder();
     private Integer maxHttpHeaderSize, maxRequestHeaders, maxResponseHeaders;
-    private Map<String, Object> contextAttributes = new LinkedHashMap<>();
+    private final Map<String, Object> contextAttributes = new LinkedHashMap<>();
     private Integer maxThreads;
 
     /**
@@ -112,13 +124,25 @@ public class ServerBuilder {
     }
 
     /**
-     * Specifies that the server should listen on {@code localhost}.  This is the default so need not be explicitly
-     * specified.
+     * Specifies that the server should listen on {@code localhost}.
+     *
+     * @return Builder
+     * @deprecated Listening only on {@code localhost} <strong>SHOULD</strong> be avoided as it will make the server
+     * inaccessible in some deployment scenarios e.g. running inside a container
+     */
+    @Deprecated(since = "0.22.0", forRemoval = false)
+    public ServerBuilder localhost() {
+        return this.hostname(LOCALHOST);
+    }
+
+    /**
+     * Specifies that the server should listen on {@code 0.0.0.0}, effectively making it listen to all interfaces and
+     * hostnames
      *
      * @return Builder
      */
-    public ServerBuilder localhost() {
-        return this.hostname("localhost");
+    public ServerBuilder allInterfaces() {
+        return this.hostname(DEFAULT_HOSTNAME);
     }
 
     /**

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestAttributesServer.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestAttributesServer.java
@@ -23,24 +23,17 @@ import io.telicent.jena.abac.attributes.ValueTerm;
 import io.telicent.jena.abac.core.AttributesStore;
 import io.telicent.jena.abac.core.AttributesStoreLocal;
 import io.telicent.jena.abac.core.AttributesStoreRemote;
+import io.telicent.smart.cache.server.jaxrs.utils.RandomPortProvider;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestAttributesServer {
 
-    private static final Random RANDOM_PORT_FACTOR = new Random();
-
-    /**
-     * Port number to use, incremented each time we build a server.  Starts from a known but randomized port to avoid
-     * port clashes between test runs if the OS is slow to clean up some ports
-     */
-    private static final AtomicInteger PORT = new AtomicInteger(17333 + RANDOM_PORT_FACTOR.nextInt(5, 50));
+    private static final RandomPortProvider PORT = new RandomPortProvider(17333);
 
     @BeforeMethod
     public void setup() {
@@ -52,7 +45,7 @@ public class TestAttributesServer {
     public void givenMockAttributesServerWithNoStore_whenStartingAndLookingUpAttributes_thenNullIsReturned() throws
             IOException {
         // Given
-        MockAttributesServer server = new MockAttributesServer(PORT.getAndIncrement(), null);
+        MockAttributesServer server = new MockAttributesServer(PORT.newPort(), null);
         try {
             // When
             server.start();
@@ -75,7 +68,7 @@ public class TestAttributesServer {
                         AttributeValue.of("admin", ValueTerm.value(true))));
         AttributesStoreLocal local = new AttributesStoreLocal();
         local.put("test", expected);
-        MockAttributesServer server = new MockAttributesServer(PORT.getAndIncrement(), local);
+        MockAttributesServer server = new MockAttributesServer(PORT.newPort(), local);
         try {
             // When
             server.start();
@@ -94,7 +87,7 @@ public class TestAttributesServer {
     public void givenMockAttributesServerWithNoStore_whenStartingAndLookingUpHierarchies_thenNullIsReturned() throws
             IOException {
         // Given
-        MockAttributesServer server = new MockAttributesServer(PORT.getAndIncrement(), null);
+        MockAttributesServer server = new MockAttributesServer(PORT.newPort(), null);
         try {
             // When
             server.start();
@@ -115,7 +108,7 @@ public class TestAttributesServer {
         AttributesStoreLocal local = new AttributesStoreLocal();
         Attribute key = Attribute.create("clearance");
         local.addHierarchy(Hierarchy.create(key, "P", "O", "S", "TS"));
-        MockAttributesServer server = new MockAttributesServer(PORT.getAndIncrement(), local);
+        MockAttributesServer server = new MockAttributesServer(PORT.newPort(), local);
         try {
             // When
             server.start();

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestBrokenHealthServer.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestBrokenHealthServer.java
@@ -19,6 +19,7 @@ import io.telicent.smart.cache.server.jaxrs.init.TestInit;
 import io.telicent.smart.cache.server.jaxrs.model.HealthStatus;
 import io.telicent.smart.cache.server.jaxrs.resources.BrokenStatusHealthResource;
 import io.telicent.smart.cache.server.jaxrs.resources.StatusHealthResource;
+import io.telicent.smart.cache.server.jaxrs.utils.RandomPortProvider;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Invocation;
@@ -28,18 +29,9 @@ import jakarta.ws.rs.core.Response;
 import org.testng.Assert;
 import org.testng.annotations.*;
 
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
-
 public class TestBrokenHealthServer extends AbstractAppEntrypoint {
 
-    private static final Random RANDOM_PORT_FACTOR = new Random();
-
-    /**
-     * Port number to use, incremented each time we build a server.  Starts from a known but randomized port to avoid
-     * port clashes between test runs if the OS is slow to clean up some ports
-     */
-    private static final AtomicInteger PORT = new AtomicInteger(15555 + RANDOM_PORT_FACTOR.nextInt(5, 50));
+    private static final RandomPortProvider PORT = new RandomPortProvider(15555);
 
     private final Client client = ClientBuilder.newClient();
 
@@ -66,7 +58,7 @@ public class TestBrokenHealthServer extends AbstractAppEntrypoint {
         return ServerBuilder.create()
                             .application(MockBrokenHealthApplication.class)
                             // Use a different port for each test just in case one test is slow to teardown the server
-                            .port(PORT.getAndIncrement())
+                            .port(PORT.newPort())
                             .displayName("Broken Health Status Tests");
     }
 

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestCors.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestCors.java
@@ -18,23 +18,15 @@ package io.telicent.smart.cache.server.jaxrs.applications;
 import io.telicent.smart.cache.server.jaxrs.filters.RequestIdFilter;
 import io.telicent.smart.cache.server.jaxrs.init.TestInit;
 import io.telicent.smart.cache.server.jaxrs.resources.StatusHealthResource;
+import io.telicent.smart.cache.server.jaxrs.utils.RandomPortProvider;
 import jakarta.ws.rs.client.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.testng.Assert;
 import org.testng.annotations.*;
 
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
-
 public class TestCors extends AbstractAppEntrypoint {
-    private static final Random RANDOM_PORT_FACTOR = new Random();
-
-    /**
-     * Port number to use, incremented each time we build a server.  Starts from a known but randomized port to avoid
-     * port clashes between test runs if the OS is slow to clean up some ports
-     */
-    private static final AtomicInteger PORT = new AtomicInteger(15888 + RANDOM_PORT_FACTOR.nextInt(5, 50));
+    private static final RandomPortProvider PORT = new RandomPortProvider(15888);
     public static final String EXAMPLE_ORIGIN = "https://example.org";
     public static final String BAD_ORIGIN = "https://bad-origin";
 
@@ -64,7 +56,7 @@ public class TestCors extends AbstractAppEntrypoint {
         return ServerBuilder.create()
                             .application(MockHealthApplication.class)
                             // Use a different port for each test just in case one test is slow to teardown the server
-                            .port(PORT.getAndIncrement())
+                            .port(PORT.newPort())
                             // Enable CORS with various additional headers and origins
                             .withCors(new CorsConfigurationBuilder(false))
                             .withCors(c -> c.preflightMaxAge(60)

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestHealthServer.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestHealthServer.java
@@ -19,6 +19,7 @@ import io.telicent.smart.cache.server.jaxrs.filters.RequestIdFilter;
 import io.telicent.smart.cache.server.jaxrs.init.TestInit;
 import io.telicent.smart.cache.server.jaxrs.model.HealthStatus;
 import io.telicent.smart.cache.server.jaxrs.resources.StatusHealthResource;
+import io.telicent.smart.cache.server.jaxrs.utils.RandomPortProvider;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Invocation;
@@ -32,19 +33,10 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.HashSet;
-import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestHealthServer extends AbstractAppEntrypoint {
-
-    private static final Random RANDOM_PORT_FACTOR = new Random();
-
-    /**
-     * Port number to use, incremented each time we build a server.  Starts from a known but randomized port to avoid
-     * port clashes between test runs if the OS is slow to clean up some ports
-     */
-    private static final AtomicInteger PORT = new AtomicInteger(14777 + RANDOM_PORT_FACTOR.nextInt(5, 50));
+    private static final RandomPortProvider PORT = new RandomPortProvider(14777);
 
     private final Client client = ClientBuilder.newClient();
 
@@ -69,7 +61,7 @@ public class TestHealthServer extends AbstractAppEntrypoint {
     protected ServerBuilder buildServer() {
         return ServerBuilder.create().application(MockHealthApplication.class)
                             // Use a different port for each test just in case one test is slow to teardown the server
-                            .port(PORT.getAndIncrement()).displayName("Health Status Tests");
+                            .port(PORT.newPort()).displayName("Health Status Tests");
     }
 
     private WebTarget forServer(Server server, String path) {

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServer.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServer.java
@@ -24,6 +24,7 @@ import io.telicent.smart.cache.server.jaxrs.model.MockData;
 import io.telicent.smart.cache.server.jaxrs.model.Problem;
 import io.telicent.smart.cache.server.jaxrs.model.VersionInfo;
 import io.telicent.smart.cache.server.jaxrs.resources.DataResource;
+import io.telicent.smart.cache.server.jaxrs.utils.RandomPortProvider;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.ServerErrorException;
@@ -37,20 +38,12 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.net.ConnectException;
-import java.util.Random;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 public class TestServer extends AbstractAppEntrypoint {
 
-    private static final Random RANDOM_PORT_FACTOR = new Random();
-
-    /**
-     * Port number to use, incremented each time we build a server.  Starts from a known but randomized port to avoid
-     * port clashes between test runs if the OS is slow to clean up some ports
-     */
-    private static final AtomicInteger PORT = new AtomicInteger(13666 + RANDOM_PORT_FACTOR.nextInt(5, 50));
+    private static final RandomPortProvider PORT = new RandomPortProvider(1366);
 
     private final Client client = ClientBuilder.newClient();
 
@@ -69,7 +62,7 @@ public class TestServer extends AbstractAppEntrypoint {
     protected ServerBuilder buildServer() {
         return ServerBuilder.create().application(MockApplication.class)
                             // Use a different port for each test just in case one test is slow to teardown the server
-                            .port(PORT.getAndIncrement()).displayName("Test");
+                            .port(PORT.newPort()).displayName("Test");
     }
 
     private WebTarget forServer(Server server, String path) {
@@ -126,6 +119,7 @@ public class TestServer extends AbstractAppEntrypoint {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void server_01d() throws IOException {
         ServerBuilder builder = buildServer();
         builder = builder.localhost();

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServerBuilder.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServerBuilder.java
@@ -106,7 +106,7 @@ public class TestServerBuilder {
         Server server =
                 ServerBuilder.create().application(MockApplication.class).port(1234).displayName("Test").build();
         Assert.assertEquals(server.getDisplayName(), "Test");
-        Assert.assertEquals(server.getHostname(), "localhost");
+        Assert.assertEquals(server.getHostname(), ServerBuilder.DEFAULT_HOSTNAME);
         Assert.assertEquals(server.getPort(), 1234);
         Assert.assertEquals(server.getBaseUri(), "http://localhost:1234/");
 
@@ -123,7 +123,7 @@ public class TestServerBuilder {
                              .displayName("Test")
                              .build();
         Assert.assertEquals(server.getDisplayName(), "Test");
-        Assert.assertEquals(server.getHostname(), "localhost");
+        Assert.assertEquals(server.getHostname(), ServerBuilder.DEFAULT_HOSTNAME);
         Assert.assertEquals(server.getPort(), 56780);
         Assert.assertEquals(server.getBaseUri(), "http://localhost:56780/");
 
@@ -140,7 +140,7 @@ public class TestServerBuilder {
                              .displayName("Test")
                              .build();
         Assert.assertEquals(server.getDisplayName(), "Test");
-        Assert.assertEquals(server.getHostname(), "localhost");
+        Assert.assertEquals(server.getHostname(), ServerBuilder.DEFAULT_HOSTNAME);
         Assert.assertEquals(server.getPort(), 56780);
         Assert.assertEquals(server.getBaseUri(), "http://localhost:56780/a/unit/test");
 
@@ -158,7 +158,7 @@ public class TestServerBuilder {
                              .displayName("Test")
                              .build();
         Assert.assertEquals(server.getDisplayName(), "Test");
-        Assert.assertEquals(server.getHostname(), "localhost");
+        Assert.assertEquals(server.getHostname(), ServerBuilder.DEFAULT_HOSTNAME);
         Assert.assertEquals(server.getPort(), 56780);
         Assert.assertEquals(server.getBaseUri(), "http://localhost:56780/");
 

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServerLimits.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServerLimits.java
@@ -15,6 +15,7 @@
  */
 package io.telicent.smart.cache.server.jaxrs.applications;
 
+import io.telicent.smart.cache.server.jaxrs.utils.RandomPortProvider;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -30,18 +31,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestServerLimits {
-
-    private static final Random RANDOM_PORT_FACTOR = new Random();
-
-    /**
-     * Port number to use, incremented each time we build a server.  Starts from a known but randomized port to avoid
-     * port clashes between test runs if the OS is slow to clean up some ports
-     */
-    private static final AtomicInteger PORT = new AtomicInteger(21212 + RANDOM_PORT_FACTOR.nextInt(5, 50));
+    private static final RandomPortProvider PORT = new RandomPortProvider(21212);
 
     private final Client client = ClientBuilder.newClient();
 
@@ -194,7 +186,7 @@ public class TestServerLimits {
 
     private static ServerBuilder buildCommon() {
         return ServerBuilder.create()
-                            .port(PORT.getAndIncrement())
+                            .port(PORT.newPort())
                             .application(MockHealthApplication.class)
                             .displayName("Limit Tests");
     }

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServerWithConfigurableAuth.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServerWithConfigurableAuth.java
@@ -24,6 +24,7 @@ import io.telicent.servlet.auth.jwt.verifier.aws.AwsElbKeyUrlRegistry;
 import io.telicent.smart.cache.configuration.Configurator;
 import io.telicent.smart.cache.configuration.sources.ConfigurationSource;
 import io.telicent.smart.cache.configuration.sources.PropertiesSource;
+import io.telicent.smart.cache.server.jaxrs.utils.RandomPortProvider;
 import io.telicent.smart.caches.configuration.auth.AuthConstants;
 import io.telicent.smart.cache.server.jaxrs.init.JwtAuthInitializer;
 import io.telicent.smart.cache.server.jaxrs.init.MockAuthInit;
@@ -43,17 +44,9 @@ import java.security.interfaces.ECPrivateKey;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestServerWithConfigurableAuth extends AbstractAppEntrypoint {
-
-    private static final Random RANDOM_PORT_FACTOR = new Random();
-
-    /**
-     * Port number to use, incremented each time we build a server.  Starts from a known but randomized port to avoid
-     * port clashes between test runs if the OS is slow to clean up some ports
-     */
-    private static final AtomicInteger PORT = new AtomicInteger(22334 + RANDOM_PORT_FACTOR.nextInt(5, 50));
+    private static final RandomPortProvider PORT = new RandomPortProvider(22334);
 
     private final Client client = ClientBuilder.newClient();
 
@@ -95,7 +88,7 @@ public class TestServerWithConfigurableAuth extends AbstractAppEntrypoint {
     protected ServerBuilder buildServer() {
         return ServerBuilder.create().application(MockApplicationWithAuth.class)
                             // Use a different port for each test just in case one test is slow to teardown the server
-                            .port(PORT.getAndIncrement()).displayName("Test");
+                            .port(PORT.newPort()).displayName("Test");
     }
 
     private WebTarget forServer(Server server, String path) {

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestWithoutCors.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestWithoutCors.java
@@ -18,6 +18,7 @@ package io.telicent.smart.cache.server.jaxrs.applications;
 import io.telicent.smart.cache.server.jaxrs.filters.RequestIdFilter;
 import io.telicent.smart.cache.server.jaxrs.init.TestInit;
 import io.telicent.smart.cache.server.jaxrs.resources.StatusHealthResource;
+import io.telicent.smart.cache.server.jaxrs.utils.RandomPortProvider;
 import jakarta.ws.rs.client.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -27,17 +28,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
-
 public class TestWithoutCors extends AbstractAppEntrypoint {
-    private static final Random RANDOM_PORT_FACTOR = new Random();
-
-    /**
-     * Port number to use, incremented each time we build a server.  Starts from a known but randomized port to avoid
-     * port clashes between test runs if the OS is slow to clean up some ports
-     */
-    private static final AtomicInteger PORT = new AtomicInteger(16999 + RANDOM_PORT_FACTOR.nextInt(5, 50));
+    private static final RandomPortProvider PORT = new RandomPortProvider(16999);
     public static final String EXAMPLE_ORIGIN = "https://example.org";
     public static final String BAD_ORIGIN = "https://bad-origin";
 
@@ -67,7 +59,7 @@ public class TestWithoutCors extends AbstractAppEntrypoint {
         return ServerBuilder.create()
                             .application(MockHealthApplication.class)
                             // Use a different port for each test just in case one test is slow to teardown the server
-                            .port(PORT.getAndIncrement())
+                            .port(PORT.newPort())
                             // Explicitly disable CORS
                             .withoutCors()
                             .displayName("CORS Disabled Tests");

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/utils/RandomPortProvider.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/utils/RandomPortProvider.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.server.jaxrs.utils;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A provider of a sequence of port numbers starting from some base port with a random adjustment applied.
+ * <p>
+ * This is designed to reduce test failures that can happen when the OS is slow to release ports.
+ * </p>
+ */
+public final class RandomPortProvider {
+
+    private final AtomicInteger port;
+    private static final Random RANDOM = new Random();
+
+    /**
+     * Creates a new random port provider
+     *
+     * @param basePort Base port to use as starting point for generating the sequence of port numbers
+     */
+    public RandomPortProvider(int basePort) {
+        this.port = new AtomicInteger(basePort + RANDOM.nextInt(5, 50));
+    }
+
+    /**
+     * Gets the current port number in use
+     *
+     * @return Current port number
+     */
+    public int getPort() {
+        return this.port.get();
+    }
+
+    /**
+     * Gets a new port number to use
+     *
+     * @return New port number
+     */
+    public int newPort() {
+        return this.port.incrementAndGet();
+    }
+}


### PR DESCRIPTION
This means the server listens on all interfaces by default which avoids a common configuration error where when running in some deployment environments, e.g. containers, the server would not be reachable as it previously defaulted to listening on localhost

Also cleaned up some repeated test code around managing random port sequences to make it reusable across all tests