### PR TITLE
Cleanup Sink and associated Sink Error Handling improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@
       that are not encapsulated in the pipeline itself, e.g. they're only used for initial setup/health probes.  This
       new sink allows those to be encapsulated into a pipeline step so that however a pipeline exits it guarantees to
       `close()` those resources.
+- Live Reporter improvements:
+    - `LiveReporter` now logs a warning if destination sink fails to accept a heartbeat rather than aborting
+      unexpectedly.
+    - `LiveErrorReporter` now logs a warning if destination sink fails to accept an error report rather than erroring
+      unexpectedly.
+- Observability improvements:
+    - `RuntimeInfo.printRuntimeInfo()` now includes available processors information.
+- CLI improvements:
+    - `LiveReporterOptions` now offers safer `teardown()` method that handles any unexpected teardown errors such that
+      they don't confuse/hide the actual causes of the application termination.  Old teardown methods are marked as
+      `@Deprecated` with pointers to use the new method.
 
 # 0.24.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+# 0.24.2
+
+- Projector improvements:
+    - Added new `CleanupSink` to help with scenarios where a projection pipeline may require some `Closeable` resources
+      that are not encapsulated in the pipeline itself, e.g. they're only used for initial setup/health probes.  This
+      new sink allows those to be encapsulated into a pipeline step so that however a pipeline exits it guarantees to
+      `close()` those resources.
+
 # 0.24.1
 
 - Kafka Event Source improvements:

--- a/docs/sinks/cleanup.md
+++ b/docs/sinks/cleanup.md
@@ -1,0 +1,50 @@
+# Cleanup Sink
+
+The `CleanupSink` is a forwarding sink that passes through items unchanged but holds references to one/more `Closeable`
+resources that should be `close()`'d when the pipeline is closed.
+
+The `CleanupSink` makes some useful guarantees by virtue of its implementation:
+
+1. It guarantees to always call the `close()` method of the destination sink first.  So any resources explicitly held by
+   other sinks further along the pipeline can be cleaned up by the sinks that own those.
+2. It guarantees to always call the `close()` method of all registered `Closeable` resources **regardless** of whether
+   the destination sinks `close()` method throws an exception.
+3. It guarantees to always call the `close()` method of all registered `Closeable`'s even if any of their `close()`
+   methods throw an exception.
+
+Therefore this sink is usually placed at the start of a pipeline and is provided with all the resources you want to
+guarantee are cleaned up regardless of whether the pipeline exits normally or abnormally.
+
+## Behaviours
+
+- Forwarding
+- Transforming: Yes
+- Batching: No
+
+## Parameters
+
+This sink takes a destination `Sink<T>` and one/more `Closeable` resources that should be closed when the `close()`
+method is called.
+
+## Example Usage
+
+In this example we are creating a `BufferedWriter` and using a lambda sink - `x -> output.println(x)` - as the
+destination.  The `CleanupSink` is wrapped around this to ensure that the writer is closed when the sinks work is done.
+
+```java
+BufferedWriter output = new BufferedWriter(new FileWriter("example.txt"));
+try (CleanupSink<String> sink 
+        = CleanupSink.<String>create()
+                   .resource(output)
+                   .destination(x -> output.println(x))
+                   .build()) {
+    for (String input : someDataSource()) {
+        sink.send(input);
+    }
+}
+```
+
+Obviously in this toy example you could achieve this without the `CleanupSink` by just wrapping the `BufferedWriter` in
+its own try-with-resources block.  However, in real pipelines there may be `Closeable` resources for which your code
+does not directly control the lifecycle and so can't use this pattern e.g. singleton instances owned by CLI option
+modules.

--- a/docs/sinks/index.md
+++ b/docs/sinks/index.md
@@ -95,6 +95,7 @@ functionality for data processing pipelines:
 - [Duplicate Suppression](duplicate-suppression.md): Suppresses duplicate data.
 - [Throughput Reporting](throughput.md): Tracks and reports throughput metrics.
 - [JSON Serialization](json.md): Writes data out as JSON.
+- [Resource Cleanup](cleanup.md): Guarantees clean up of `Closeable` resource(s) when pipelines are `close()`'d.
 
 The [`event-sources-core`](../event-sources/index.md#additional-utilities) module provides the following additional
 implementations:

--- a/live-reporter/src/main/java/io/telicent/smart/cache/live/LiveErrorReporter.java
+++ b/live-reporter/src/main/java/io/telicent/smart/cache/live/LiveErrorReporter.java
@@ -122,6 +122,14 @@ public class LiveErrorReporter {
      * Closes the reporter which closes the underlying sink
      */
     public void close() {
-        this.destination.close();
+        try {
+            this.destination.close();
+        } catch (SinkException e) {
+            // This might happen naturally during shutdown when the exact ordering in which components shutdown isn't
+            // guaranteed, we just log the message because we don't want to throw the error upwards as that might
+            // interrupt other areas of otherwise orderly shutdown and/or conflate the cause of the shutdown with the
+            // failing error handling.
+            LOGGER.warn("Failed to close Live Error reporter: {}", e.getMessage());
+        }
     }
 }

--- a/live-reporter/src/test/java/io/telicent/smart/cache/projectors/sinks/IntermittentlyFaultySink.java
+++ b/live-reporter/src/test/java/io/telicent/smart/cache/projectors/sinks/IntermittentlyFaultySink.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.projectors.sinks;
+
+import io.telicent.smart.cache.projectors.Sink;
+import io.telicent.smart.cache.projectors.SinkException;
+
+import java.util.Random;
+
+/**
+ * A sink for testing that randomly faults when trying to send items onwards to its destination based on a configurable
+ * fault percentage
+ *
+ * @param <T> Item type
+ */
+public class IntermittentlyFaultySink<T> extends AbstractTransformingSink<T, T> {
+
+    private final Random random = new Random();
+    private final double faultPercentage;
+
+    /**
+     * Creates a new intermittently faulty sink
+     *
+     * @param destination     Destination
+     * @param faultPercentage Fault percentage as a value between 0.0 and 1.0, e.g. 0.7 means 70% of items will produce
+     *                        a fault ({@link SinkException}) when trying to {@link #send(Object)} them.  For values
+     *                        outside the range then the sink always faults.
+     */
+    public IntermittentlyFaultySink(Sink<T> destination, double faultPercentage) {
+        super(destination);
+        this.faultPercentage = faultPercentage;
+    }
+
+    @Override
+    public void send(T item) throws SinkException {
+        // If fault percentage set outside allowed range then always faulty
+        if (this.faultPercentage < 0.0 || this.faultPercentage >= 1.0) {
+            throw new SinkException("always faulty");
+        } else if (this.faultPercentage == 0.0) {
+            // If set to 0 then never faulty
+            super.send(item);
+            return;
+        }
+        // Otherwise generate a random number and throw error if less than configured fault percentage
+        double test = random.nextDouble();
+        if (test <= this.faultPercentage) {
+            throw new SinkException("sometimes faulty");
+        }
+        super.send(item);
+    }
+
+    @Override
+    protected T transform(T item) {
+        return item;
+    }
+}

--- a/observability-core/src/main/java/io/telicent/smart/cache/observability/RuntimeInfo.java
+++ b/observability-core/src/main/java/io/telicent/smart/cache/observability/RuntimeInfo.java
@@ -42,9 +42,10 @@ public class RuntimeInfo {
     public static void printRuntimeInfo(Logger logger) {
         double rawMemory = Runtime.getRuntime().maxMemory();
         Pair<Double, String> memory = RuntimeInfo.parseMemory(rawMemory);
-        logger.info("Memory: {} {}", String.format("%.2f", memory.getKey()), memory.getValue());
-        logger.info("Java:   {}", System.getProperty("java.version"));
-        logger.info("OS:     {} {} {}", System.getProperty("os.name"), System.getProperty("os.version"),
+        logger.info("Processors: {}", Runtime.getRuntime().availableProcessors());
+        logger.info("Memory:     {} {}", String.format("%.2f", memory.getKey()), memory.getValue());
+        logger.info("Java:       {}", System.getProperty("java.version"));
+        logger.info("OS:         {} {} {}", System.getProperty("os.name"), System.getProperty("os.version"),
                     System.getProperty("os.arch"));
     }
 
@@ -66,7 +67,7 @@ public class RuntimeInfo {
     /**
      * Parses a raw memory value in bytes into a human-readable representation
      * <p>
-     * The human readable representation will be expressed in binary units, rather than decimal, units.  So for example
+     * The human-readable representation will be expressed in binary units, rather than decimal, units.  So for example
      * a parsed value of {@code 2 GiB} represents 2 Gibibytes, which is {@code 2147483648} bytes.
      * </p>
      * <p>

--- a/observability-core/src/test/java/io/telicent/smart/cache/observability/TestRuntimeInfo.java
+++ b/observability-core/src/test/java/io/telicent/smart/cache/observability/TestRuntimeInfo.java
@@ -44,9 +44,14 @@ public class TestRuntimeInfo {
     }
 
     @Test(dataProvider = "memory")
-    public void parse_memory(double raw, String expectedValue, String expectedUnit) {
+    public void givenRawMemory_whenParsing_thenHumanReadableValueIsReturned(double raw, String expectedValue, String expectedUnit) {
+        // Given
         Pair<Double, String> parsed = RuntimeInfo.parseMemory(raw);
+
+        // When
         verifyMemoryAmount(parsed, expectedValue);
+
+        // Then
         Assert.assertEquals(parsed.getValue(), expectedUnit);
     }
 
@@ -56,18 +61,26 @@ public class TestRuntimeInfo {
     }
 
     @Test
-    public void dump_runtime_info() {
+    public void givenTestLogger_whenPrintingRuntimeInfo_thenExpectedLinesAreOutput() {
+        // Given
         TestLogger logger = TestLoggerFactory.getTestLogger(TestRuntimeInfo.class);
         try {
+            // When
             RuntimeInfo.printRuntimeInfo(logger);
 
+            // Then
             List<String> messages = logger.getAllLoggingEvents().stream().map(LoggingEvent::getFormattedMessage).toList();
-            Assert.assertTrue(messages.stream().anyMatch(m -> StringUtils.contains(m, "OS:")));
-            Assert.assertTrue(messages.stream().anyMatch(m -> StringUtils.contains(m, "Java:")));
-            Assert.assertTrue(messages.stream().anyMatch(m -> StringUtils.contains(m, "Memory:")));
+            verifyMatchingLogMessage(messages, "Processors:");
+            verifyMatchingLogMessage(messages, "OS:");
+            verifyMatchingLogMessage(messages, "Java:");
+            verifyMatchingLogMessage(messages, "Memory:");
         } finally {
             logger.clearAll();
         }
+    }
+
+    private static void verifyMatchingLogMessage(List<String> messages, String searchSeq) {
+        Assert.assertTrue(messages.stream().anyMatch(m -> StringUtils.contains(m, searchSeq)));
     }
 
     @Test

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/CleanupSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/CleanupSink.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.projectors.sinks;
+
+import io.telicent.smart.cache.projectors.Sink;
+import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBuilder;
+import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A sink that passes items through unchanged <strong>BUT</strong> manages a set of {@link Closeable} resources that are
+ * closed when the sinks {@link #close()} method is called.  The sink guarantees to close those resources regardless of
+ * whether the destination sink closure fails, or any individual {@link Closeable#close()} fails.
+ * <p>
+ * This is useful for pipelines where there are leakable resources used that aren't easily encapsulated in another sink
+ * implementation that will close those resources.
+ * </p>
+ * <p>
+ * Generally it is recommended that this sink be placed first in the chain of sinks as it will propagate the
+ * {@link #close()} call down to the destination sink prior to closing the resources it has been instructed to clean
+ * up.
+ * </p>
+ *
+ * @param <T> Item type
+ */
+public class CleanupSink<T> extends AbstractTransformingSink<T, T> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CleanupSink.class);
+
+    private final List<Closeable> cleanups = new ArrayList<>();
+
+    /**
+     * Creates a new cleanup sink
+     *
+     * @param destination Destination
+     * @param cleanups    Resources to clean up
+     */
+    CleanupSink(Sink<T> destination, List<Closeable> cleanups) {
+        super(destination);
+        this.cleanups.addAll(Objects.requireNonNull(cleanups, "Resources to cleanup cannot be null"));
+    }
+
+    @Override
+    protected T transform(T item) {
+        return item;
+    }
+
+    @Override
+    public void close() {
+        try {
+            super.close();
+        } finally {
+            for (Closeable closeable : cleanups) {
+                try {
+                    closeable.close();
+                } catch (IOException e) {
+                    LOGGER.warn("Failed to close {}", closeable, e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates a new cleanup sink builder
+     *
+     * @param <TItem> Item type
+     * @return Cleanup sink builder
+     */
+    public static <TItem> Builder<TItem> create() {
+        return new Builder<>();
+    }
+
+    /**
+     * Builder for cleanup sinks
+     *
+     * @param <TItem> Item type
+     */
+    public static class Builder<TItem>
+            extends AbstractForwardingSinkBuilder<TItem, TItem, CleanupSink<TItem>, Builder<TItem>> {
+        private final List<Closeable> cleanups = new ArrayList<>();
+
+        /**
+         * Adds a single closeable resource to clean up
+         *
+         * @param closeable Closeable resource
+         * @return Builder
+         */
+        public Builder<TItem> cleanup(Closeable closeable) {
+            if (closeable != null) {
+                this.cleanups.add(closeable);
+            }
+            return this;
+        }
+
+        /**
+         * Adds multiple closeable resource(s) to clean up
+         *
+         * @param closeables Closeable resources
+         * @return Builder
+         */
+        public Builder<TItem> cleanup(Closeable... closeables) {
+            if (closeables != null) {
+                CollectionUtils.addAll(this.cleanups, closeables);
+            }
+            return this;
+        }
+
+        /**
+         * Adds multiple closeable resource(s) to clean up
+         *
+         * @param closeables Closeable resources
+         * @return Builder
+         */
+        public Builder<TItem> cleanup(Collection<Closeable> closeables) {
+            if (closeables != null) {
+                CollectionUtils.addAll(this.cleanups, closeables);
+            }
+            return this;
+        }
+
+        @Override
+        public CleanupSink<TItem> build() {
+            return new CleanupSink<>(this.getDestination(), this.cleanups);
+        }
+    }
+
+}

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/Sinks.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/Sinks.java
@@ -59,6 +59,16 @@ public class Sinks {
     }
 
     /**
+     * Creates a new cleanup sink builder
+     *
+     * @param <T> Item type
+     * @return Cleanup sink builder
+     */
+    public static <T> CleanupSink.Builder<T> cleanup() {
+        return CleanupSink.create();
+    }
+
+    /**
      * Creates a new JSON sink builder
      *
      * @param <T> Item type

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/builder/AbstractForwardingSinkBuilder.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/builder/AbstractForwardingSinkBuilder.java
@@ -89,6 +89,16 @@ public abstract class AbstractForwardingSinkBuilder<TInput, TOutput, TSink exten
     }
 
     /**
+     * Sets the destination for this sink to be a cleanup sink
+     *
+     * @param f Builder function that can be used to build the cleanup sink
+     * @return Builder
+     */
+    public TBuilder cleanup(Function<CleanupSink.Builder<TOutput>, SinkBuilder<TOutput, CleanupSink<TOutput>>> f) {
+        return this.destination(f.apply(Sinks.cleanup()).build());
+    }
+
+    /**
      * Sets the destination for this sink to be a JSON sink
      *
      * @param f Builder function that can be used to build the JSON sink

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestCleanupSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestCleanupSink.java
@@ -1,0 +1,257 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.projectors.sinks;
+
+import io.telicent.smart.cache.projectors.Sink;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestCleanupSink {
+
+    @Test
+    public void givenCleanupSinkWithNullCloseable_whenClosing_thenNothingRegisteredForCleanup() {
+        // Given
+        try (CleanupSink<String> sink = Sinks.<String>cleanup().resource(null).discard().build()) {
+            // When
+            sink.close();
+
+            // Then
+            Assert.assertEquals(sink.resourcesCount(), 0);
+        }
+    }
+
+    @Test
+    public void givenCleanupSinkWithNullResourcesList_whenClosing_thenNothingRegisteredForCleanup() {
+        // Given
+        try (CleanupSink<String> sink = Sinks.<String>cleanup().resources((List<Closeable>) null).discard().build()) {
+            // When
+            sink.close();
+
+            // Then
+            Assert.assertEquals(sink.resourcesCount(), 0);
+        }
+    }
+
+    @Test
+    public void givenCleanupSinkWithNullResourcesArray_whenClosing_thenNothingRegisteredForCleanup() {
+        // Given
+        try (CleanupSink<String> sink = Sinks.<String>cleanup().resources((Closeable[]) null).discard().build()) {
+            // When
+            sink.close();
+
+            // Then
+            Assert.assertEquals(sink.resourcesCount(), 0);
+        }
+    }
+
+    @Test
+    public void givenCleanupSinkWithListOfNullCloseables_whenClosing_thenNothingRegisteredForCleanup() {
+        // Given
+        List<Closeable> resources = new ArrayList<>();
+        resources.add(null);
+        resources.add(null);
+        try (CleanupSink<String> sink = Sinks.<String>cleanup().resources(resources).discard().build()) {
+            // When
+            sink.close();
+
+            // Then
+            Assert.assertEquals(sink.resourcesCount(), 0);
+        }
+    }
+
+    @Test
+    public void givenCleanupSinkWithListOfNullCloseablesDirectly_whenClosing_thenNothingRegisteredForCleanup() {
+        // Given
+        List<Closeable> resources = new ArrayList<>();
+        resources.add(null);
+        resources.add(null);
+        try (CleanupSink<String> sink = new CleanupSink<>(NullSink.of(), resources)) {
+            // When
+            sink.close();
+
+            // Then
+            Assert.assertEquals(sink.resourcesCount(), 0);
+        }
+    }
+
+    @Test
+    public void givenCleanupSinkWithCloseables_whenClosing_thenResourcesAreClosed() {
+        // Given
+        GoodCloseable resource1 = new GoodCloseable();
+        GoodCloseable resource2 = new GoodCloseable();
+        try (CleanupSink<String> sink = Sinks.<String>cleanup()
+                                             .resource(resource1)
+                                             .resource(resource2)
+                                             .discard()
+                                             .build()) {
+            // When
+            sink.close();
+
+            // Then
+            Assert.assertTrue(resource1.closed.get());
+            Assert.assertTrue(resource2.closed.get());
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Fails")
+    public void givenCleanupSinkWithDestinationThatFailsOnClose_whenClosing_thenErrorIsThrown_andResourcesAreClosed() {
+        // Given
+        GoodCloseable resource = new GoodCloseable();
+        try (CleanupSink<String> sink = Sinks.<String>cleanup()
+                                             .resource(resource)
+                                             .destination(new FailsOnCloseSink<>())
+                                             .build()) {
+            // When and Then
+            sink.close();
+            Assert.fail("Destination sink close exception should still be thrown");
+        } finally {
+            // And
+            Assert.assertTrue(resource.closed.get());
+        }
+    }
+
+    @Test
+    public void givenCleanupSinkWithValidDestination_whenSendingItems_thenItemsAreDelivered_andOnClosingResourcesAreClosed() {
+        // Given
+        GoodCloseable resource = new GoodCloseable();
+        try (CollectorSink<String> collector = Sinks.<String>collect().build()) {
+            try (CleanupSink<String> sink = Sinks.<String>cleanup().resource(resource).destination(collector).build()) {
+                // When
+                sink.send("a");
+                sink.send("b");
+
+                // Then
+                Assert.assertFalse(collector.get().isEmpty());
+                Assert.assertEquals(collector.get().size(), 2);
+
+                // And
+                sink.close();
+                Assert.assertTrue(resource.closed.get());
+                Assert.assertTrue(collector.get().isEmpty());
+            }
+        }
+    }
+
+    @DataProvider(name = "closeables")
+    public Object[][] closeables() {
+        return new Object[][] {
+                { List.of(new GoodCloseable(), new BadCloseable(), new GoodCloseable()) },
+                { List.of(new GoodCloseable(), new BadCloseable()) },
+                { List.of(new BadCloseable(), new GoodCloseable()) },
+                };
+    }
+
+    @Test(dataProvider = "closeables")
+    public void givenCleanupSinkWithMultipleCloseables_whenClosing_thenResourcesAreClosed(List<Closeable> resources) {
+        // Given
+        try (CleanupSink<String> sink = Sinks.<String>cleanup().resources(resources).discard().build()) {
+            // When
+            sink.close();
+
+            // Then
+            for (Closeable c : resources) {
+                if (c instanceof GoodCloseable good) {
+                    Assert.assertTrue(good.closed.get());
+                }
+            }
+        }
+    }
+
+    @Test(dataProvider = "closeables")
+    public void givenCleanupSinkWithMultipleCloseablesAsArray_whenClosing_thenResourcesAreClosed(
+            List<Closeable> resources) {
+        // Given
+        try (CleanupSink<String> sink = Sinks.<String>cleanup()
+                                             .resources(resources.toArray(new Closeable[0]))
+                                             .discard()
+                                             .build()) {
+            // When
+            sink.close();
+
+            // Then
+            for (Closeable c : resources) {
+                if (c instanceof GoodCloseable good) {
+                    Assert.assertTrue(good.closed.get());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void givenMultipleCleanupSinksWithSameResource_whenClosing_thenResourceIsClosedMultipleTimes() {
+        // Given
+        CountingCloseable resource = new CountingCloseable();
+        try (CleanupSink<String> sink = Sinks.<String>cleanup()
+                                             .resource(resource)
+                                             .cleanup(c -> c.resources(resource).discard())
+                                             .build()) {
+            // When
+            sink.close();
+
+            // Then
+            Assert.assertEquals(resource.count.get(), 2);
+        }
+    }
+
+
+    private final class GoodCloseable implements Closeable {
+
+        public AtomicBoolean closed = new AtomicBoolean(false);
+
+        @Override
+        public void close() throws IOException {
+            this.closed.set(true);
+        }
+    }
+
+    private final class BadCloseable implements Closeable {
+
+        @Override
+        public void close() throws IOException {
+            throw new RuntimeException("Close failure");
+        }
+    }
+
+    private final class CountingCloseable implements Closeable {
+        private final AtomicInteger count = new AtomicInteger(0);
+
+
+        @Override
+        public void close() throws IOException {
+            this.count.incrementAndGet();
+        }
+    }
+
+    private final class FailsOnCloseSink<T> implements Sink<T> {
+        @Override
+        public void send(T item) {
+            // No-op
+        }
+
+        @Override
+        public void close() {
+            throw new RuntimeException("Fails");
+        }
+    }
+}


### PR DESCRIPTION
Some accumulated cleanup and error handling improvements that were spotted while working on the most recent release of Search where the `KafkaSink` improvements made to these libraries in #64 were causing unhandled errors when the application terminated because shutdown order isn't guarantee able.

Main changes are as follows:

- Adds a new `CleanupSink` that can be added to existing pipelines to guarantee cleanup of `Closeable` resources
- Improves `LiveReporter` and `LiveErrorReporter` to gracefully handle `send()`'ing and `close()` errors where possible
- Improves `LiveReporterOptions` with new `teardown()` method that tears down the configured reporters gracefully logging any unexpected errors that occur during this
- `RuntimeInfo` now includes processor count in its output