### PR TITLE
Support serializing Problem as plain text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
       built-in support for generating Telicent standard headers.
     - `TelicentHeaders` adds constants for more Telicent standard headers.
     - Adds missing documentation for the existing and new event sinks
+- JAX-RS Base Server improvements:
+    - Added support for serializing `Problem` response as plain text
 
 # 0.24.2
 

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/AbstractApplication.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/AbstractApplication.java
@@ -21,6 +21,7 @@ import io.telicent.smart.cache.server.jaxrs.filters.FailureLoggingFilter;
 import io.telicent.smart.cache.server.jaxrs.filters.RequestIdFilter;
 import io.telicent.smart.cache.server.jaxrs.resources.AbstractHealthResource;
 import io.telicent.smart.cache.server.jaxrs.resources.VersionInfoResource;
+import io.telicent.smart.cache.server.jaxrs.writers.ProblemPlainTextWriter;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 import org.slf4j.Logger;
@@ -51,12 +52,17 @@ public abstract class AbstractApplication extends Application {
         classes.add(NotFoundExceptionMapper.class);
         classes.add(NotAllowedExceptionMapper.class);
         classes.add(FallbackExceptionMapper.class);
+
         // Request Filters
         if (this.isAuthEnabled()) {
             classes.add(JwtAuthFilter.class);
         }
         classes.add(RequestIdFilter.class);
         classes.add(FailureLoggingFilter.class);
+
+        // Message Body Writers
+        classes.add(ProblemPlainTextWriter.class);
+
         // Health Resource
         Class<? extends AbstractHealthResource> healthResourceClass = getHealthResourceClass();
         if (healthResourceClass != null) {
@@ -64,8 +70,10 @@ public abstract class AbstractApplication extends Application {
         } else {
             LOGGER.warn("No standardised Health Resource available for application {}", this.getClass().getCanonicalName());
         }
+
         // Version Info Resource
         classes.add(VersionInfoResource.class);
+
         return classes;
     }
 

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/model/Problem.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/model/Problem.java
@@ -31,6 +31,11 @@ import java.util.Objects;
 @JsonPropertyOrder({ "type", "title", "status", "detail", "instance" })
 public class Problem {
 
+    /**
+     * Media Type for Problem JSON responses per RFC 7807
+     */
+    public static final String MEDIA_TYPE = "application/problem+json";
+
     private String type, title, instance, detail;
     private int status;
 
@@ -60,12 +65,28 @@ public class Problem {
     /**
      * Converts the problem into an HTTP Response that can be returned by the server
      *
+     * <p>
+     * Note that as of {@code 0.25.0} we no longer set the
+     * {@link jakarta.ws.rs.core.Response.ResponseBuilder#type(String)} to {@value #MEDIA_TYPE} by default since we
+     * added support for serializing problems into other media types, e.g. {@code text/plain}.  Setting it explicitly
+     * overrode the JAX-RS server runtimes ability to set it based on the negotiated {@code Content-Type} for the
+     * response.
+     * </p>
+     * <p>
+     * Thus any endpoint that can return problem responses in this way <strong>MUST</strong> declare at least one of
+     * {@value jakarta.ws.rs.core.MediaType#TEXT_PLAIN}, {@value jakarta.ws.rs.core.MediaType#APPLICATION_JSON} or
+     * {@value #MEDIA_TYPE} in its {@link jakarta.ws.rs.Produces} annotation in order for the problem response to be
+     * serializable.  If you need to support problem responses in other media types then you will need to implement and
+     * register a suitable {@link jakarta.ws.rs.ext.MessageBodyWriter} in your application in the same way as we
+     * register {@link io.telicent.smart.cache.server.jaxrs.writers.ProblemPlainTextWriter} by default in our base
+     * {@link io.telicent.smart.cache.server.jaxrs.applications.AbstractApplication} class.
+     * </p>
+     *
      * @return HTTP Response
      */
     public Response toResponse() {
         return Response.status(this.status)
                        .entity(this)
-                       .type("application/problem+json")
                        .build();
     }
 
@@ -182,12 +203,11 @@ public class Problem {
 
     @Override
     public String toString() {
-        String sb = "Problem{" + "type='" + type + '\'' +
+        return "Problem{" + "type='" + type + '\'' +
                 ", title='" + title + '\'' +
                 ", instance='" + instance + '\'' +
                 ", detail='" + detail + '\'' +
                 ", status=" + status +
                 '}';
-        return sb;
     }
 }

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/writers/ProblemPlainTextWriter.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/writers/ProblemPlainTextWriter.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.server.jaxrs.writers;
+
+import io.telicent.smart.cache.server.jaxrs.model.Problem;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.riot.web.HttpNames;
+
+import java.io.*;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * A message body writer than can serialize {@link Problem} instances into Plain Text responses
+ */
+@Provider
+@Produces(MediaType.TEXT_PLAIN)
+public class ProblemPlainTextWriter implements MessageBodyWriter<Problem> {
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type == Problem.class && mediaType.equals(MediaType.TEXT_PLAIN_TYPE);
+    }
+
+    @Override
+    public void writeTo(Problem problem, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws
+            WebApplicationException {
+        try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(entityStream))) {
+            writer.print(problem.getStatus());
+            writer.print(' ');
+            int titleLength = Integer.toString(problem.getStatus()).length() + 1;
+            if (StringUtils.isNotBlank(problem.getTitle())) {
+                writer.println(problem.getTitle());
+                titleLength += problem.getTitle().length();
+                addTitleUnderline(writer, titleLength);
+            } else {
+                writer.println();
+                addTitleUnderline(writer, titleLength);
+            }
+            writer.println(problem.getDetail());
+            writer.println();
+        }
+    }
+
+    private static void addTitleUnderline(PrintWriter writer, int titleLength) {
+        writer.println(StringUtils.repeat('-', titleLength));
+        writer.println();
+    }
+}

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/resources/ProblemsResource.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/resources/ProblemsResource.java
@@ -24,7 +24,7 @@ import jakarta.ws.rs.core.Response;
 public class ProblemsResource {
 
     @GET
-    @Produces({ MediaType.APPLICATION_JSON, "application/problem+json" })
+    @Produces({ MediaType.APPLICATION_JSON, Problem.MEDIA_TYPE, MediaType.TEXT_PLAIN })
     public Response getProblem(@QueryParam("type") @DefaultValue("RuntimeException") String type,
                                @QueryParam("title") @DefaultValue("Unexpected Error") String title,
                                @QueryParam("status") @DefaultValue("500") int status,
@@ -38,4 +38,6 @@ public class ProblemsResource {
     public Response throwError(@QueryParam("message") @DefaultValue("Unexpected error") String message) {
         throw new RuntimeException(message);
     }
+
+
 }


### PR DESCRIPTION
This fixes a bug that has cropped up a few times as new services are built out that if an API is designed to support simpler `text/plain` responses but an error occurs our `ExceptionMapper`'s turn it into a `Problem` response which can't be serialized as `text/plain` out of the box.

To resolve this we add a new `ProblemPlainTextWriter` and register it in our `AbstractApplication` so serializing `Problem` responses to `text/plain` is supposed out of the box.

A related change is that `Problem.toResponse()` no longer sets the `Content-Type` always to `application/problem+json`, instead it allows the JAX-RS framework to set that correctly based on the HTTP request content negotiation it has already done.