### PR TITLE
Fix bugs with LiveReporter and Kafka AuthN (CORE-518)

### DIFF
--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/KafkaConfigurationOptions.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/KafkaConfigurationOptions.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.cli.options;
+
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.AllowedRawValues;
+import io.telicent.smart.cache.configuration.Configurator;
+import io.telicent.smart.cache.sources.kafka.KafkaSecurity;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * Options related to provided additional Kafka configuration, especially around authentication
+ */
+public class KafkaConfigurationOptions {
+    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConfigurationOptions.class);
+
+    /**
+     * Environment variable used to specify Kafka username
+     */
+    public static final String KAFKA_USERNAME = "KAFKA_USER";
+    /**
+     * Environment variable used to specify Kafka password
+     */
+    public static final String KAFKA_PASSWORD = "KAFKA_PASSWORD";
+
+    /**
+     * Environment variable used to specify Kafka Configuration properties file
+     */
+    public static final String KAFKA_CONFIG_FILE_PATH = "KAFKA_CONFIG_FILE_PATH";
+
+    /**
+     * Alternative environment variable used to specify Kafka Configuration properties file
+     */
+    public static final String KAFKA_PROPERTIES = "KAFKA_PROPERTIES";
+
+    private static final String LOGIN_PLAIN = "PLAIN";
+    private static final String LOGIN_SCRAM_SHA_256 = "SCRAM-SHA-256";
+    private static final String LOGIN_SCRAM_SHA_512 = "SCRAM-SHA-512";
+
+    @Option(name = {
+            "--kafka-user", "--kafka-username"
+    }, title = "KafkaUser", description = "Specifies the username used to connect to Kafka.  May also be specified via the KAFKA_USER environment variable.")
+    private String username = Configurator.get(KAFKA_USERNAME);
+
+    @Option(name = "--kafka-password", title = "KafkaPassword", description = "Specifies the password used to connect to Kafka.  Generally it is better to use the KAFKA_PASSWORD environment variable to supply this instead of supplying it directly at the command line.")
+    private String password = Configurator.get(KAFKA_PASSWORD);
+
+    @Option(name = "--kafka-login-type", title = "LoginType", description = "Specifies the Kafka Login Type to use in conjunction with the --kafka-user and --kafka-password arguments for SASL authentication, if you use an alternative Kafka authentication mechanism, or a variant of SASL not listed as supported here, then use --kafka-properties to supply a suitably configured properties file instead.")
+    @AllowedRawValues(allowedValues = { LOGIN_PLAIN, LOGIN_SCRAM_SHA_256, LOGIN_SCRAM_SHA_512 })
+    private String loginType = LOGIN_PLAIN;
+
+    @Option(name = "--kafka-properties", title = "KafkaPropertiesFile", description = "Specifies a properties file containing Kafka configuration properties to use with Kafka.")
+    @com.github.rvesse.airline.annotations.restrictions.File(mustExist = true)
+    private File propertiesFile = Configurator.get(new String[] { KAFKA_CONFIG_FILE_PATH, KAFKA_PROPERTIES }, File::new, null);
+
+    @Option(name = "--kafka-property", title = "KafkaProperty", arity = 2, description = "Specifies a Kafka configuration property to use with Kafka.  These are loaded prior to any properties from a file specified via the --kafka-properties option.")
+    private List<String> extraConfiguration = new ArrayList<>();
+
+    private Properties properties = null;
+
+    /**
+     * Gets the additional configuration properties to pass to Kafka
+     *
+     * @return Configuration properties
+     */
+    public synchronized Properties getAdditionalProperties() {
+        // Use cached properties if present
+        if (properties != null) {
+            return this.properties;
+        }
+        Properties properties = new Properties();
+
+        // If a Username and Password are provided then configure Kafka properties for login based on those
+        if (StringUtils.isNotBlank(this.username) && StringUtils.isNotBlank(this.password)) {
+            properties.put(SaslConfigs.SASL_MECHANISM, this.loginType);
+            properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG,
+                           Objects.equals(this.loginType, LOGIN_PLAIN) ? SecurityProtocol.SASL_PLAINTEXT.name :
+                           SecurityProtocol.SASL_SSL.name);
+            properties.put(SaslConfigs.SASL_JAAS_CONFIG, Objects.equals(this.loginType, LOGIN_PLAIN) ?
+                                                         KafkaSecurity.plainLogin(this.username, this.password) :
+                                                         KafkaSecurity.scramLogin(this.username, this.password));
+            LOGGER.info("Configured Kafka properties for SASL {} authentication", this.loginType);
+        }
+
+        // Load in any command line provided properties
+        for (int i = 0; i <= this.extraConfiguration.size() - 2; i += 2) {
+            properties.put(this.extraConfiguration.get(i), this.extraConfiguration.get(i + 1));
+        }
+
+        // Load in the properties file (if specified)
+        if (this.propertiesFile != null) {
+            try (FileInputStream input = new FileInputStream(this.propertiesFile)) {
+                properties.load(input);
+            } catch (IOException e) {
+                throw new RuntimeException(String.format("Failed to read user supplied Kafka properties file %s",
+                                                         this.propertiesFile.getAbsolutePath()));
+            }
+        }
+
+        LOGGER.info("Gathered/generated {} Kafka properties based on supplied options", properties.size());
+        // Cache properties for later reuse because some option modules and/or commands may call this method multiple
+        // times and this avoids repeating the property loading unnecessary
+        this.properties = properties;
+        return properties;
+    }
+}

--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/KafkaOptions.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/KafkaOptions.java
@@ -208,7 +208,7 @@ public class KafkaOptions {
     @Option(name = "--kafka-password", title = "KafkaPassword", description = "Specifies the password used to connect to Kafka.  Generally it is better to use the KAFKA_PASSWORD environment variable to supply this instead of supplying it directly at the command line.")
     private String password = Configurator.get(KAFKA_PASSWORD);
 
-    @Option(name = "--kafka-login-type", title = "LoginType", description = "Specifies the Kafka Login Type to use in conjunction with the --kafka-user and --kafka-password arguments, if you use an alternative Kafka authentication mechanism then use --kafka-properties to supply a suitably configured properties file instead.")
+    @Option(name = "--kafka-login-type", title = "LoginType", description = "Specifies the Kafka Login Type to use in conjunction with the --kafka-user and --kafka-password arguments for SASL authentication, if you use an alternative Kafka authentication mechanism, or a variant of SASL not listed as supported here, then use --kafka-properties to supply a suitably configured properties file instead.")
     @AllowedRawValues(allowedValues = { LOGIN_PLAIN, LOGIN_SCRAM_SHA_256, LOGIN_SCRAM_SHA_512 })
     private String loginType = LOGIN_PLAIN;
 

--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/LiveReporterOptions.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/LiveReporterOptions.java
@@ -42,7 +42,7 @@ import java.time.Duration;
 /**
  * Options for Telicent Live heartbeat reporting
  */
-public class LiveReporterOptions {
+public class LiveReporterOptions extends KafkaConfigurationOptions {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LiveReporterOptions.class);
 
@@ -101,10 +101,14 @@ public class LiveReporterOptions {
         //@formatter:on
         if (StringUtils.isNotBlank(this.liveBootstrapServers)) {
             logLiveReportingLocation(this.liveBootstrapServers);
-            builder = builder.toKafka(k -> k.bootstrapServers(this.liveBootstrapServers).topic(this.liveReportTopic));
+            builder = builder.toKafka(k -> k.bootstrapServers(this.liveBootstrapServers)
+                                            .topic(this.liveReportTopic)
+                                            .producerConfig(this.getAdditionalProperties()));
         } else if (StringUtils.isNotBlank(bootstrapServers)) {
             logLiveReportingLocation(bootstrapServers);
-            builder = builder.toKafka(k -> k.bootstrapServers(bootstrapServers).topic(this.liveReportTopic));
+            builder = builder.toKafka(k -> k.bootstrapServers(bootstrapServers)
+                                            .topic(this.liveReportTopic)
+                                            .producerConfig(this.getAdditionalProperties()));
         }
 
         this.reporter = builder.build();
@@ -156,6 +160,7 @@ public class LiveReporterOptions {
                             .topic(this.liveErrorTopic)
                             .keySerializer(BytesSerializer.class)
                             .valueSerializer(LiveErrorSerializer.class)
+                            .producerConfig(this.getAdditionalProperties())
                             .build();
             //@formatter:on
         }

--- a/cli/cli-debug/pom.xml
+++ b/cli/cli-debug/pom.xml
@@ -172,6 +172,7 @@
                                 <phase>process-test-resources</phase>
                                 <configuration>
                                     <executable>${project.basedir}/test-certs/generateCerts.sh</executable>
+                                    <skip>${skipTests}</skip>
                                 </configuration>
                             </execution>
                         </executions>

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliSecureKafka.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliSecureKafka.java
@@ -192,4 +192,21 @@ public class DockerTestDebugCliSecureKafka extends AbstractCommandTests {
 
         AbstractDockerDebugCliTests.verifyEvents("\"%d\"");
     }
+
+    @Test(retryAnalyzer = FlakyKafkaTest.class)
+    public void givenNonEmptyTopic_whenDumpingRdfEvents_thenEventsAreDumped_andLiveReporterHeartbeatsAreGenerated() {
+        // Given
+        generateKafkaEvents("<http://subject> <http://predicate> \"%d\" .");
+
+        // When
+        runDumpCommand("rdf-dump", "--live-reporter");
+
+        // Then
+        AbstractDockerDebugCliTests.verifyRdfDumpCommandUsed();
+        AbstractDockerDebugCliTests.verifyEvents("\"%d\"");
+
+        // And
+        String stdErr = SmartCacheCommandTester.getLastStdErr();
+        Assert.assertTrue(StringUtils.contains(stdErr, "LiveReporter"));
+    }
 }

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -98,20 +98,20 @@ because only the root loggers level is modified.
 
 The `KafkaOptions` module provides all the options around connecting to Kafka:
 
-| Option(s) | Purpose | Environment Variable | Default Value |
-|-----------|---------|----------------------|---------------|
-| `--bootstrap-server`/`--bootstrap-servers`| Specifies the Kafka Bootstrap servers | `BOOTSTRAP_SERVERS` | |
-| `-t`/`--topic` | Specifies the Kafka topic(s) to read from | `TOPIC`/`INPUT_TOPIC` | |
-| `--dlq`/`--dlq-topic` | Specifies the Kafka topic to use as the DLQ | `DLQ_TOPIC` | |
-| `-g`/`--group` | Specifies the Kafka consumer group to use | | Name of the CLI command |
-| `--lag-report-interval` | Specifies how often (in seconds) that the lag on read topics is checked and reported in logs | | `30` |
-| `--kafka-max-poll-records` | Specifies the maximum number of records to poll from Kafka at once | | `1000` |
-| `--kafka-user`/`--kafka-username` | Specifies a username for authenticating to Kafka | `KAFKA_USER` | |
-| `--kafka-password` | Specifies a password for authenticating to Kafka | `KAFKA_PASSWORD` | |
-| `--kafka-login-type` | Specifies the login type to use for username and password authentication to Kafka | | `PLAIN` |
-| `--kafka-properties` | Specifies a properties file containing additional Kafka configuration properties, useful for more advanced authentication methods like mTLS | | |
-| `--kafka-property` | Specifies a single Kafka configuration property directly on the command line | | |
-| `--read-policy` | Specifies how to read from Kafka topics | | `EARLIEST` |
+| Option(s) | Purpose | Environment Variable                       | Default Value |
+|-----------|---------|--------------------------------------------|---------------|
+| `--bootstrap-server`/`--bootstrap-servers`| Specifies the Kafka Bootstrap servers | `BOOTSTRAP_SERVERS`                        | |
+| `-t`/`--topic` | Specifies the Kafka topic(s) to read from | `TOPIC`/`INPUT_TOPIC`                      | |
+| `--dlq`/`--dlq-topic` | Specifies the Kafka topic to use as the DLQ | `DLQ_TOPIC`                                | |
+| `-g`/`--group` | Specifies the Kafka consumer group to use |                                            | Name of the CLI command |
+| `--lag-report-interval` | Specifies how often (in seconds) that the lag on read topics is checked and reported in logs |                                            | `30` |
+| `--kafka-max-poll-records` | Specifies the maximum number of records to poll from Kafka at once |                                            | `1000` |
+| `--kafka-user`/`--kafka-username` | Specifies a username for authenticating to Kafka | `KAFKA_USER`                               | |
+| `--kafka-password` | Specifies a password for authenticating to Kafka | `KAFKA_PASSWORD`                           | |
+| `--kafka-login-type` | Specifies the login type to use for username and password authentication to Kafka |                                            | `PLAIN` |
+| `--kafka-properties` | Specifies a properties file containing additional Kafka configuration properties, useful for more advanced authentication methods like mTLS | `KAFKA_CONFIG_FILE_PATH`/`KAFKA_PROPERTIES` | |
+| `--kafka-property` | Specifies a single Kafka configuration property directly on the command line |                                            | |
+| `--read-policy` | Specifies how to read from Kafka topics |                                            | `EARLIEST` |
 
 If you are deriving from one of the abstract commands with `Kafka` in its name then this will be accessible via the
 protected `kafka` field in your command class.  Command code can access the various Kafka configuration either directly

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -145,11 +145,11 @@ to authenticate the command to the cluster.  `KafkaOptions` takes care of popula
 `getAdditionalProperties()` with suitable configuration to enable that authentication to take place.
 
 Note that if the cluster is using one of the SASL-SCRAM authentication mechanims that Kafka supports the user will need
-to specify `--login-type SCRAM-SHA-256` or `--login-type SCRAM-SHA-512` as appropriate.  They will also need additional
-SSL related configuration to ensure that it is provided a trust store that allows it to trust the broker(s) SSL
-certificates and establish an encrypted channel over which authentication may occur.  The trust store should contain at
-least the CA Root Certificate that signed the broker certificate, and ideally for maximum security the certificates of
-the individual brokers.
+to specify `--kafka-login-type SCRAM-SHA-256` or `--kafka-login-type SCRAM-SHA-512` as appropriate.  They will also need
+additional SSL related configuration to ensure that it is provided a trust store that allows it to trust the broker(s)
+SSL certificates and establish an encrypted channel over which authentication may occur.  The trust store should contain
+at least the CA Root Certificate that signed the broker certificate, and ideally for maximum security the certificates
+of the individual brokers.
 
 This may be provided either directly via the `--kafka-property` option e.g. `--kafka-property
 ssl.truststore.location=/path/to/truststore --kafka-property ssl.truststore.password=<password>`, or since it will
@@ -167,6 +167,9 @@ Store.
 Developers can spin up a SASL Plaintext secured Kafka cluster as described in the [Testing
 Kafka](../event-sources/kafka.md#testing-secure-clusters) documentation.
 
+For other SASL mechanisms, e.g. `OAUTHBEARER`, that require substantially more configuration then `--kafka-properties`
+should be used to supply a properties file with the necessary configuration.
+
 ### Kafka mTLS Authentication
 
 Communicating with a Kafka cluster using mTLS authentication is somewhat more involved as the user needs to provide SSL
@@ -182,7 +185,7 @@ ssl.keystore.password=<keystore-password>
 ssl.key.password=<key-password>
 ```
 
-Where the relevante password placeholders are replaced with the appropriate passwords for the users environment.
+Where the relevant password placeholders are replaced with the appropriate passwords for the users environment.
 
 If the cluster is a test cluster, or deployed in an environment where the certificates don't/can't contain the hostnames
 of the brokers and clients, then the following additional configuration will be necessary:

--- a/event-sources/event-source-kafka/pom.xml
+++ b/event-sources/event-source-kafka/pom.xml
@@ -138,6 +138,7 @@
                                 <phase>process-test-resources</phase>
                                 <configuration>
                                     <executable>${project.basedir}/test-certs/generateCerts.sh</executable>
+                                    <skip>${skipTests}</skip>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Refactors part of how `KafkaOptions` are retrieved into a new super-class `KafkaConfigurationOptions` so that this can be reused by `LiveReporterOptions` and allows `LiveReporter` to successfully communicate with secure Kafka clusters.  This resolves the bug seen in CORE-518 while testing secure Kafka clusters in other repositories.

New integration tests are added that cover this scenario and verifies that `LiveReporter` is functioning correctly

# Related Issues and PRs

- This resolves CORE-518