### PR TITLE
Fix CVE-2024-7254

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Kafka Event Source improvements:
     - **BREAKING:** `KafkaTestCluster` is now an abstract class, use `BasicKafkaTestCluster` for the default
       implementation of the interface
-    - New `MutualTlsKafkaTestCluster` can be used to create a single node mTLS Authentication Kafka Cluster provided
+    - New `MutualTlsKafkaTestCluster` can be used to create a single node mTLS Authenticated Kafka Cluster provided
       that suitable Key and Trust Stores are generated 
     - New `certs-helper` artifact provides helper scripts to enable generating these in other modules and test
       environments
@@ -14,6 +14,11 @@
     - Added new `--kafka-property` option to supply custom Kafka configuration properties directly at command line
     - Added new `--kafka-properties` option to supply Kafka properties file where more complex configuration is
       necessary, or users don't want to expose sensitive values in the CLI arguments
+- Build improvements:
+    - Excluded `protobuf-java` from transitive dependencies due to CVE-2024-7254 and adding explicit dependency on
+      4.27.5 that is fixed
+    - Logback upgraded to 1.5.8
+    - Various build and test dependencies upgraded to latest available
 
 # 0.22.0
 

--- a/event-sources/event-sources-core/pom.xml
+++ b/event-sources/event-sources-core/pom.xml
@@ -35,6 +35,13 @@
             <artifactId>jena-rdfpatch</artifactId>
         </dependency>
 
+        <!-- Needed due to CVE-2024-7254 so we can still accept Binary RDF/Patches -->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${dependency.protobuf}</version>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,7 @@
         <dependency.opentelemetry.agent>1.33.6</dependency.opentelemetry.agent>
         <dependency.opentelemetry.sdk>1.41.0</dependency.opentelemetry.sdk>
         <dependency.opentelemetry.sdk-alpha>1.27.0-alpha</dependency.opentelemetry.sdk-alpha>
+        <dependency.protobuf>4.27.5</dependency.protobuf> <!-- CVE-2024-7254 -->
         <dependency.rdf-abac>0.71.7</dependency.rdf-abac>
         <dependency.resilience4j>2.2.0</dependency.resilience4j>
         <dependency.servlet>6.1.0</dependency.servlet>
@@ -141,25 +142,18 @@
             <!-- Jena for RDF processing -->
             <dependency>
                 <groupId>org.apache.jena</groupId>
-                <artifactId>apache-jena-libs</artifactId>
+                <artifactId>jena-arq</artifactId>
                 <version>${dependency.jena}</version>
-                <type>pom</type>
                 <exclusions>
+                    <!-- Excluded due to upstream issue with being in compile scope by mistake -->
                     <exclusion>
                         <groupId>org.junit.platform</groupId>
                         <artifactId>junit-platform-suite-engine</artifactId>
                     </exclusion>
-                </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.jena</groupId>
-                <artifactId>jena-arq</artifactId>
-                <version>${dependency.jena}</version>
-                <exclusions>
+                    <!-- Excluded due to CVE-2024-7354 -->
                     <exclusion>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-suite-engine</artifactId>
+                        <groupId>com.google.protobuf</groupId>
+                        <artifactId>protobuf-java</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -168,6 +162,12 @@
                 <groupId>org.apache.jena</groupId>
                 <artifactId>jena-rdfpatch</artifactId>
                 <version>${dependency.jena}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${dependency.protobuf}</version>
             </dependency>
 
             <!-- RDF ABAC -->


### PR DESCRIPTION
Excludes vulnerable protobuf dependency and adds explicit dependency on it where needed