### PR TITLE
/healthz caches health status (CORE-422)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,17 @@
     - `ServerBuilder` now defaults to listening on `0.0.0.0`, i.e. all interfaces, rather than `localhost` which reduces
       inadvertent configuration errors where the server only listens on `localhost` and isn't accessible in some
       deployment scenarios e.g. running in a container.
-    - New `allInterfaces()` method to make it explicit that you want to listen on all interfaces
+    - `ServerBuilder` adds new `allInterfaces()` method to make it explicit that you want to listen on all interfaces
+      when building your server.
     - New `RandomPortProvider` in `tests` module to make it easier to manage generating a sequence of psuedo-random port
-      numbers to avoid port collisions between tests
+      numbers to avoid port collisions between tests.
+    - `AbstractHealthResource` now caches the computed `HealthStatus` for 30 seconds to remove the ability for a
+      malicious user to DoS attack a server (and its underlying services where those are probed as part of computing the
+      health status) via its `/healthz` endpoint.
+    - **BREAKING:** `AbstractApplication` **MUST** now override a new `getHealthResourceClass()` method to supply either
+      a resource class derived from `AbstractHealthResource` or `null` if it does not want to provide a `/healthz`
+      endpoint.  This change is designed to ensure that all application developers at least consider whether a health
+      resource is needed and to ensure they receive the DoS attack mitigation also included in this release.
 - Build improvements:
     - Removed unnecessary `logback.xml` from some library modules as these could conflict with application provided
       logging configurations

--- a/cli/cli-probe-server/src/main/java/io/telicent/smart/cache/cli/probes/HealthProbeApplication.java
+++ b/cli/cli-probe-server/src/main/java/io/telicent/smart/cache/cli/probes/HealthProbeApplication.java
@@ -17,21 +17,18 @@ package io.telicent.smart.cache.cli.probes;
 
 import io.telicent.smart.cache.cli.probes.resources.ReadinessResource;
 import io.telicent.smart.cache.server.jaxrs.applications.AbstractApplication;
-
-import java.util.Set;
+import io.telicent.smart.cache.server.jaxrs.resources.AbstractHealthResource;
 
 public final class HealthProbeApplication extends AbstractApplication {
-
-    @Override
-    public Set<Class<?>> getClasses() {
-        Set<Class<?>> classes = super.getClasses();
-        classes.add(ReadinessResource.class);
-        return classes;
-    }
 
     @Override
     protected boolean isAuthEnabled() {
         // Authentication is ALWAYS disabled for the health probe application
         return false;
+    }
+
+    @Override
+    protected Class<? extends AbstractHealthResource> getHealthResourceClass() {
+        return ReadinessResource.class;
     }
 }

--- a/cli/cli-probe-server/src/test/java/io/telicent/smart/cache/cli/probes/TestHealthProbeServer.java
+++ b/cli/cli-probe-server/src/test/java/io/telicent/smart/cache/cli/probes/TestHealthProbeServer.java
@@ -21,6 +21,7 @@ import io.telicent.smart.cache.cli.probes.resources.ReadinessResource;
 import io.telicent.smart.cache.server.jaxrs.applications.AbstractAppEntrypoint;
 import io.telicent.smart.cache.server.jaxrs.model.HealthStatus;
 import io.telicent.smart.cache.server.jaxrs.model.VersionInfo;
+import io.telicent.smart.cache.server.jaxrs.resources.AbstractHealthResource;
 import io.telicent.smart.cache.server.jaxrs.utils.RandomPortProvider;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -331,8 +332,11 @@ public class TestHealthProbeServer {
         // And
         verifyLiveness(server);
         verifyReadiness(server, false);
+        AbstractHealthResource.invalidateCachedStatus();
         verifyReadiness(server, true);
+        AbstractHealthResource.invalidateCachedStatus();
         verifyReadiness(server, false);
+        AbstractHealthResource.invalidateCachedStatus();
         verifyReadinessWarningLogged();
     }
 }

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/AbstractApplication.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/AbstractApplication.java
@@ -19,9 +19,12 @@ import io.telicent.servlet.auth.jwt.jaxrs3.JwtAuthFilter;
 import io.telicent.smart.cache.server.jaxrs.errors.*;
 import io.telicent.smart.cache.server.jaxrs.filters.FailureLoggingFilter;
 import io.telicent.smart.cache.server.jaxrs.filters.RequestIdFilter;
+import io.telicent.smart.cache.server.jaxrs.resources.AbstractHealthResource;
 import io.telicent.smart.cache.server.jaxrs.resources.VersionInfoResource;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -35,7 +38,8 @@ import java.util.Set;
  * </p>
  */
 @ApplicationPath("/")
-public class AbstractApplication extends Application {
+public abstract class AbstractApplication extends Application {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractApplication.class);
 
     @Override
     public Set<Class<?>> getClasses() {
@@ -53,6 +57,13 @@ public class AbstractApplication extends Application {
         }
         classes.add(RequestIdFilter.class);
         classes.add(FailureLoggingFilter.class);
+        // Health Resource
+        Class<? extends AbstractHealthResource> healthResourceClass = getHealthResourceClass();
+        if (healthResourceClass != null) {
+            classes.add(healthResourceClass);
+        } else {
+            LOGGER.warn("No Health Resource available for application {}", this.getClass().getCanonicalName());
+        }
         // Version Info Resource
         classes.add(VersionInfoResource.class);
         return classes;
@@ -66,4 +77,10 @@ public class AbstractApplication extends Application {
     protected boolean isAuthEnabled() {
         return false;
     }
+
+    /**
+     * Gets the health resource class that should be used for the application
+     * @return Health Resource class
+     */
+    protected abstract Class<? extends AbstractHealthResource> getHealthResourceClass();
 }

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/AbstractApplication.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/AbstractApplication.java
@@ -62,7 +62,7 @@ public abstract class AbstractApplication extends Application {
         if (healthResourceClass != null) {
             classes.add(healthResourceClass);
         } else {
-            LOGGER.warn("No Health Resource available for application {}", this.getClass().getCanonicalName());
+            LOGGER.warn("No standardised Health Resource available for application {}", this.getClass().getCanonicalName());
         }
         // Version Info Resource
         classes.add(VersionInfoResource.class);
@@ -80,7 +80,15 @@ public abstract class AbstractApplication extends Application {
 
     /**
      * Gets the health resource class that should be used for the application
-     * @return Health Resource class
+     * <p>
+     * The derived application <strong>MAY</strong> choose to return {@code null} here to indicate that they don't want
+     * to provide a {@code /healthz} endpoint, or that they are implementing their own endpoint without using
+     * {@link AbstractHealthResource}.  However implementations <strong>SHOULD</strong> create their health endpoint by
+     * deriving from {@link AbstractHealthResource} wherever possible as it handles common error conditions and DoS
+     * mitigations for the endpoint.
+     * </p>
+     *
+     * @return Health Resource class, or {@code null}
      */
     protected abstract Class<? extends AbstractHealthResource> getHealthResourceClass();
 }

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/resources/AbstractHealthResource.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/resources/AbstractHealthResource.java
@@ -15,6 +15,8 @@
  */
 package io.telicent.smart.cache.server.jaxrs.resources;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.telicent.smart.cache.server.jaxrs.model.HealthStatus;
 import jakarta.servlet.ServletContext;
 import jakarta.ws.rs.GET;
@@ -23,7 +25,9 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,6 +38,19 @@ import java.util.List;
 public abstract class AbstractHealthResource {
 
     /**
+     * A cache used to hold the most recently computed Health Status of the application
+     */
+    private static final Cache<String, HealthStatus> CACHED_STATUS =
+            Caffeine.newBuilder().maximumSize(10).initialCapacity(1).expireAfterWrite(Duration.ofSeconds(30)).build();
+
+    /**
+     * Invalidates the cached health status, generally only needs to be called from tests
+     */
+    public static void invalidateCachedStatus() {
+        CACHED_STATUS.invalidateAll();
+    }
+
+    /**
      * Error message returned when the derived resource fails to generate a Health Status
      */
     public static final String UNEXPECTED_ERROR_REASON =
@@ -41,6 +58,12 @@ public abstract class AbstractHealthResource {
 
     /**
      * Returns a health response
+     * <p>
+     * The underlying {@link HealthStatus}, as computed by the {@link #determineStatus(ServletContext)} method, will be
+     * cached for up to 30 seconds so subsequent requests to this endpoint within that window will return the same
+     * status.  This is so that repeated requests to the {@code /healthz} endpoint do not allow an indirect denial of
+     * service attack against underlying services that the application may be probing to determine its health status.
+     * </p>
      *
      * @param servletContext Servlet Context
      * @return Health response
@@ -48,14 +71,19 @@ public abstract class AbstractHealthResource {
     @GET
     @Produces({ MediaType.APPLICATION_JSON })
     @Path("healthz")
-    public Response healthy(@Context ServletContext servletContext) {
+    public Response healthy(@Context ServletContext servletContext, @Context UriInfo uriInfo) {
         HealthStatus status;
         try {
-            status = this.determineStatus(servletContext);
+            // Could potentially be multiple servers/applications running in the same JVM so differentiate their cached
+            // status by the host, port and path at which it was reached
+            String healthKeyCache =
+                    String.format("%s:%d%s", uriInfo.getRequestUri().getHost(), uriInfo.getRequestUri().getPort(),
+                                  uriInfo.getRequestUri().getPath());
+            status = CACHED_STATUS.get(healthKeyCache, k -> this.determineStatus(servletContext));
         } catch (Throwable t) {
-            // There is a bug we've seen where a derived resources determineStatus() method hits an error that then
-            // results in a 500 Internal Server Error rather than an actual 503 Service Unavailable so catch that
-            // possibility here and report it appropriately
+            // There is an issue we've seen where a derived resources determineStatus() implementation hits an error
+            // that then results in a 500 Internal Server Error rather than an actual 503 Service Unavailable so catch
+            // that possibility here and report it appropriately with a generic error message
             status = new HealthStatus(false, List.of(UNEXPECTED_ERROR_REASON, t.getMessage()), Collections.emptyMap());
         }
         return Response.status(status.isHealthy() ? Response.Status.OK : Response.Status.SERVICE_UNAVAILABLE)
@@ -65,6 +93,12 @@ public abstract class AbstractHealthResource {
 
     /**
      * Determines the status for the server
+     * <p>
+     * Computing this may involve probing other services that the application depends upon to accurately report the
+     * health status of the server.  However, the calling method {@link #healthy(ServletContext, UriInfo)} will cache
+     * the computed response for a while (30 seconds) in order to avoid the {@code /healthz} endpoint enabling an
+     * indirect Denial of Service attack on the underlying services.
+     * </p>
      *
      * @param context Servlet Context
      * @return Health Status

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/resources/AbstractHealthResource.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/resources/AbstractHealthResource.java
@@ -37,11 +37,23 @@ import java.util.List;
 @Path("/")
 public abstract class AbstractHealthResource {
 
+    private static final int CACHE_SIZE = 10;
+    private static final Duration CACHE_DURATION = Duration.ofSeconds(30);
     /**
      * A cache used to hold the most recently computed Health Status of the application
+     * <p>
+     * Because multiple applications/servers may be hosted within a single JVM this cache, while a static singleton, has
+     * a default size of {@value #CACHE_SIZE} to account for that.  Computed health statuses for different
+     * applications/servers are stored in the cache against a key based upon the host domain, port and path of the
+     * {@code /healthz} endpoint answering the request.
+     * </p>
      */
     private static final Cache<String, HealthStatus> CACHED_STATUS =
-            Caffeine.newBuilder().maximumSize(10).initialCapacity(1).expireAfterWrite(Duration.ofSeconds(30)).build();
+            Caffeine.newBuilder()
+                    .maximumSize(CACHE_SIZE)
+                    .initialCapacity(CACHE_SIZE)
+                    .expireAfterWrite(CACHE_DURATION)
+                    .build();
 
     /**
      * Invalidates the cached health status, generally only needs to be called from tests

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockApplication.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockApplication.java
@@ -16,10 +16,7 @@
 package io.telicent.smart.cache.server.jaxrs.applications;
 
 import io.telicent.smart.cache.server.jaxrs.parameters.ModeParametersProvider;
-import io.telicent.smart.cache.server.jaxrs.resources.DataResource;
-import io.telicent.smart.cache.server.jaxrs.resources.HealthResource;
-import io.telicent.smart.cache.server.jaxrs.resources.ParamsResource;
-import io.telicent.smart.cache.server.jaxrs.resources.ProblemsResource;
+import io.telicent.smart.cache.server.jaxrs.resources.*;
 
 import java.util.Set;
 
@@ -34,5 +31,10 @@ public class MockApplication extends AbstractApplication {
         classes.add(ParamsResource.class);
         classes.add(ProblemsResource.class);
         return classes;
+    }
+
+    @Override
+    protected Class<? extends AbstractHealthResource> getHealthResourceClass() {
+        return null;
     }
 }

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockAttributesApplication.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockAttributesApplication.java
@@ -15,6 +15,7 @@
  */
 package io.telicent.smart.cache.server.jaxrs.applications;
 
+import io.telicent.smart.cache.server.jaxrs.resources.AbstractHealthResource;
 import io.telicent.smart.cache.server.jaxrs.resources.AttributesResource;
 
 import java.util.Set;
@@ -30,5 +31,10 @@ public class MockAttributesApplication extends AbstractApplication {
     @Override
     protected boolean isAuthEnabled() {
         return false;
+    }
+
+    @Override
+    protected Class<? extends AbstractHealthResource> getHealthResourceClass() {
+        return null;
     }
 }

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockBrokenHealthApplication.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockBrokenHealthApplication.java
@@ -15,6 +15,7 @@
  */
 package io.telicent.smart.cache.server.jaxrs.applications;
 
+import io.telicent.smart.cache.server.jaxrs.resources.AbstractHealthResource;
 import io.telicent.smart.cache.server.jaxrs.resources.BrokenStatusHealthResource;
 
 import java.util.Set;
@@ -22,9 +23,7 @@ import java.util.Set;
 public class MockBrokenHealthApplication extends AbstractApplication {
 
     @Override
-    public Set<Class<?>> getClasses() {
-        Set<Class<?>> classes = super.getClasses();
-        classes.add(BrokenStatusHealthResource.class);
-        return classes;
+    protected Class<? extends AbstractHealthResource> getHealthResourceClass() {
+        return BrokenStatusHealthResource.class;
     }
 }

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockHealthApplication.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockHealthApplication.java
@@ -15,6 +15,7 @@
  */
 package io.telicent.smart.cache.server.jaxrs.applications;
 
+import io.telicent.smart.cache.server.jaxrs.resources.AbstractHealthResource;
 import io.telicent.smart.cache.server.jaxrs.resources.StatusHealthResource;
 
 import java.util.Set;
@@ -22,9 +23,7 @@ import java.util.Set;
 public class MockHealthApplication extends AbstractApplication {
 
     @Override
-    public Set<Class<?>> getClasses() {
-        Set<Class<?>> classes = super.getClasses();
-        classes.add(StatusHealthResource.class);
-        return classes;
+    protected Class<? extends AbstractHealthResource> getHealthResourceClass() {
+        return StatusHealthResource.class;
     }
 }

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockKeyServerApplication.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockKeyServerApplication.java
@@ -15,6 +15,7 @@
  */
 package io.telicent.smart.cache.server.jaxrs.applications;
 
+import io.telicent.smart.cache.server.jaxrs.resources.AbstractHealthResource;
 import io.telicent.smart.cache.server.jaxrs.resources.AwsElbResource;
 import io.telicent.smart.cache.server.jaxrs.resources.JwksResource;
 
@@ -27,5 +28,10 @@ public class MockKeyServerApplication extends AbstractApplication {
         classes.add(JwksResource.class);
         classes.add(AwsElbResource.class);
         return classes;
+    }
+
+    @Override
+    protected Class<? extends AbstractHealthResource> getHealthResourceClass() {
+        return null;
     }
 }

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/resources/StatusHealthResource.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/resources/StatusHealthResource.java
@@ -33,6 +33,7 @@ public class StatusHealthResource extends AbstractHealthResource {
     public static void reset() {
         IS_HEALTHY = true;
         REASONS.clear();
+        AbstractHealthResource.invalidateCachedStatus();
     }
 
     @Override


### PR DESCRIPTION
This modifies the `AbstractHealthResource` to cache the applications computed health status for a brief period (30 seconds).  This provides a DoS mitigation in case of the applications health check involving expensive computation, or probes to the services it depends on, that would otherwise provide a DoS vector for a malicious user to attack the underlying services.

Also modifies `AbstractApplication` to developers need to be more explicit about choosing to implement, or not implement, a `/healthz` endpoint in their applications.

# Related Issues and PRs

- This implements CORE-422