### PR TITLE
Improved Problem Response Content-Type headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+# 0.25.1
+
+- JAX-RS Base Server improvements:
+    - Fixed a bug where `Problem` responses would default to `application/octet-stream` unexpectedly in some cases, it
+      should now make best effort to conform to an appropriate `Content-Type` based on clients `Accept` header and any
+      content negotation the JAX-RS framework has done prior to the problem being generated as a response.
+        - A new `toResponse(HttpHeaders)` overload is added to facilitate this behaviour
+
 # 0.25.0
 
 - Projector improvements:

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/ConstraintViolationMapper.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/ConstraintViolationMapper.java
@@ -20,6 +20,7 @@ import io.telicent.smart.cache.server.jaxrs.utils.ParamInfo;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.ExceptionMapper;
@@ -42,6 +43,9 @@ public class ConstraintViolationMapper implements ExceptionMapper<ConstraintViol
 
     @Context
     UriInfo uri;
+
+    @Context
+    HttpHeaders headers;
 
     @Override
     public Response toResponse(ConstraintViolationException exception) {
@@ -70,10 +74,13 @@ public class ConstraintViolationMapper implements ExceptionMapper<ConstraintViol
                 = exception.getConstraintViolations().isEmpty()
                   ? "InvalidRequestParameter"
                   : "InvalidRequestParameters";
+        //@formatter:off
         return new Problem(problemType,
                            null,
                            status.getStatusCode(),
                            detail.toString(),
-                           null).toResponse();
+                           null)
+                .toResponse(this.headers);
+        //@formatter:on
     }
 }

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/FallbackExceptionMapper.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/FallbackExceptionMapper.java
@@ -17,6 +17,8 @@ package io.telicent.smart.cache.server.jaxrs.errors;
 
 import io.telicent.smart.cache.server.jaxrs.model.Problem;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
@@ -30,6 +32,9 @@ import org.slf4j.LoggerFactory;
 public class FallbackExceptionMapper implements ExceptionMapper<Exception> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FallbackExceptionMapper.class);
+
+    @Context
+    private HttpHeaders headers;
 
     private String buildDetail(Throwable e) {
         StringBuilder builder = new StringBuilder();
@@ -55,7 +60,8 @@ public class FallbackExceptionMapper implements ExceptionMapper<Exception> {
                                null,
                                webEx.getResponse().getStatus(),
                                webEx.getMessage(),
-                               webEx.getClass().getCanonicalName()).toResponse();
+                               webEx.getClass().getCanonicalName())
+                    .toResponse(this.headers);
             //@formatter:on
         }
 
@@ -68,7 +74,8 @@ public class FallbackExceptionMapper implements ExceptionMapper<Exception> {
                            "Unexpected Error",
                            500,
                            buildDetail(exception),
-                           exception.getClass().getCanonicalName()).toResponse();
+                           exception.getClass().getCanonicalName())
+                .toResponse(this.headers);
         //@formatter:on
     }
 }

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/NotAllowedExceptionMapper.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/NotAllowedExceptionMapper.java
@@ -17,10 +17,7 @@ package io.telicent.smart.cache.server.jaxrs.errors;
 
 import io.telicent.smart.cache.server.jaxrs.model.Problem;
 import jakarta.ws.rs.NotAllowedException;
-import jakarta.ws.rs.core.Context;
-import jakarta.ws.rs.core.Request;
-import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.core.*;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 
@@ -34,15 +31,21 @@ public class NotAllowedExceptionMapper implements ExceptionMapper<NotAllowedExce
     private UriInfo uri;
 
     @Context
+    private HttpHeaders headers;
+
+    @Context
     private Request request;
 
     @Override
     public Response toResponse(NotAllowedException exception) {
+        //@formatter:off
         return new Problem("MethodNotAllowed",
                            null,
                            Response.Status.METHOD_NOT_ALLOWED.getStatusCode(),
                            String.format("/%s does not permit %s requests",
                                          this.uri.getPath(), this.request.getMethod()),
-                           null).toResponse();
+                           null)
+                .toResponse(this.headers);
+        //@formatter:on
     }
 }

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/NotFoundExceptionMapper.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/NotFoundExceptionMapper.java
@@ -18,6 +18,7 @@ package io.telicent.smart.cache.server.jaxrs.errors;
 import io.telicent.smart.cache.server.jaxrs.model.Problem;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.ExceptionMapper;
@@ -31,6 +32,9 @@ public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundExceptio
     @Context
     private UriInfo uri;
 
+    @Context
+    private HttpHeaders headers;
+
     @Override
     public Response toResponse(NotFoundException exception) {
         return new Problem("NotFound",
@@ -38,6 +42,6 @@ public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundExceptio
                            Response.Status.NOT_FOUND.getStatusCode(),
                            String.format("/%s is not a valid URL in this API",
                                          this.uri.getPath()),
-                           null).toResponse();
+                           null).toResponse(headers);
     }
 }

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/ParamExceptionMapper.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/errors/ParamExceptionMapper.java
@@ -16,6 +16,8 @@
 package io.telicent.smart.cache.server.jaxrs.errors;
 
 import io.telicent.smart.cache.server.jaxrs.model.Problem;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
@@ -26,16 +28,23 @@ import org.glassfish.jersey.server.ParamException;
  */
 @Provider
 public class ParamExceptionMapper implements ExceptionMapper<ParamException> {
+
+    @Context
+    private HttpHeaders headers;
+
     @Override
     public Response toResponse(ParamException exception) {
+        //@formatter:off
         return new Problem("BadRequestParameter",
-                           null,
+                           "Bad Parameter",
                            400,
                            String.format("%s Parameter '%s' received invalid value",
                                          exception.getParameterType()
                                                   .getSimpleName()
                                                   .replace("Param", ""),
                                          exception.getParameterName()),
-                           null).toResponse();
+                           null)
+                .toResponse(this.headers);
+        //@formatter:on
     }
 }

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/model/Problem.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/model/Problem.java
@@ -17,6 +17,8 @@ package io.telicent.smart.cache.server.jaxrs.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import java.util.Objects;
@@ -32,9 +34,15 @@ import java.util.Objects;
 public class Problem {
 
     /**
-     * Media Type for Problem JSON responses per RFC 7807
+     * JAX-RS Media Type for Problem JSON responses per RFC 7807
+     */
+    public static final MediaType APPLICATION_PROBLEM_JSON = new MediaType("application", "problem+json");
+
+    /**
+     * Media Type string for Problem JSON responses per RFC 7807
      */
     public static final String MEDIA_TYPE = "application/problem+json";
+
 
     private String type, title, instance, detail;
     private int status;
@@ -83,11 +91,66 @@ public class Problem {
      * </p>
      *
      * @return HTTP Response
+     * @deprecated Preferable to use {@link #toResponse(HttpHeaders)} to get improved Content Negotiation behaviour
+     * wherever possible
      */
+    @Deprecated
     public Response toResponse() {
-        return Response.status(this.status)
-                       .entity(this)
-                       .build();
+        return toResponse(null);
+    }
+
+    /**
+     * Converts the problem into an HTTP Response that can be returned by the server
+     *
+     * <p>
+     * Note that as of {@code 0.25.0} we no longer set the
+     * {@link jakarta.ws.rs.core.Response.ResponseBuilder#type(String)} to {@value #MEDIA_TYPE} by default since we
+     * added support for serializing problems into other media types, e.g. {@code text/plain}.  Setting it explicitly
+     * overrode the JAX-RS server runtimes ability to set it based on the negotiated {@code Content-Type} for the
+     * response.  However, if non-null {@link HttpHeaders} are provided then we make our best effort to set it
+     * appropriately based on the negotiated acceptable media types.
+     * </p>
+     * <p>
+     * Thus any endpoint that can return problem responses in this way <strong>MUST</strong> declare at least one of
+     * {@value jakarta.ws.rs.core.MediaType#TEXT_PLAIN}, {@value jakarta.ws.rs.core.MediaType#APPLICATION_JSON} or
+     * {@value #MEDIA_TYPE} in its {@link jakarta.ws.rs.Produces} annotation in order for the problem response to be
+     * serializable.  If you need to support problem responses in other media types then you will need to implement and
+     * register a suitable {@link jakarta.ws.rs.ext.MessageBodyWriter} in your application in the same way as we
+     * register {@link io.telicent.smart.cache.server.jaxrs.writers.ProblemPlainTextWriter} by default in our base
+     * {@link io.telicent.smart.cache.server.jaxrs.applications.AbstractApplication} class.
+     * </p>
+     *
+     * @return HTTP Response
+     * @since 0.25.1
+     */
+    public Response toResponse(HttpHeaders headers) {
+        return Response.status(this.status).entity(this).type(selectContentType(headers)).build();
+    }
+
+    /**
+     * Selects the most appropriate {@code Content-Type} header based on the HTTP Content Negotiation the JAX-RS
+     * framework has already done
+     *
+     * @param headers HTTP Headers
+     * @return Content Type, possibly {@code null} if it's been negotiated to some type we don't have built-in support
+     * for
+     */
+    public String selectContentType(HttpHeaders headers) {
+        if (headers == null) {
+            return MEDIA_TYPE;
+        }
+        for (MediaType acceptable : headers.getAcceptableMediaTypes()) {
+            if (acceptable.isWildcardType()) {
+                return MEDIA_TYPE;
+            } else if (acceptable.equals(APPLICATION_PROBLEM_JSON)) {
+                return MEDIA_TYPE;
+            } else if (acceptable.equals(MediaType.APPLICATION_JSON_TYPE)) {
+                return MediaType.APPLICATION_JSON;
+            } else if (acceptable.equals(MediaType.TEXT_PLAIN_TYPE)) {
+                return MediaType.TEXT_PLAIN;
+            }
+        }
+        return null;
     }
 
     /**
@@ -189,11 +252,9 @@ public class Problem {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Problem problem = (Problem) o;
-        return status == problem.status &&
-                Objects.equals(type, problem.type) &&
-                Objects.equals(title, problem.title) &&
-                Objects.equals(instance, problem.instance) &&
-                Objects.equals(detail, problem.detail);
+        return status == problem.status && Objects.equals(type, problem.type) && Objects.equals(title,
+                                                                                                problem.title) && Objects.equals(
+                instance, problem.instance) && Objects.equals(detail, problem.detail);
     }
 
     @Override
@@ -203,11 +264,6 @@ public class Problem {
 
     @Override
     public String toString() {
-        return "Problem{" + "type='" + type + '\'' +
-                ", title='" + title + '\'' +
-                ", instance='" + instance + '\'' +
-                ", detail='" + detail + '\'' +
-                ", status=" + status +
-                '}';
+        return "Problem{" + "type='" + type + '\'' + ", title='" + title + '\'' + ", instance='" + instance + '\'' + ", detail='" + detail + '\'' + ", status=" + status + '}';
     }
 }

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockApplication.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/MockApplication.java
@@ -30,6 +30,7 @@ public class MockApplication extends AbstractApplication {
         classes.add(DataResource.class);
         classes.add(ParamsResource.class);
         classes.add(ProblemsResource.class);
+        classes.add(ProblemCustomReaderWriter.class);
         return classes;
     }
 

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/ProblemCustomReaderWriter.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/ProblemCustomReaderWriter.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.server.jaxrs.applications;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.telicent.smart.cache.server.jaxrs.model.Problem;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.MessageBodyReader;
+import jakarta.ws.rs.ext.MessageBodyWriter;
+import jakarta.ws.rs.ext.Provider;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+@Provider
+@Consumes("application/custom")
+@Produces("application/custom")
+public class ProblemCustomReaderWriter implements MessageBodyWriter<Problem>, MessageBodyReader<Problem> {
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type == Problem.class;
+    }
+
+    @Override
+    public void writeTo(Problem problem, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                        MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException,
+            WebApplicationException {
+        JSON.writeValue(entityStream, problem);
+    }
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type == Problem.class;
+    }
+
+    @Override
+    public Problem readFrom(Class<Problem> type, Type genericType, Annotation[] annotations, MediaType mediaType,
+                            MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException,
+            WebApplicationException {
+        return JSON.readValue(entityStream, Problem.class);
+    }
+}

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/model/TestProblem.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/model/TestProblem.java
@@ -17,23 +17,36 @@ package io.telicent.smart.cache.server.jaxrs.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class TestProblem {
 
     private final ObjectMapper json = new ObjectMapper();
 
     @Test
-    public void problem_test_01() throws JsonProcessingException {
-        Problem problem = new Problem("Test", "Title", 400, "You were being bad", "BadRequest#1234");
+    public void givenProblemDetails_whenConstructingProblem_thenValuesAsExpected_andRoundTripsViaJson() throws
+            JsonProcessingException {
+        // Given and When
+        Problem problem = createTestProblem();
+
+        // Then
         Assert.assertTrue(problem.equals(problem));
         Assert.assertFalse(problem.equals(null));
         Assert.assertFalse(problem.equals(new Object()));
 
+        // And
         String json = this.json.writeValueAsString(problem);
         Problem retrieved = this.json.readValue(json, Problem.class);
-
         Assert.assertEquals(retrieved, problem);
         Assert.assertTrue(retrieved.equals(problem));
         Assert.assertEquals(retrieved.hashCode(), problem.hashCode());
@@ -41,13 +54,16 @@ public class TestProblem {
     }
 
     @Test
-    public void problem_test_02() {
-        Problem a = new Problem("Test", "Title", 400, "You were being bad", "BadRequest#1234");
-        Problem b = new Problem("Test", "Title", 400, "You were being bad", "BadRequest#1234");
+    public void givenTwoIdenticalProblems_whenComparingEquality_thenCorrect_andMutatingOneChangesEqualityResult() {
+        // Given
+        Problem a = createTestProblem();
+        Problem b = createTestProblem();
 
+        // When and Then
         Assert.assertEquals(a, b);
         Assert.assertTrue(a.equals(b));
 
+        // And
         // Mutate each field checking equality no longer holds
         b.setDetail(null);
         verifyNotEquals(a, b);
@@ -64,5 +80,69 @@ public class TestProblem {
     private static void verifyNotEquals(Problem a, Problem b) {
         Assert.assertNotEquals(a, b);
         Assert.assertFalse(a.equals(b));
+    }
+
+    @Test
+    public void givenProblem_whenConvertingToResponse_thenDefaultContentTypeSet() {
+        // Given
+        Problem problem = createTestProblem();
+
+        // When
+        Response response = problem.toResponse();
+
+        // Then
+        Assert.assertEquals(response.getMediaType(), Problem.APPLICATION_PROBLEM_JSON);
+    }
+
+    @Test
+    public void givenProblem_whenConvertingToResponseWithWildcardAccept_thenDefaultContentTypeSet() {
+        // Given
+        Problem problem = createTestProblem();
+        HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getAcceptableMediaTypes()).thenReturn(List.of(MediaType.WILDCARD_TYPE));
+
+        // When
+        Response response = problem.toResponse(headers);
+
+        // Then
+        Assert.assertEquals(response.getMediaType(), Problem.APPLICATION_PROBLEM_JSON);
+    }
+
+    @DataProvider(name = "mediaTypes")
+    private Object[][] mediaTypes() {
+        return new Object[][] {
+                {
+                        List.of(MediaType.APPLICATION_JSON, Problem.MEDIA_TYPE), MediaType.APPLICATION_JSON
+                }, {
+                        List.of(MediaType.TEXT_PLAIN), MediaType.TEXT_PLAIN
+                }, {
+                        List.of(Problem.MEDIA_TYPE), Problem.MEDIA_TYPE
+                }, {
+                        List.of("application/custom"), null
+                }
+        };
+    }
+
+    @Test(dataProvider = "mediaTypes")
+    public void givenProblem_whenConvertingToResponseWithAccept_thenExpectedContentTypeSet(List<String> accept,
+                                                                                           String expected) {
+        // Given
+        Problem problem = createTestProblem();
+        HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getAcceptableMediaTypes()).thenReturn(accept.stream().map(MediaType::valueOf).toList());
+
+        // When
+        Response response = problem.toResponse(headers);
+
+        // Then
+        if (expected != null) {
+            Assert.assertEquals(response.getMediaType(), MediaType.valueOf(expected));
+        } else {
+            Assert.assertNull(response.getMediaType());
+        }
+    }
+
+    private static Problem createTestProblem() {
+        return new Problem("Test", "Title", 400, "You were being bad", "BadRequest#1234");
     }
 }

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/resources/AttributesResource.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/resources/AttributesResource.java
@@ -26,6 +26,8 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.slf4j.Logger;
@@ -54,13 +56,13 @@ public class AttributesResource {
     @GET
     @Path("users/lookup/{user}")
     @Produces({MediaType.APPLICATION_JSON})
-    public Response lookupUser(@PathParam("user") @NotBlank String user) {
+    public Response lookupUser(@Context HttpHeaders headers, @PathParam("user") @NotBlank String user) {
         AttributesStore store = getAttributesStore();
         AttributeValueSet attributes = store.attributes(user);
         if (attributes == null) {
             LOGGER.warn("No attributes for user {}", user);
             return new Problem("NotFound", "User Not Found", Response.Status.NOT_FOUND.getStatusCode(),
-                               "No attributes for user " + user, null).toResponse();
+                               "No attributes for user " + user, null).toResponse(headers);
         } else {
             LOGGER.info("Returning attributes for user {}", user);
         }
@@ -76,7 +78,7 @@ public class AttributesResource {
     @GET
     @Path("hierarchies/lookup/{name}")
     @Produces({MediaType.APPLICATION_JSON})
-    public Response lookupHierarchy(@PathParam("name") @NotBlank String name) {
+    public Response lookupHierarchy(@Context HttpHeaders headers, @PathParam("name") @NotBlank String name) {
         AttributesStore store = getAttributesStore();
         Attribute key = Attribute.create(name);
         if (store.hasHierarchy(key)) {
@@ -92,7 +94,7 @@ public class AttributesResource {
         } else {
             LOGGER.warn("No hierarchy {}", name);
             return new Problem("NotFound", "Hierarchy Not Found", Response.Status.NOT_FOUND.getStatusCode(),
-                               "No hierarchy " + name + " exists", null).toResponse();
+                               "No hierarchy " + name + " exists", null).toResponse(headers);
         }
     }
 }

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/resources/ProblemsResource.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/resources/ProblemsResource.java
@@ -17,6 +17,8 @@ package io.telicent.smart.cache.server.jaxrs.resources;
 
 import io.telicent.smart.cache.server.jaxrs.model.Problem;
 import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -24,12 +26,13 @@ import jakarta.ws.rs.core.Response;
 public class ProblemsResource {
 
     @GET
-    @Produces({ MediaType.APPLICATION_JSON, Problem.MEDIA_TYPE, MediaType.TEXT_PLAIN })
-    public Response getProblem(@QueryParam("type") @DefaultValue("RuntimeException") String type,
+    @Produces({ MediaType.APPLICATION_JSON, Problem.MEDIA_TYPE, MediaType.TEXT_PLAIN , "application/custom"})
+    public Response getProblem(@Context HttpHeaders headers,
+                               @QueryParam("type") @DefaultValue("RuntimeException") String type,
                                @QueryParam("title") @DefaultValue("Unexpected Error") String title,
                                @QueryParam("status") @DefaultValue("500") int status,
                                @QueryParam("detail") @DefaultValue("") String detail) {
-        return new Problem(type, title, status, detail, null).toResponse();
+        return new Problem(type, title, status, detail, null).toResponse(headers);
     }
 
     @GET


### PR DESCRIPTION
Iterates on a change made in the 0.25.0 release where we stopped setting the `Content-Type` header at all to allow the JAX-RS server to do content negotiation properly.  However, turns out that in some corner cases this results in a `Problem` response being defaulted to
`application/octet-stream` responses which is rarely useful/helpful.

Therefore this improves the behaviour to make a best effort to add a recognised `Content-Type` header, when it is compatible with the acceptable content types indicated by the clients `Accept` header. A new `toResponse(HttpHeaders)` overload is added to facilitate this, and existing callers of `toResponse()` updated to call the new method instead.

Also greatly expands the test coverage in this area to validate various scenarios around different combinations of `Accept` header, resource `@Produces` headers and the resulting `Content-Type` header.

# Related Issues and PRs

- Discovered while reviewing Dependabot PRs for the 0.25.0 upgrade e.g. https://github.com/Telicent-io/user-preferences-service/actions/runs/12345464738/job/34449662984 was failing with the following:
    > TestUserPreferencesServerBlocking>AbstractUserPreferencesServerTests.givenAuthenticatedUser_whenSavingQueryWithInvalidId_thenBadRequest:503->AbstractUserPreferencesServerTests.verifyInvalidId:480->AbstractUserPreferencesServerTests.verify:172 » MessageBodyProviderNotFound MessageBodyReader not found for media type=application/octet-stream, type=class io.telicent.smart.cache.server.jaxrs.model.Problem, genericType=class io.telicent.smart.cache.server.jaxrs.model.Problem.
    - Using a `SNAPSHOT` build from this branch those errors no longer occur