### PR TITLE
Fix JAX-RS Base Server dependency scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+# 0.26.2
+
+- Build improvements:
+    - Fix some incorrect jaxrs-base-server dependency scope changes that could still cause runtime failures in some
+      deployment scenarios
+    - Jersey upgraded to 3.1.10
+    - OpenTelemetry SDK upgraded 1.46.0
+
 # 0.26.1
 
 - Build improvements:

--- a/jaxrs-base-server/pom.xml
+++ b/jaxrs-base-server/pom.xml
@@ -117,6 +117,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-grizzly2-servlet</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
@@ -142,7 +147,6 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Authentication Dependencies -->
@@ -160,6 +164,13 @@
             <groupId>io.telicent.smart-caches</groupId>
             <artifactId>jwt-auth-common</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${dependency.jjwt}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -195,13 +206,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.jsonwebtoken</groupId>
-            <artifactId>jjwt-jackson</artifactId>
-            <version>${dependency.jjwt}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.glassfish.jersey.containers</groupId>
+                <artifactId>jersey-container-grizzly2-servlet</artifactId>
+                <version>${dependency.jersey}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.glassfish.grizzly</groupId>
                 <artifactId>grizzly-framework</artifactId>
                 <version>${dependency.grizzly}</version>


### PR DESCRIPTION
Downstream projects were still seeing runtime failures due to incorrect dependency scoping when used in some deployment scenarios.  This commit restores the missing dependencies and/or corrects dependency scopes as appropriate.

Discovered this while trying to test the new User Preferences Service release, while the tests were passing the containerised build was failing as some required dependencies weren't get copied over leading to Class Not Found errors at runtime