### PR TITLE
Improved KafkaSink send() behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+# 0.24.1
+
+- Kafka Event Source improvements:
+    - Improved `KafkaSink` error handling so any Kafka producer errors are reliably surfaced via `SinkException`'s when
+      interacting with the sink
+- CLI improvements:
+    - `AbstractProjectorCommand` more proactively cancels the `ProjectorDriver` on receiving an interrupt, this mainly
+      affected scenarios where a command was run in the background for integration tests
+
 # 0.24.0
 
 - Kafka Event Source improvements:

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaSinkErrorHandling.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaSinkErrorHandling.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka;
+
+import io.telicent.smart.cache.projectors.SinkException;
+import io.telicent.smart.cache.sources.kafka.sinks.KafkaSink;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.apache.kafka.common.serialization.BytesSerializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Properties;
+
+public class DockerTestKafkaSinkErrorHandling {
+
+    private final KafkaTestCluster<?> kafka = new BasicKafkaTestCluster();
+
+    /**
+     * An event where the value is intentionally above Kafka's default record size limit so should always result in a
+     * producer error
+     */
+    private static final SimpleEvent<Integer, Bytes> TOO_LARGE_EVENT =
+            new SimpleEvent<>(Collections.emptyList(), 1, Bytes.wrap(new byte[1024 * 1024 * 2]));
+
+    @BeforeClass
+    public void setup() {
+        Utils.logTestClassStarted(DockerTestKafkaSinkErrorHandling.class);
+        this.kafka.setup();
+    }
+
+    @AfterClass
+    public void teardown() {
+        this.kafka.teardown();
+        Utils.logTestClassFinished(DockerTestKafkaSinkErrorHandling.class);
+    }
+
+    private KafkaSink.KafkaSinkBuilder<Integer, Bytes> getBuilder() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.RETRIES_CONFIG, 3);
+        props.put(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG, 5000);
+        props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 5000);
+
+        return KafkaSink.<Integer, Bytes>create()
+                        .bootstrapServers(this.kafka.getBootstrapServers())
+                        .topic(KafkaTestCluster.DEFAULT_TOPIC)
+                        .keySerializer(IntegerSerializer.class)
+                        .valueSerializer(BytesSerializer.class)
+                        .producerConfig(props)
+                        .producerConfig(this.kafka.getClientProperties());
+    }
+
+    @Test(expectedExceptions = SinkException.class)
+    public void givenKafkaSink_whenSendingToSink_thenSendSucceeds_andCloseFails() {
+        // Given
+        try (KafkaSink<Integer, Bytes> sink = getBuilder().async().build()) {
+            // When and Then
+            sink.send(TOO_LARGE_EVENT);
+
+            // And
+            sink.close();
+            Assert.fail("Should have thrown a SinkException");
+        }
+    }
+
+    @Test(expectedExceptions = SinkException.class)
+    public void givenKafkaSink_whenSendingToSink_thenSendSucceeds_andSubsequentSendFails() throws InterruptedException {
+        // Given
+        try (KafkaSink<Integer, Bytes> sink = getBuilder().async().build()) {
+            // When and Then
+            sink.send(TOO_LARGE_EVENT);
+
+            // And
+            // NB - Need a brief wait to allow the previous send to time out and fail
+            Thread.sleep(1500);
+            sink.send(TOO_LARGE_EVENT);
+            Assert.fail("Should have thrown a SinkException");
+        }
+    }
+
+    @Test(expectedExceptions = SinkException.class)
+    public void givenKafkaSink_whenSendingToSinkSynchronously_thenSendFails() {
+        // Given
+        try (KafkaSink<Integer, Bytes> sink = getBuilder().noAsync().build()) {
+            // When and Then
+            sink.send(TOO_LARGE_EVENT);
+        }
+    }
+
+    @Test
+    public void givenKafkaSinkAndCustomCallback_whenSendingToSink_thenSendSucceeds_andCallbackInvoked() {
+        // Given
+        TestKafkaSinkErrorHandling.TrackerCallback tracker = new TestKafkaSinkErrorHandling.TrackerCallback();
+
+        try (KafkaSink<Integer, Bytes> sink = getBuilder().async(tracker).build()) {
+            // When and Then
+            sink.send(TOO_LARGE_EVENT);
+        }
+
+        // And
+        Assert.assertEquals(tracker.failure.get(), 1);
+        Assert.assertEquals(tracker.errors.size(), 1);
+        Assert.assertTrue(tracker.errors.get(0) instanceof RecordTooLargeException);
+    }
+}

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaTopicExistence.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaTopicExistence.java
@@ -48,7 +48,7 @@ import static java.util.Objects.nonNull;
 public class DockerTestKafkaTopicExistence {
 
     public static final String NO_SUCH_TOPIC = "no-such-topic";
-    private KafkaTestCluster kafka;
+    private KafkaTestCluster<?> kafka;
 
     private AdminClient adminClient;
 

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestSecureKafkaCluster.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestSecureKafkaCluster.java
@@ -15,15 +15,18 @@
  */
 package io.telicent.smart.cache.sources.kafka;
 
+import io.telicent.smart.cache.projectors.SinkException;
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.EventSourceException;
 import io.telicent.smart.cache.sources.kafka.sinks.KafkaSink;
 import io.telicent.smart.cache.sources.memory.SimpleEvent;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
@@ -73,12 +76,16 @@ public class DockerTestSecureKafkaCluster {
     }
 
     @Test
-    public void secure_cluster_admin_01() throws ExecutionException, InterruptedException, TimeoutException {
+    public void givenValidCredentials_whenListingTopics_thenSuccess() throws ExecutionException, InterruptedException,
+            TimeoutException {
+        // Given
         AdminClient client = this.kafka.getAdminClient();
         Assert.assertNotNull(client);
 
-        // Verify that the admin client is supplied with suitable credentials by default
+        // When
         ListTopicsResult topics = client.listTopics();
+
+        // Then
         Assert.assertNotNull(topics);
         Set<String> topicNames = topics.names().get(10, TimeUnit.SECONDS);
         Assert.assertNotNull(topicNames);
@@ -88,26 +95,32 @@ public class DockerTestSecureKafkaCluster {
 
     @SuppressWarnings("resource")
     @Test(expectedExceptions = KafkaException.class, expectedExceptionsMessageRegExp = "Failed to create.*")
-    public void secure_cluster_admin_02() {
-        // Try to create an admin client with no credentials
+    public void givenNoCredentials_whenCreatingAdminClient_thenFails() {
+        // Given
         Properties props = new Properties();
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.kafka.getBootstrapServers());
         props.put(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, 3000);
+
+        // When and Then
         KafkaAdminClient.create(props);
     }
 
     @SuppressWarnings("resource")
     @Test(expectedExceptions = KafkaException.class, expectedExceptionsMessageRegExp = "Failed to create.*")
-    public void secure_cluster_admin_03() {
+    public void givenBadCredentials_whenCreatingAdminClient_thenFails() {
+        // Given
         Properties props = new Properties();
         props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.kafka.getBootstrapServers());
         props.put(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, 3000);
         props.putAll(this.kafka.getClientProperties(NO_SUCH_USER, NO_SUCH_SECRET));
+
+        // When and Then
         KafkaAdminClient.create(props);
     }
 
-    @Test
-    public void secure_cluster_send_01() {
+    @Test(expectedExceptions = SinkException.class)
+    public void givenNoCredentials_whenSendingToKafka_thenNothingSent_andErrorsThrownOnClose() {
+        // Given
         try (KafkaSink<Bytes, String> sink = KafkaSink.<Bytes, String>create()
                                                       .bootstrapServers(this.kafka.getBootstrapServers())
                                                       .topic(KafkaTestCluster.DEFAULT_TOPIC)
@@ -115,20 +128,55 @@ public class DockerTestSecureKafkaCluster {
                                                       .valueSerializer(StringSerializer.class)
                                                       .producerConfig(ProducerConfig.MAX_BLOCK_MS_CONFIG, 3000L)
                                                       .build()) {
+
+            // When
+            // This doesn't fail in of itself because the underlying KafkaProducer.send() call is async
             sink.send(new SimpleEvent<>(Collections.emptyList(), null, "No authentication"));
-            // This doesn't fail in of itself because the underlying KafkaProducer.send() is async and we don't supply
-            // a callback
+
+            // Then
             // However, the error should have been recorded by the producer
-            Map<MetricName, ? extends Metric> metrics = sink.metrics();
-            Assert.assertNotNull(metrics);
-            Double totalErrors = findKafkaMetric(metrics, RECORD_ERROR_TOTAL);
-            Assert.assertNotNull(totalErrors);
-            Assert.assertTrue(Double.compare(totalErrors, 0.0) > 0);
+            verifyRecordErrorMetric(sink);
+
+            // And
+            // When we close the async errors should have been recorded and will be thrown
+            verifyFailOnClosure(sink);
         }
     }
 
-    @Test
-    public void secure_cluster_send_02() {
+    @Test(expectedExceptions = SinkException.class)
+    public void givenNoCredentials_whenSendingToKafkaSynchronously_thenFailsImmediately() {
+        // Given
+        try (KafkaSink<Bytes, String> sink = KafkaSink.<Bytes, String>create()
+                                                      .bootstrapServers(this.kafka.getBootstrapServers())
+                                                      .topic(KafkaTestCluster.DEFAULT_TOPIC)
+                                                      .keySerializer(BytesSerializer.class)
+                                                      .valueSerializer(StringSerializer.class)
+                                                      .producerConfig(ProducerConfig.MAX_BLOCK_MS_CONFIG, 3000L)
+                                                      .noAsync()
+                                                      .build()) {
+
+            // When and Then
+            sink.send(new SimpleEvent<>(Collections.emptyList(), null, "No authentication"));
+            Assert.fail("Synchronous send should have failed immediately");
+        }
+    }
+
+    private static void verifyRecordErrorMetric(KafkaSink<?, ?> sink) {
+        Map<MetricName, ? extends Metric> metrics = sink.metrics();
+        Assert.assertNotNull(metrics);
+        Double totalErrors = findKafkaMetric(metrics, RECORD_ERROR_TOTAL);
+        Assert.assertNotNull(totalErrors);
+        Assert.assertTrue(Double.compare(totalErrors, 0.0) > 0);
+    }
+
+    private static void verifyFailOnClosure(KafkaSink<Bytes, String> sink) {
+        sink.close();
+        Assert.fail("Should have thrown SinkException upon closure");
+    }
+
+    @Test(expectedExceptions = SinkException.class)
+    public void givenBadCredentials_whenSendingToKafka_thenNothingSent_andErrorsThrownOnClose() {
+        // Given
         try (KafkaSink<Bytes, String> sink = KafkaSink.<Bytes, String>create()
                                                       .bootstrapServers(this.kafka.getBootstrapServers())
                                                       .topic(KafkaTestCluster.DEFAULT_TOPIC)
@@ -138,15 +186,36 @@ public class DockerTestSecureKafkaCluster {
                                                       .producerConfig(this.kafka.getClientProperties(NO_SUCH_USER,
                                                                                                      NO_SUCH_SECRET))
                                                       .build()) {
+            // When
+            // This doesn't fail in of itself because the underlying KafkaProducer.send() is async
             sink.send(new SimpleEvent<>(Collections.emptyList(), null, "Bad authentication"));
-            // This doesn't fail in of itself because the underlying KafkaProducer.send() is async and we don't supply
-            // a callback
+
+            // Then
             // However, the error should have been recorded by the producer
-            Map<MetricName, ? extends Metric> metrics = sink.metrics();
-            Assert.assertNotNull(metrics);
-            Double totalErrors = findKafkaMetric(metrics, RECORD_ERROR_TOTAL);
-            Assert.assertNotNull(totalErrors);
-            Assert.assertTrue(Double.compare(totalErrors, 0.0) > 0);
+            verifyRecordErrorMetric(sink);
+
+            // And
+            verifyFailOnClosure(sink);
+        }
+    }
+
+    @Test(expectedExceptions = SinkException.class)
+    public void givenBadCredentials_whenSendingToKafkaSynchronously_thenFailsImmediately() {
+        // Given
+        try (KafkaSink<Bytes, String> sink = KafkaSink.<Bytes, String>create()
+                                                      .bootstrapServers(this.kafka.getBootstrapServers())
+                                                      .topic(KafkaTestCluster.DEFAULT_TOPIC)
+                                                      .keySerializer(BytesSerializer.class)
+                                                      .valueSerializer(StringSerializer.class)
+                                                      .producerConfig(ProducerConfig.MAX_BLOCK_MS_CONFIG, 3000L)
+                                                      .producerConfig(this.kafka.getClientProperties(NO_SUCH_USER,
+                                                                                                     NO_SUCH_SECRET))
+                                                      .noAsync()
+                                                      .build()) {
+
+            // When and Then
+            sink.send(new SimpleEvent<>(Collections.emptyList(), null, "No authentication"));
+            Assert.fail("Synchronous send should have failed immediately");
         }
     }
 
@@ -161,7 +230,8 @@ public class DockerTestSecureKafkaCluster {
     }
 
     @Test
-    public void secure_cluster_send_03() {
+    public void givenValidCredentials_whenSendingToKafka_thenSuccess_andEventsCanBePolled() {
+        // Given
         try (KafkaSink<Bytes, String> sink = KafkaSink.<Bytes, String>create()
                                                       .bootstrapServers(this.kafka.getBootstrapServers())
                                                       .topic(KafkaTestCluster.DEFAULT_TOPIC)
@@ -172,58 +242,35 @@ public class DockerTestSecureKafkaCluster {
                                                               this.kafka.getAdminUsername(),
                                                               this.kafka.getAdminPassword()))
                                                       .build()) {
+            // When
             sink.send(new SimpleEvent<>(Collections.emptyList(), null, "Has authentication"));
-            Map<MetricName, ? extends Metric> metrics = sink.metrics();
-            Assert.assertNotNull(metrics);
-            Double totalErrors = findKafkaMetric(metrics, RECORD_ERROR_TOTAL);
-            Assert.assertEquals(totalErrors, 0.0);
+
+            // Then
+            verifyNoRecordErrors(sink);
         }
 
+        // And
         verifyUnableToPollEventsWithoutCredentials();
-        Event<Bytes, String> event;
-
-        // Verify we can poll for events with valid credentials
-        verifyPollEventsWithCredentials(this.kafka.getAdminUsername(), this.kafka.getAdminPassword(), true);
-        for (Map.Entry<String, String> user : this.kafka.getAdditionalUsers().entrySet()) {
-            verifyPollEventsWithCredentials(user.getKey(), user.getValue(), true);
-        }
-
-        // Verify we cannot poll for events with bad credentials
+        verifyPollWithAllValidUsers();
         verifyPollEventsWithCredentials(NO_SUCH_USER, NO_SUCH_SECRET, false);
     }
 
-    @Test
-    public void secure_cluster_send_04() {
-        try (KafkaSink<Bytes, String> sink = KafkaSink.<Bytes, String>create()
-                                                      .bootstrapServers(this.kafka.getBootstrapServers())
-                                                      .topic(KafkaTestCluster.DEFAULT_TOPIC)
-                                                      .keySerializer(BytesSerializer.class)
-                                                      .valueSerializer(StringSerializer.class)
-                                                      .producerConfig(ProducerConfig.MAX_BLOCK_MS_CONFIG, 3000L)
-                                                      .plainLogin(this.kafka.getAdminUsername(),
-                                                                  this.kafka.getAdminPassword())
-                                                      .build()) {
-            sink.send(new SimpleEvent<>(Collections.emptyList(), null, "Has authentication"));
-            Map<MetricName, ? extends Metric> metrics = sink.metrics();
-            Assert.assertNotNull(metrics);
-            Double totalErrors = findKafkaMetric(metrics, RECORD_ERROR_TOTAL);
-            Assert.assertEquals(totalErrors, 0.0);
-        }
-
-        verifyUnableToPollEventsWithoutCredentials();
-        Event<Bytes, String> event;
-
-        // Verify we can poll for events with valid credentials
+    private void verifyPollWithAllValidUsers() {
         verifyPollEventsWithCredentials(this.kafka.getAdminUsername(), this.kafka.getAdminPassword(), true);
         for (Map.Entry<String, String> user : this.kafka.getAdditionalUsers().entrySet()) {
             verifyPollEventsWithCredentials(user.getKey(), user.getValue(), true);
         }
+    }
 
-        // Verify we cannot poll for events with bad credentials
-        verifyPollEventsWithCredentials(NO_SUCH_USER, NO_SUCH_SECRET, false);
+    private static void verifyNoRecordErrors(KafkaSink<Bytes, String> sink) {
+        Map<MetricName, ? extends Metric> metrics = sink.metrics();
+        Assert.assertNotNull(metrics);
+        Double totalErrors = findKafkaMetric(metrics, RECORD_ERROR_TOTAL);
+        Assert.assertEquals(totalErrors, 0.0);
     }
 
     private void verifyPollEventsWithCredentials(String username, String password, boolean areCredentialsValid) {
+        Utils.logStdOut("Polling for events with %s credentials", areCredentialsValid ? "valid" : "invalid");
         Event<Bytes, String> event = null;
         KafkaEventSource<Bytes, String> goodSource = KafkaEventSource.<Bytes, String>create()
                                                                      .bootstrapServers(this.kafka.getBootstrapServers())
@@ -235,6 +282,12 @@ public class DockerTestSecureKafkaCluster {
                                                                      .consumerConfig(
                                                                              this.kafka.getClientProperties(username,
                                                                                                             password))
+                                                                     .consumerConfig(
+                                                                             CommonClientConfigs.DEFAULT_API_TIMEOUT_MS_CONFIG,
+                                                                             3000)
+                                                                     .consumerConfig(
+                                                                             CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG,
+                                                                             3000)
                                                                      .plainLogin(username, password)
                                                                      .build();
         try {
@@ -253,19 +306,28 @@ public class DockerTestSecureKafkaCluster {
             Assert.assertNull(event);
         }
         goodSource.close();
+        Utils.logStdOut("Finished polling for events");
     }
 
     private void verifyUnableToPollEventsWithoutCredentials() {
+        Utils.logStdOut("Trying to poll for events with no credentials");
         KafkaEventSource<Bytes, String> badSource = KafkaEventSource.<Bytes, String>create()
                                                                     .bootstrapServers(this.kafka.getBootstrapServers())
                                                                     .topic(KafkaTestCluster.DEFAULT_TOPIC)
                                                                     .keyDeserializer(BytesDeserializer.class)
                                                                     .valueDeserializer(StringDeserializer.class)
                                                                     .consumerGroup("secure-cluster-03")
+                                                                    .consumerConfig(
+                                                                            CommonClientConfigs.DEFAULT_API_TIMEOUT_MS_CONFIG,
+                                                                            3000)
+                                                                    .consumerConfig(
+                                                                            CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG,
+                                                                            3000)
                                                                     .fromBeginning()
                                                                     .build();
         Event<Bytes, String> event = badSource.poll(Duration.ofSeconds(3));
         Assert.assertNull(event);
         badSource.close();
+        Utils.logStdOut("Finished polling for events");
     }
 }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaSinkErrorHandling.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaSinkErrorHandling.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka;
+
+import io.telicent.smart.cache.projectors.SinkException;
+import io.telicent.smart.cache.sources.kafka.sinks.KafkaSink;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestKafkaSinkErrorHandling {
+
+    private static final SimpleEvent<Integer, String> EVENT = new SimpleEvent<>(Collections.emptyList(), 1, "Test");
+
+    private KafkaSink.KafkaSinkBuilder<Integer, String> getBuilder() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.RETRIES_CONFIG, 3);
+        props.put(CommonClientConfigs.REQUEST_TIMEOUT_MS_CONFIG, 1000);
+        props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 1000);
+
+        return KafkaSink.<Integer, String>create()
+                        .bootstrapServers("localhost:9092")
+                        .topic(KafkaTestCluster.DEFAULT_TOPIC)
+                        .keySerializer(IntegerSerializer.class)
+                        .valueSerializer(StringSerializer.class)
+                        .producerConfig(props);
+    }
+
+    @Test(expectedExceptions = SinkException.class)
+    public void givenKafkaSink_whenSendingToSink_thenSendSucceeds_andCloseFails() {
+        // Given
+        try (KafkaSink<Integer, String> sink = getBuilder().async().build()) {
+            // When and Then
+            sink.send(EVENT);
+
+            // And
+            sink.close();
+            Assert.fail("Should have thrown a SinkException");
+        }
+    }
+
+    @Test(expectedExceptions = SinkException.class)
+    public void givenKafkaSink_whenSendingToSink_thenSendSucceeds_andSubsequentSendFails() throws InterruptedException {
+        // Given
+        try (KafkaSink<Integer, String> sink = getBuilder().async().build()) {
+            // When and Then
+            sink.send(EVENT);
+
+            // And
+            // NB - Need a brief wait to allow the previous send to time out and fail
+            Thread.sleep(1500);
+            sink.send(EVENT);
+            Assert.fail("Should have thrown a SinkException");
+        }
+    }
+
+    @Test(expectedExceptions = SinkException.class)
+    public void givenKafkaSink_whenSendingToSinkSynchronously_thenSendFails() {
+        // Given
+        try (KafkaSink<Integer, String> sink = getBuilder().noAsync().build()) {
+            // When and Then
+            sink.send(EVENT);
+        }
+    }
+
+    @Test
+    public void givenKafkaSinkAndCustomCallback_whenSendingToSink_thenSendSucceeds_andCallbackInvoked() {
+        // Given
+        TrackerCallback callback = new TrackerCallback();
+
+        try (KafkaSink<Integer, String> sink = getBuilder().async(callback).build()) {
+            // When and Then
+            sink.send(EVENT);
+        }
+
+        // And
+        Assert.assertEquals(callback.failure.get(), 1);
+        Assert.assertEquals(callback.errors.size(), 1);
+    }
+
+    public static final class TrackerCallback implements Callback {
+        public final AtomicInteger success = new AtomicInteger(0);
+        public final AtomicInteger failure = new AtomicInteger(0);
+        public final List<Exception> errors = new ArrayList<>();
+
+        @Override
+        public void onCompletion(RecordMetadata metadata, Exception exception) {
+            if (exception != null) {
+                this.failure.incrementAndGet();
+                this.errors.add(exception);
+            } else {
+                this.success.incrementAndGet();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Noticed when trying to use `KafkaSink` outside of test cases that in some scenarios it was silently swallowing errors produced by Kafka so caller could think data was going to Kafka when it wasn't.  Improved `KafkaSink.send()` implementation to capture and surface `KafkaProducer`'s async errors on subsequent `send()`/`close()` calls.

Added various new unit and integration tests around this, and updated some existing negative tests that relied on the old buggy behaviour to be aware that errors are now thrown in those cases.

Documentation is updated to reflect the new behaviour and clarify how and when errors are surfaced.

Also fixes a related bug with using Projector commands in unit/integration test scenarios that could leave a projection running indefinitely.