### PR TITLE
Make dependency:analyze failOnWarning configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log
 
+# 0.26.0
+
+- Build improvements:
+    - Revert upgrade to JAX-RS 4.0 as was causing cryptic build/runtime compatibility issues on some downstream projects
+    - New `analyze.failOnWarnings` property can be overridden in modules/projects to skip `dependency:analyze-only` goal
+      if the module/project is not yet ready for stricter dependency analysis.
+
 # 0.25.2
+
 - Build improvements
   - Minor dependency cleanup
+
 # 0.25.1
 
 - JAX-RS Base Server improvements:

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,9 @@
         <!-- Javadoc Configuration -->
         <javadoc.failOnWarnings>true</javadoc.failOnWarnings>
 
+        <!-- Dependency Analyze Configuration -->
+        <analyze.failOnWarnings>true</analyze.failOnWarnings>
+
         <!-- Parallel Testing -->
         <!--
         Controls how many JVM forks are used for parallel testing in some modules, set to a conservative 2 which offers
@@ -702,7 +705,7 @@
                                 <goal>analyze-only</goal>
                             </goals>
                             <configuration>
-                                <failOnWarning>true</failOnWarning>
+                                <failOnWarning>${analyze.failOnWarnings}</failOnWarning>
                                 <ignoredNonTestScopedDependencies>
                                     <ignoredNonTestScopedDependency>org.glassfish.grizzly:grizzly-http</ignoredNonTestScopedDependency>
                                     <ignoredNonTestScopedDependency>jakarta.ws.rs:jakarta.ws.rs-api</ignoredNonTestScopedDependency>


### PR DESCRIPTION
This allows for downstream consumers of this library, which may be projects in the prototype stage, to turn off this strict dependency analyze until they are ready to opt into it