### PR TITLE
Fix unhelpful errors for @BeanParam fields (CORE-480)

### DIFF
--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/utils/ParamInfo.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/utils/ParamInfo.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Iterator;
 
@@ -66,9 +67,7 @@ public class ParamInfo {
                 Path.MethodNode method = (Path.MethodNode) node;
                 if (cls != null) {
                     try {
-                        m = cls.getMethod(method.getName(),
-                                          method.getParameterTypes()
-                                                .toArray(new Class[0]));
+                        m = cls.getMethod(method.getName(), method.getParameterTypes().toArray(new Class[0]));
                     } catch (NoSuchMethodException e) {
                         // Ignore, just means we won't be able to find a friendly parameter name for the parameter
                         LOGGER.warn("Constraint violation path identifies method {} which does not exist on class {}",
@@ -77,25 +76,67 @@ public class ParamInfo {
                 }
             } else if (node.getKind() == ElementKind.PARAMETER) {
                 Path.ParameterNode param = (Path.ParameterNode) node;
+                boolean shouldContinue = false;
                 if (m != null) {
                     for (Annotation annotation : m.getParameterAnnotations()[param.getParameterIndex()]) {
-                        if (annotation instanceof QueryParam queryParam) {
-                            return new ParamInfo(queryParam.value(), "Query");
-                        } else if (annotation instanceof PathParam pathParam) {
-                            return new ParamInfo(pathParam.value(), "Path");
-                        } else if (annotation instanceof HeaderParam headerParam) {
-                            return new ParamInfo(headerParam.value(), "Header");
-                        } else if (annotation instanceof CookieParam cookieParam) {
-                            return new ParamInfo(cookieParam.value(), "Cookie");
-                        } else if (annotation instanceof FormParam formParam) {
-                            return new ParamInfo(formParam.value(), "Form");
+                        ParamInfo info = findParamInfoFromAnnotation(annotation);
+                        if (info != null) {
+                            return info;
+                        } else if (annotation instanceof BeanParam) {
+                            cls = m.getParameterTypes()[param.getParameterIndex()];
+                            // Need to continue on to next step of the violation path to find the bean property that is
+                            // annotated
+                            shouldContinue = true;
+                            break;
                         }
                     }
                 }
+                if (shouldContinue) {
+                    continue;
+                }
                 return new ParamInfo(param.getName(), null);
+            } else if (node.getKind() == ElementKind.PROPERTY) {
+                // If @BeanParam parameters are used then the fields of that are Property nodes in the violation path
+                Path.PropertyNode property = (Path.PropertyNode) node;
+                try {
+                    if (cls != null) {
+                        Field field = cls.getField(property.getName());
+                        for (Annotation annotation : field.getAnnotations()) {
+                            ParamInfo info = findParamInfoFromAnnotation(annotation);
+                            if (info != null) {
+                                return info;
+                            }
+                        }
+                    }
+                } catch (NoSuchFieldException e) {
+                    // Ignored, can't get a more specific param info
+                }
+                return new ParamInfo(property.getName(), null);
             }
         }
         return new ParamInfo(path.toString(), null);
+    }
+
+    /**
+     * Finds parameter information based on annotations
+     *
+     * @param annotation Annotation to test for parameter info
+     * @return Param info, or {@code null} if not an annotation that provides parameter info
+     */
+    protected static ParamInfo findParamInfoFromAnnotation(Annotation annotation) {
+        if (annotation instanceof QueryParam queryParam) {
+            return new ParamInfo(queryParam.value(), "Query");
+        } else if (annotation instanceof PathParam pathParam) {
+            return new ParamInfo(pathParam.value(), "Path");
+        } else if (annotation instanceof HeaderParam headerParam) {
+            return new ParamInfo(headerParam.value(), "Header");
+        } else if (annotation instanceof CookieParam cookieParam) {
+            return new ParamInfo(cookieParam.value(), "Cookie");
+        } else if (annotation instanceof FormParam formParam) {
+            return new ParamInfo(formParam.value(), "Form");
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/model/ExternalParams.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/model/ExternalParams.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.server.jaxrs.model;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.QueryParam;
+
+public class ExternalParams {
+
+    @QueryParam("query") @NotBlank public String query;
+    @HeaderParam("X-Custom-Header") public String header;
+    @FormParam("form") @NotBlank public String formParam;
+}

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/parameters/ModeParametersProvider.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/parameters/ModeParametersProvider.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Type;
 @Provider
 public class ModeParametersProvider implements ParamConverterProvider {
     @Override
+    @SuppressWarnings("unchecked")
     public <T> ParamConverter<T> getConverter(Class<T> rawType, Type genericType, Annotation[] annotations) {
         if (rawType.equals(Mode.class)) {
             return (ParamConverter<T>) new ModeConverter();

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/resources/ParamsResource.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/resources/ParamsResource.java
@@ -15,7 +15,9 @@
  */
 package io.telicent.smart.cache.server.jaxrs.resources;
 
+import io.telicent.smart.cache.server.jaxrs.model.ExternalParams;
 import io.telicent.smart.cache.server.jaxrs.model.Mode;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -46,6 +48,13 @@ public class ParamsResource {
     public Response everything(@PathParam("path") String path, @QueryParam("query") String query,
                                @HeaderParam("X-Custom-Header") String header, @CookieParam("cookie") String cookie,
                                @FormParam("form") String form) {
+        return Response.noContent().build();
+    }
+
+    @POST
+    @Path("/external/{path}")
+    @Consumes({ MediaType.APPLICATION_FORM_URLENCODED })
+    public Response external(@BeanParam @Valid ExternalParams params) {
         return Response.noContent().build();
     }
 }


### PR DESCRIPTION
Noted in testing of CORE-480 when a field on a `@BeanParam` annotated type fails validation the generated validation error message doesn't provide the correct parameter type/name.  This commit improves the logic so that `@BeanParam` fields are reported correctly.

Additional test cases are added around this scenario.