### PR TITLE
Restore wrongly scoped Jersey related dependencies

### DIFF
--- a/jaxrs-base-server/pom.xml
+++ b/jaxrs-base-server/pom.xml
@@ -37,6 +37,16 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-framework</artifactId>
         </dependency>
@@ -87,6 +97,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.telicent.public</groupId>
             <artifactId>jwt-servlet-auth-core</artifactId>
         </dependency>
@@ -132,6 +152,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.telicent.public</groupId>
+            <artifactId>jwt-servlet-auth-aws</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.telicent.smart-caches</groupId>
             <artifactId>jwt-auth-common</artifactId>
             <version>${project.version}</version>
@@ -174,21 +199,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt-jackson</artifactId>
             <version>${dependency.jjwt}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -197,24 +210,6 @@
             <artifactId>jwt-servlet-auth-core</artifactId>
             <version>${dependency.jwt-auth}</version>
             <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.telicent.public</groupId>
-            <artifactId>jwt-servlet-auth-aws</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Even with 0.26.0 release was still getting strange runtime errors in downstream repositories.  On further investigation realised this was become some dependencies has been erroneously moved to test scope when they were in fact required for servers to run correctly.  They were wrongly classified by dependency analysis as unused because they are not directly used, rather indirectly via Service Loading.

This also explains why the tests here didn't fail as these dependencies has simpy been moved to test scope so they were present for the tests and allowed those to pass successfully.