### PR TITLE
Revert "Bump jakarta.ws.rs:jakarta.ws.rs-api from 3.1.0 to 4.0.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency.jakarta.annotation>3.0.0</dependency.jakarta.annotation>
         <dependency.jakarta-inject>2.0.1.MR</dependency.jakarta-inject>
         <dependency.jakarta.validation>3.1.0</dependency.jakarta.validation>
-        <dependency.jakarta.ws.rs>4.0.0</dependency.jakarta.ws.rs>
+        <dependency.jakarta.ws.rs>3.1.0</dependency.jakarta.ws.rs>
         <dependency.jena>5.2.0</dependency.jena>
         <dependency.jersey>3.1.9</dependency.jersey>
         <dependency.jetbrains-annotations>26.0.1</dependency.jetbrains-annotations>


### PR DESCRIPTION
Reverts telicent-oss/smart-caches-core#84

This is causing strange build/run issues in downstream consumers of these libraries due to changes in their major version bump.  It's not clear that Jersey properly supports JAX-RS 4 yet so until it does we should avoid taking this upgrade