### PR TITLE
Ignore Trivy Cache for checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ hs_err_*
 *~
 .#*
 \#*
+
+# Trivy Cache
+.trivy/

--- a/pom.xml
+++ b/pom.xml
@@ -414,6 +414,8 @@
                                 <exclude>**/*.md</exclude>
                                 <exclude>**/*.jpeg</exclude>
                                 <exclude>**/template</exclude>
+                                <!-- Trivy Cache -->
+                                <exclude>.trivy/**</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>


### PR DESCRIPTION
Some of these checks hit a OOM error in GitHub Actions CI/CD environment