### PR TITLE
Improvements to Kafka Event Sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@
       an external `OffsetStore`, rather than Kafka's Consumer Group offset tracking.
     - Added new `resetOffsets()` method to `KafkaEventSource` that allows resetting the offsets to either reprocess
       previous events, or skip over events, as desired.
+    - `close()` is more tolerant of errors during closure and ensures that for all managed resources appropriate closure
+      actions are taken.
 - Projector Driver improvements:
     - `ProjectorDriver` explicitly logs unexpected errors that cause projection to be aborted
     - `ProjectorDriver` now provides additional get methods to allow inspecting some aspects of the driver
+- Build and Test Improvements:
+    - Further unit and integration test cases added around various `KafkaEventSource` behaviours
 
 # 0.26.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+# 0.27.0
+
+- Kafka Event Source improvements:
+    - Added new `KafkaReadPolicies.fromExternalOffsets()` static method that allows controlling the Kafka offsets from
+      an external `OffsetStore`, rather than Kafka's Consumer Group offset tracking.
+    - Added new `resetOffsets()` method to `KafkaEventSource` that allows resetting the offsets to either reprocess
+      previous events, or skip over events, as desired.
+- Projector Driver improvements:
+    - `ProjectorDriver` explicitly logs unexpected errors that cause projection to be aborted
+    - `ProjectorDriver` now provides additional get methods to allow inspecting some aspects of the driver
+
 # 0.26.2
 
 - Build improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 # 0.27.0
 
+- Event Source improvements:
+    - `RdfPayload` has new `sizeInBytes()` method that exposes the raw byte sequence size, even if the byte sequence has
+      been successfully deserialised and discarded.
 - Kafka Event Source improvements:
     - Added new `KafkaReadPolicies.fromExternalOffsets()` static method that allows controlling the Kafka offsets from
       an external `OffsetStore`, rather than Kafka's Consumer Group offset tracking.

--- a/cli/cli-core/pom.xml
+++ b/cli/cli-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli-core</artifactId>

--- a/cli/cli-debug/pom.xml
+++ b/cli/cli-debug/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli-debug</artifactId>

--- a/cli/cli-probe-server/pom.xml
+++ b/cli/cli-probe-server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>cli</artifactId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <artifactId>cli-probe-server</artifactId>
     <name>Telicent Smart Caches - CLI - Health Probe Server</name>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli</artifactId>

--- a/configurator/pom.xml
+++ b/configurator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <artifactId>configurator</artifactId>
     <name>Telicent Smart Caches - Configuration API</name>

--- a/event-sources/event-source-file/pom.xml
+++ b/event-sources/event-source-file/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-source-file</artifactId>

--- a/event-sources/event-source-kafka/pom.xml
+++ b/event-sources/event-source-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-source-kafka</artifactId>

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractBufferedEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractBufferedEventSource.java
@@ -21,6 +21,7 @@ import io.telicent.smart.cache.sources.EventSource;
 import java.time.Duration;
 import java.util.LinkedList;
 import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
  * An event source that uses an internal buffer
@@ -44,7 +45,7 @@ public abstract class AbstractBufferedEventSource<TIntermediate, TKey, TValue> i
     /**
      * The buffer of intermediate events
      */
-    protected final Queue<TIntermediate> events = new LinkedList<>();
+    protected final Queue<TIntermediate> events = new ConcurrentLinkedQueue<>();
 
     /**
      * Creates a new buffered event source

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/TopicExistenceChecker.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/TopicExistenceChecker.java
@@ -257,7 +257,7 @@ public class TopicExistenceChecker {
      * @return True if the topic exists, false otherwise
      */
     protected final boolean doesTopicExist(String topic, Duration timeout) {
-        if (this.topicExists.containsKey(topic) && this.topicExists.get(topic).booleanValue()) {
+        if (this.topicExists.containsKey(topic) && this.topicExists.get(topic)) {
             return true;
         }
 

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/AbstractReadPolicy.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/AbstractReadPolicy.java
@@ -17,14 +17,17 @@ package io.telicent.smart.cache.sources.kafka.policies;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.telicent.smart.cache.sources.kafka.policies.automatic.AbstractAutoReadPolicy;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -36,10 +39,17 @@ import java.util.stream.Collectors;
  * @param <TValue> Value type
  */
 public abstract class AbstractReadPolicy<TKey, TValue> implements KafkaReadPolicy<TKey, TValue> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractReadPolicy.class);
+
     /**
      * The Kafka consumer that is being used
      */
     protected Consumer<TKey, TValue> consumer = null;
+
+    /**
+     * A map of offset resets that have yet to be applied
+     */
+    protected final Map<TopicPartition, Long> resetOffsets = new ConcurrentHashMap<>();
 
     /**
      * We create a basic cache to control the amount of repeated status messages logged that add no value.
@@ -119,10 +129,10 @@ public abstract class AbstractReadPolicy<TKey, TValue> implements KafkaReadPolic
             long position = this.consumer.position(p);
             OptionalLong currentLag = this.consumer.currentLag(p);
             String knownLag = currentLag.isPresent() ? String.format("%,d", currentLag.getAsLong()) : "unknown";
-            String key = String.format("%s-%d-%s", p , position , knownLag);
-            if(LOGGING_CACHE.getIfPresent(key) == null) {
+            String key = String.format("%s-%d-%s", p, position, knownLag);
+            if (LOGGING_CACHE.getIfPresent(key) == null) {
                 FmtLog.info(logger, "Kafka Partition %s is at position %,d with a current lag of %s", p,
-                        position, knownLag);
+                            position, knownLag);
                 LOGGING_CACHE.put(key, Boolean.TRUE);
             }
         });
@@ -157,5 +167,58 @@ public abstract class AbstractReadPolicy<TKey, TValue> implements KafkaReadPolic
         } else {
             return totalLag.get();
         }
+    }
+
+    @Override
+    public void resetOffsets(Map<TopicPartition, Long> offsets) {
+        synchronized (this.resetOffsets) {
+            // Clear any previously requested offset resets that we were yet to apply
+            this.resetOffsets.clear();
+
+            // Try to apply each reset
+            Set<String> relevantTopics = this.consumer.subscription();
+            for (Map.Entry<TopicPartition, Long> newOffset : offsets.entrySet()) {
+                TopicPartition partition = newOffset.getKey();
+                if (relevantTopics.contains(partition.topic())) {
+                    if (this.consumer.assignment().contains(partition)) {
+                        // Currently subscribed to topic and assigned this partition so reset immediately
+                        LOGGER.info("Reset offset for topic partition {}-{} to offset {}", partition.topic(),
+                                    partition.partition(), newOffset.getValue());
+                        this.consumer.seek(partition, newOffset.getValue());
+                        markAsReset(partition);
+                    } else {
+                        ignoreResetForNow(newOffset, "as not currently assigned that partition");
+                    }
+                } else {
+                    ignoreResetForNow(newOffset, "as not currently subscribed to that topic");
+                }
+            }
+        }
+    }
+
+    /**
+     * Called when {@link #resetOffsets(Map)} applies an offset reset to the given topic partition.
+     * <p>
+     * This method does nothing by default, derived read policies may wish to override this method in order that they
+     * can update any internal state they hold that might cause them to seek away from the explicitly reset offset.
+     * </p>
+     *
+     * @param partition Topic partition
+     */
+    protected void markAsReset(TopicPartition partition) {
+        // No-op by default
+    }
+
+    /**
+     * Marks that an offset reset has been ignored for now but could be applicable later
+     *
+     * @param newOffset New Offset to reset to
+     * @param reason    Reason for ignoring
+     */
+    private void ignoreResetForNow(Map.Entry<TopicPartition, Long> newOffset, String reason) {
+        LOGGER.info(
+                "Ignored reset for topic partition {}-{} {}.  This will be applied if and when we are assigned that partition.",
+                newOffset.getKey().topic(), newOffset.getKey().partition(), reason);
+        this.resetOffsets.put(newOffset.getKey(), newOffset.getValue());
     }
 }

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/KafkaReadPolicies.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/KafkaReadPolicies.java
@@ -17,6 +17,7 @@ package io.telicent.smart.cache.sources.kafka.policies;
 
 import io.telicent.smart.cache.sources.kafka.policies.automatic.*;
 import io.telicent.smart.cache.sources.kafka.policies.manual.ManualFromBeginning;
+import io.telicent.smart.cache.sources.offsets.OffsetStore;
 import org.apache.kafka.common.TopicPartition;
 
 import java.util.Map;
@@ -110,5 +111,19 @@ public class KafkaReadPolicies {
     public static <TKey, TValue> KafkaReadPolicy<TKey, TValue> fromOffsets(Map<TopicPartition, Long> offsets,
                                                                            long defaultOffset) {
         return new AutoFromOffset<>(offsets, defaultOffset);
+    }
+
+    /**
+     * Reads event starting from specific offsets as managed by an external offsets store
+     *
+     * @param offsets       Offsets store
+     * @param defaultOffset Default offset to use for any partition whose desired offset is not explicitly specified
+     * @param <TKey>        Key Type
+     * @param <TValue>      Value Type
+     * @return Read Policy
+     */
+    public static <TKey, TValue> KafkaReadPolicy<TKey, TValue> fromExternalOffsets(OffsetStore offsets,
+                                                                                   long defaultOffset) {
+        return new AutoFromExternalOffsetsStore<>(offsets, defaultOffset);
     }
 }

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/KafkaReadPolicy.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/KafkaReadPolicy.java
@@ -17,8 +17,10 @@ package io.telicent.smart.cache.sources.kafka.policies;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.common.TopicPartition;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -100,4 +102,11 @@ public interface KafkaReadPolicy<TKey, TValue> extends ConsumerRebalanceListener
      * @param topic Topic to stop receiving events on
      */
     void stopEvents(String topic);
+
+    /**
+     * Resets the offsets of the consumer to the offsets provided
+     *
+     * @param offsets Offsets
+     */
+    void resetOffsets(Map<TopicPartition, Long> offsets);
 }

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/automatic/AbstractAutoReadPolicy.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/automatic/AbstractAutoReadPolicy.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Abstract base class for Kafka read policies that rely upon Kafka's Consumer Groups subscription model.
@@ -117,10 +118,7 @@ public abstract class AbstractAutoReadPolicy<TKey, TValue> extends AbstractReadP
         Set<String> affectedTopics = getAffectedTopics(partitions);
         LOGGER.info("Assigned {} partitions for Kafka topic {}", partitions.size(),
                     StringUtils.join(affectedTopics, ", "));
-
         seek(partitions);
-
         logPartitionPositions(partitions, LOGGER);
     }
-
 }

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/automatic/AbstractAutoSeekingPolicy.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/automatic/AbstractAutoSeekingPolicy.java
@@ -16,6 +16,8 @@
 package io.telicent.smart.cache.sources.kafka.policies.automatic;
 
 import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.*;
 
@@ -27,23 +29,64 @@ import java.util.*;
  * @param <TValue> Value type
  */
 public abstract class AbstractAutoSeekingPolicy<TKey, TValue> extends AbstractAutoReadPolicy<TKey, TValue> {
+    private final static Logger LOGGER = LoggerFactory.getLogger(AbstractAutoSeekingPolicy.class);
+
     private final Set<TopicPartition> seekedPartitions = new HashSet<>();
 
     @Override
-    protected final void seek(Collection<TopicPartition> partitions) {
+    protected void markAsReset(TopicPartition partition) {
         synchronized (this.seekedPartitions) {
-            // Due to consumer group re-balances we could get reassigned the same partitions during the course of our
-            // lifetime in which case we do not want to repeatedly seek to the desired position within the topic as that
-            // would cause us to redo work everytime a re-balance happens
-            List<TopicPartition> needsSeek = new ArrayList<>();
-            for (TopicPartition partition : partitions) {
-                if (!seekedPartitions.contains(partition)) {
-                    needsSeek.add(partition);
+            // If we've reset this partition then we have already effectively seeked it, and we should not seek again if
+            // we are re-assigned it in future
+            this.seekedPartitions.add(partition);
+        }
+    }
+
+    @Override
+    protected final void seek(Collection<TopicPartition> partitions) {
+        synchronized (this.resetOffsets) {
+            synchronized (this.seekedPartitions) {
+                // Due to consumer group re-balances we could get reassigned the same partitions during the course of
+                // our lifetime in which case we do not want to repeatedly seek to the desired position within the topic
+                // as that would cause us to redo work everytime a re-balance happens
+                // However, we do permit for offsets to be explicitly reset in which case we will seek to the requested
+                // offset
+                List<TopicPartition> needsSeek = new ArrayList<>();
+                for (TopicPartition partition : partitions) {
+                    if (!seekedPartitions.contains(partition) || this.resetOffsets.containsKey(partition)) {
+                        needsSeek.add(partition);
+                    }
                 }
-            }
-            if (!needsSeek.isEmpty()) {
-                seekInternal(needsSeek);
-                seekedPartitions.addAll(needsSeek);
+                if (!needsSeek.isEmpty()) {
+                    // If we had some offset resets that we previously could not apply we apply them now if possible
+                    if (!this.resetOffsets.isEmpty()) {
+                        for (TopicPartition partition : needsSeek.stream().toList()) {
+                            // Do we have an offset reset for this partition?
+                            long offset = this.resetOffsets.getOrDefault(partition, Long.MIN_VALUE);
+                            if (offset != Long.MIN_VALUE) {
+                                // If so we apply it now, and mark the partition as seeked so we won't override this with
+                                // our default seeking behaviour later
+                                LOGGER.info("Resetting offset for topic partition {}-{} to offset {}",
+                                            partition.topic(),
+                                            partition.partition(), offset);
+                                this.consumer.seek(partition, offset);
+
+                                // We only want to reset once so mark this reset as applied, and this partition as
+                                // seeked
+                                this.resetOffsets.remove(partition);
+                                seekedPartitions.add(partition);
+                                needsSeek.remove(partition);
+                            }
+                        }
+                    }
+
+                    // If we still have partitions for which we need to seek go ahead and defer to the derived
+                    // implementations internal seek logic now
+                    if (!needsSeek.isEmpty()) {
+                        seekInternal(needsSeek);
+                        seekedPartitions.addAll(needsSeek);
+                    }
+                }
             }
         }
     }

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/automatic/AbstractOffsetSelectingPolicy.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/automatic/AbstractOffsetSelectingPolicy.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka.policies.automatic;
+
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Collection;
+
+/**
+ * An automatic read policy that seeks within partitions when they are assigned to it based upon previously provided
+ * offsets.  It guarantees that the seek happens only once for each partition.
+ *
+ * @param <TKey>   Key type
+ * @param <TValue> Value type
+ */
+public abstract class AbstractOffsetSelectingPolicy<TKey, TValue> extends AbstractAutoSeekingPolicy<TKey, TValue> {
+    protected final long defaultOffset;
+
+    /**
+     * Creates a new policy
+     *
+     * @param defaultOffset The default offset to seek to if no more specific offset available for a partition
+     */
+    public AbstractOffsetSelectingPolicy(long defaultOffset) {
+        if (defaultOffset < 0) {
+            throw new IllegalArgumentException("defaultOffset must be >= 0");
+        }
+        this.defaultOffset = defaultOffset;
+    }
+
+    @Override
+    protected final void seekInternal(Collection<TopicPartition> partitions) {
+        for (TopicPartition partition : partitions) {
+            long offset = selectOffset(partition);
+            this.consumer.seek(partition, offset);
+        }
+    }
+
+    /**
+     * Selects the offset to seek to for the given partition
+     *
+     * @param partition Partition
+     * @return Offset to seek to
+     */
+    protected abstract long selectOffset(TopicPartition partition);
+}

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/automatic/AutoFromExternalOffsetsStore.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/automatic/AutoFromExternalOffsetsStore.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka.policies.automatic;
+
+import io.telicent.smart.cache.sources.kafka.KafkaEventSource;
+import io.telicent.smart.cache.sources.offsets.OffsetStore;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.*;
+
+/**
+ * A Kafka read policy that reads events from specific offsets, as defined by an external offset store, onwards from all
+ * assigned partitions (which are assigned automatically via Kafka Consumer groups).
+ *
+ * @param <TKey>   Key Type
+ * @param <TValue> Value Type
+ */
+public class AutoFromExternalOffsetsStore<TKey, TValue> extends AbstractOffsetSelectingPolicy<TKey, TValue> {
+
+    private final OffsetStore offsets;
+
+    /**
+     * Creates a new policy that reads from the offsets in an external offsets store
+     *
+     * @param offsets       Offset store that provides the offsets to start reading from
+     * @param defaultOffset Default offset to use for any partition whose offset is not yet tracked
+     */
+    public AutoFromExternalOffsetsStore(OffsetStore offsets, long defaultOffset) {
+        super(defaultOffset);
+        this.offsets = Objects.requireNonNull(offsets, "Offsets Store cannot be null");
+    }
+
+    /**
+     * Selects the offset to read from for the given partition
+     *
+     * @param partition Partition
+     * @return Offset to read from
+     */
+    @Override
+    protected long selectOffset(TopicPartition partition) {
+        String consumerGroup = this.consumer.groupMetadata().groupId();
+        String key =
+                KafkaEventSource.externalOffsetStoreKey(partition.topic(), partition.partition(), consumerGroup);
+        if (this.offsets.hasOffset(key)) {
+            return this.offsets.loadOffset(key);
+        } else {
+            return this.defaultOffset;
+        }
+    }
+}

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/manual/ManualFromBeginning.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/manual/ManualFromBeginning.java
@@ -16,8 +16,12 @@
 package io.telicent.smart.cache.sources.kafka.policies.manual;
 
 import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * A Kafka Read Policy that uses manual partition assignment to assign itself all available partitions for a topic and
@@ -27,8 +31,31 @@ import java.util.Collection;
  * @param <TValue> Value Type
  */
 public class ManualFromBeginning<TKey, TValue> extends AbstractManualReadPolicy<TKey, TValue> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ManualFromBeginning.class);
+
     @Override
     protected void seek(Collection<TopicPartition> partitions) {
-        this.consumer.seekToBeginning(partitions);
+        synchronized (this.resetOffsets) {
+            Set<TopicPartition> needsSeek = new HashSet<>(partitions);
+
+            // Do any of the partitions we've assigned ourselves need an offset reset?
+            if (!this.resetOffsets.isEmpty()) {
+                for (TopicPartition partition : partitions) {
+                    long offset = this.resetOffsets.getOrDefault(partition, Long.MIN_VALUE);
+                    if (offset != Long.MIN_VALUE) {
+                        // If it needs an offset apply it now
+                        this.consumer.seek(partition, offset);
+                        LOGGER.info("Resetting offset for topic partition {}-{} to offset {}",
+                                    partition.topic(),
+                                    partition.partition(), offset);
+                        needsSeek.remove(partition);
+                    }
+                }
+            }
+            if (!needsSeek.isEmpty()) {
+                // For any other assigned partitions seek to the beginning
+                this.consumer.seekToBeginning(needsSeek);
+            }
+        }
     }
 }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/AbstractConsumerMocks.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/AbstractConsumerMocks.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class AbstractConsumerMocks {
+
+    public static void mockSubscribeUnsubscribe(KafkaConsumer consumer) {
+        Set<String> topics = new LinkedHashSet<>();
+        doAnswer(invocation -> {
+            topics.clear();
+            topics.addAll(invocation.getArgument(0, Collection.class));
+            return null;
+        }).when(consumer).subscribe(any(Collection.class), any());
+        doAnswer(invocation -> {
+            topics.clear();
+            return null;
+        }).when(consumer).unsubscribe();
+        when(consumer.subscription()).thenReturn(topics);
+    }
+
+    public static void mockAssignment(KafkaConsumer consumer) {
+        Set<TopicPartition> partitions = new LinkedHashSet<>();
+        doAnswer(invocation -> {
+            partitions.addAll(invocation.getArgument(0, Collection.class));
+            return null;
+        }).when(consumer).assign(any());
+        when(consumer.assignment()).thenReturn(partitions);
+    }
+
+    public static TopicPartition mockPartition(KafkaConsumer consumer, String topic) {
+        TopicPartition partition = new TopicPartition(topic, 0);
+        when(consumer.partitionsFor(topic)).thenReturn(asPartitionInfo(partition));
+        return partition;
+    }
+
+    public static void mockConsumerGroup(KafkaConsumer consumer) {
+        ConsumerGroupMetadata group = mock(ConsumerGroupMetadata.class);
+        when(group.groupId()).thenReturn(TestKafkaEventSource.TEST_GROUP);
+        when(consumer.groupMetadata()).thenReturn(group);
+    }
+
+    public static List<PartitionInfo> asPartitionInfo(TopicPartition partition) {
+        Node n = mock(Node.class);
+        Node[] ns = new Node[] { n };
+        return Collections.singletonList(new PartitionInfo(partition.topic(), partition.partition(), n, ns, ns));
+    }
+}

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockReadPolicy.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockReadPolicy.java
@@ -102,7 +102,10 @@ public class MockReadPolicy<TKey, TValue> implements KafkaReadPolicy<TKey, TValu
     @Override
     public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
         this.policy.onPartitionsAssigned(partitions);
+    }
 
-
+    @Override
+    public void resetOffsets(Map<TopicPartition, Long> offsets) {
+        this.policy.resetOffsets(offsets);
     }
 }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceClosure.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceClosure.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka;
+
+import io.telicent.smart.cache.sources.EventSource;
+import io.telicent.smart.cache.sources.kafka.policies.KafkaReadPolicy;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings("unchecked")
+public class TestKafkaEventSourceClosure extends AbstractConsumerMocks {
+
+    @AfterMethod
+    public void cleanup() {
+        MockitoKafkaEventSource.reset();
+    }
+
+    @Test
+    public void givenBasicMockConsumer_whenClosingSource_thenExpectedCloseActionsCalledOnConsumer() {
+        // Given
+        KafkaConsumer<Integer, String> consumer = mock(KafkaConsumer.class);
+        MockitoKafkaEventSource.setMockConsumer(consumer);
+        KafkaReadPolicy<Integer, String> policy = mock(KafkaReadPolicy.class);
+        EventSource<Integer, String> source =
+                new MockitoKafkaEventSource<>("localhost:9092", Set.of(KafkaTestCluster.DEFAULT_TOPIC), "test",
+                                              IntegerDeserializer.class.getCanonicalName(),
+                                              StringDeserializer.class.getCanonicalName(), 100,
+                                              policy, true);
+
+        // When
+        source.close();
+
+        // Then
+        verifyCloseActionsCalled(consumer, policy);
+    }
+
+    private static void verifyCloseActionsCalled(KafkaConsumer<Integer, String> consumer, KafkaReadPolicy<Integer, String> policy) {
+        verify(consumer, times(1)).commitSync();
+        verify(policy, times(1)).stopEvents(any());
+        verify(consumer).close();
+    }
+
+    @Test
+    public void givenConsumerThatFailsOnCommit_whenClosingSource_thenExpectedCloseActionsCalledOnConsumer() {
+        // Given
+        KafkaConsumer<Integer, String> consumer = mock(KafkaConsumer.class);
+        doThrow(new RuntimeException()).when(consumer).commitSync();
+        KafkaReadPolicy<Integer, String> policy = mock(KafkaReadPolicy.class);
+        MockitoKafkaEventSource.setMockConsumer(consumer);
+        EventSource<Integer, String> source =
+                new MockitoKafkaEventSource<>("localhost:9092", Set.of(KafkaTestCluster.DEFAULT_TOPIC), "test",
+                                              IntegerDeserializer.class.getCanonicalName(),
+                                              StringDeserializer.class.getCanonicalName(), 100,
+                                              policy, true);
+
+        // When
+        source.close();
+
+        // Then
+        verifyCloseActionsCalled(consumer, policy);
+    }
+
+    @Test
+    public void givenReadPolicyThatFailsOnStopEvents_whenClosingSource_thenExpectedCloseActionsCalledOnConsumer() {
+        // Given
+        KafkaConsumer<Integer, String> consumer = mock(KafkaConsumer.class);
+        KafkaReadPolicy<Integer, String> policy = mock(KafkaReadPolicy.class);
+        doThrow(new RuntimeException()).when(policy).stopEvents(any());
+        MockitoKafkaEventSource.setMockConsumer(consumer);
+        EventSource<Integer, String> source =
+                new MockitoKafkaEventSource<>("localhost:9092", Set.of(KafkaTestCluster.DEFAULT_TOPIC), "test",
+                                              IntegerDeserializer.class.getCanonicalName(),
+                                              StringDeserializer.class.getCanonicalName(), 100,
+                                              policy, true);
+
+        // When
+        source.close();
+
+        // Then
+        verifyCloseActionsCalled(consumer, policy);
+    }
+
+    @Test
+    public void givenAdminClientThatFailsOnClosure_whenClosingSource_thenExpectedCloseActionsCalledOnConsumer() {
+        // Given
+        KafkaConsumer<Integer, String> consumer = mock(KafkaConsumer.class);
+        KafkaReadPolicy<Integer, String> policy = mock(KafkaReadPolicy.class);
+        AdminClient adminClient = mock(AdminClient.class);
+        doThrow(new RuntimeException()).when(adminClient).close();
+        MockitoKafkaEventSource.setMockConsumer(consumer);
+        MockitoKafkaEventSource.setMockAdminClient(adminClient);
+        EventSource<Integer, String> source =
+                new MockitoKafkaEventSource<>("localhost:9092", Set.of(KafkaTestCluster.DEFAULT_TOPIC), "test",
+                                              IntegerDeserializer.class.getCanonicalName(),
+                                              StringDeserializer.class.getCanonicalName(), 100,
+                                              policy, true);
+
+        // When
+        source.close();
+
+        // Then
+        verifyCloseActionsCalled(consumer, policy);
+    }
+}

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/policies/AbstractReadPolicyTests.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/policies/AbstractReadPolicyTests.java
@@ -15,11 +15,9 @@
  */
 package io.telicent.smart.cache.sources.kafka.policies;
 
+import io.telicent.smart.cache.sources.kafka.AbstractConsumerMocks;
 import io.telicent.smart.cache.sources.kafka.TestKafkaEventSource;
-import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.Node;
-import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.mockito.exceptions.base.MockitoAssertionError;
 import org.mockito.internal.invocation.InvocationMarker;
@@ -34,7 +32,7 @@ import java.util.*;
 import static org.mockito.Mockito.*;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
-public abstract class AbstractReadPolicyTests<TKey, TValue> {
+public abstract class AbstractReadPolicyTests<TKey, TValue> extends AbstractConsumerMocks {
 
     public static final String OTHER_TOPIC = "other";
 
@@ -114,41 +112,6 @@ public abstract class AbstractReadPolicyTests<TKey, TValue> {
         } else {
             verify(consumer, atLeastOnce()).assign(Collections.emptyList());
         }
-    }
-
-    private void mockSubscribeUnsubscribe(KafkaConsumer consumer) {
-        Set<String> topics = new LinkedHashSet<>();
-        doAnswer(invocation -> {
-            topics.clear();
-            topics.addAll(invocation.getArgument(0, Collection.class));
-            return null;
-        }).when(consumer).subscribe(any(Collection.class), any());
-        doAnswer(invocation -> {
-            topics.clear();
-            return null;
-        }).when(consumer).unsubscribe();
-        when(consumer.subscription()).thenReturn(topics);
-    }
-
-    private void mockAssignment(KafkaConsumer consumer) {
-        Set<TopicPartition> partitions = new LinkedHashSet<>();
-        doAnswer(invocation -> {
-            partitions.addAll(invocation.getArgument(0, Collection.class));
-            return null;
-        }).when(consumer).assign(any());
-        when(consumer.assignment()).thenReturn(partitions);
-    }
-
-    private TopicPartition mockPartition(KafkaConsumer consumer, String topic) {
-        TopicPartition partition = new TopicPartition(topic, 0);
-        when(consumer.partitionsFor(topic)).thenReturn(asPartitionInfo(partition));
-        return partition;
-    }
-
-    private void mockConsumerGroup(KafkaConsumer consumer) {
-        ConsumerGroupMetadata group = mock(ConsumerGroupMetadata.class);
-        when(group.groupId()).thenReturn(TestKafkaEventSource.TEST_GROUP);
-        when(consumer.groupMetadata()).thenReturn(group);
     }
 
     @Test
@@ -257,12 +220,6 @@ public abstract class AbstractReadPolicyTests<TKey, TValue> {
                 throw new MockitoAssertionError(String.format("Wanted %d or %d invocations but got %d", x, y, actual));
             }
         };
-    }
-
-    private List<PartitionInfo> asPartitionInfo(TopicPartition partition) {
-        Node n = mock(Node.class);
-        Node[] ns = new Node[] { n };
-        return Collections.singletonList(new PartitionInfo(partition.topic(), partition.partition(), n, ns, ns));
     }
 
     protected abstract boolean seeksOnAssignment();

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/policies/AbstractReadPolicyTests.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/policies/AbstractReadPolicyTests.java
@@ -33,6 +33,7 @@ import java.util.*;
 
 import static org.mockito.Mockito.*;
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class AbstractReadPolicyTests<TKey, TValue> {
 
     public static final String OTHER_TOPIC = "other";
@@ -270,6 +271,7 @@ public abstract class AbstractReadPolicyTests<TKey, TValue> {
     public void read_policy_rebalance_listener_01() {
         KafkaReadPolicy<TKey, TValue> policy = createPolicy();
         KafkaConsumer consumer = mock(KafkaConsumer.class);
+        mockConsumerGroup(consumer);
         policy.setConsumer(consumer);
 
         policy.onPartitionsAssigned(Collections.singletonList(new TopicPartition(TestKafkaEventSource.TEST_TOPIC, 0)));
@@ -285,6 +287,7 @@ public abstract class AbstractReadPolicyTests<TKey, TValue> {
     public void read_policy_rebalance_listener_02() {
         KafkaReadPolicy<TKey, TValue> policy = createPolicy();
         KafkaConsumer consumer = mock(KafkaConsumer.class);
+        mockConsumerGroup(consumer);
         policy.setConsumer(consumer);
 
         policy.onPartitionsRevoked(Collections.singletonList(new TopicPartition(TestKafkaEventSource.TEST_TOPIC, 0)));
@@ -294,6 +297,7 @@ public abstract class AbstractReadPolicyTests<TKey, TValue> {
     public void read_policy_rebalance_listener_03() {
         KafkaReadPolicy<TKey, TValue> policy = createPolicy();
         KafkaConsumer consumer = mock(KafkaConsumer.class);
+        mockConsumerGroup(consumer);
         policy.setConsumer(consumer);
 
         policy.onPartitionsLost(Collections.singletonList(new TopicPartition(TestKafkaEventSource.TEST_TOPIC, 0)));
@@ -303,6 +307,7 @@ public abstract class AbstractReadPolicyTests<TKey, TValue> {
     public void read_policy_rebalance_listener_04() {
         KafkaReadPolicy<TKey, TValue> policy = createPolicy();
         KafkaConsumer consumer = mock(KafkaConsumer.class);
+        mockConsumerGroup(consumer);
         policy.setConsumer(consumer);
 
         List<TopicPartition> partitions =

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/policies/TestAutoFromExternalOffsets.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/policies/TestAutoFromExternalOffsets.java
@@ -15,15 +15,15 @@
  */
 package io.telicent.smart.cache.sources.kafka.policies;
 
-import io.telicent.smart.cache.sources.kafka.policies.automatic.AutoFromOffset;
+import io.telicent.smart.cache.sources.kafka.policies.automatic.AutoFromExternalOffsetsStore;
+import io.telicent.smart.cache.sources.offsets.MemoryOffsetStore;
+import io.telicent.smart.cache.sources.offsets.OffsetStore;
 import org.testng.annotations.Test;
 
-import java.util.Collections;
-
-public class TestAutoFromOffset extends AbstractReadPolicyTests<String, String> {
+public class TestAutoFromExternalOffsets extends AbstractReadPolicyTests<String, String>{
     @Override
     protected KafkaReadPolicy<String, String> createPolicy() {
-        return new AutoFromOffset<>();
+        return new AutoFromExternalOffsetsStore<>(new MemoryOffsetStore(), 0L);
     }
 
     @Override
@@ -36,8 +36,19 @@ public class TestAutoFromOffset extends AbstractReadPolicyTests<String, String> 
         return true;
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void givenNullOffsetsStore_whenConstructingAutoFromExternalOffsets_thenNPE() {
+        // Given, When and Then
+        new AutoFromExternalOffsetsStore<>(null, 0L);
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*>= 0")
-    public void givenNegativeOffset_whenConstructingAutoFromOffset_thenIllegalArgument() {
-        new AutoFromOffset<>(Collections.emptyMap(), -1);
+    public void givenNegativeDefaultOffset_whenConstructingAutoFromExternalOffsets_thenIllegalArgument() {
+        // GIven
+        OffsetStore store = new MemoryOffsetStore();
+        long defaultOffset = -1L;
+
+        // When and Then
+        new AutoFromExternalOffsetsStore<>(store, defaultOffset);
     }
 }

--- a/event-sources/event-source-kafka/src/test/resources/logback-test.xml
+++ b/event-sources/event-source-kafka/src/test/resources/logback-test.xml
@@ -17,7 +17,7 @@
 -->
 <configuration>
     <!-- Disables logging of Logback initialisation - remove if facing issue with logging config -->
-    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+    <!--<statusListener class="ch.qos.logback.core.status.NopStatusListener" />-->
     <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->

--- a/event-sources/event-sources-core/pom.xml
+++ b/event-sources/event-sources-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Event Sources - Core API</name>

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/payloads/RdfPayload.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/payloads/RdfPayload.java
@@ -45,8 +45,7 @@ import java.util.Objects;
 public class RdfPayload {
 
     private static final CharSequence[] RDF_PATCH_CONTENT_TYPES = {
-            WebContent.contentTypePatch,
-            WebContent.contentTypePatchThrift
+            WebContent.contentTypePatch, WebContent.contentTypePatchThrift
     };
 
     /**
@@ -81,6 +80,7 @@ public class RdfPayload {
     }
 
     private byte[] rawData;
+    private final long sizeInBytes;
     private final String contentType;
 
     private final WriteOnceReference<DatasetGraph> dsg = new WriteOnceReference<>();
@@ -95,6 +95,7 @@ public class RdfPayload {
     private RdfPayload(String contentType, byte[] rawData) {
         this.contentType = contentType;
         this.rawData = Objects.requireNonNull(rawData, "Raw RDF Payload Data cannot be null");
+        this.sizeInBytes = this.rawData.length;
     }
 
     /**
@@ -105,6 +106,7 @@ public class RdfPayload {
     private RdfPayload(DatasetGraph dsg) {
         this.dsg.set(Objects.requireNonNull(dsg, "Dataset cannot be null"));
         this.contentType = null;
+        this.sizeInBytes = 0;
     }
 
     /**
@@ -115,6 +117,7 @@ public class RdfPayload {
     private RdfPayload(RDFPatch patch) {
         this.patch.set(Objects.requireNonNull(patch, "Patch cannot be null"));
         this.contentType = null;
+        this.sizeInBytes = 0;
     }
 
     /**
@@ -122,7 +125,7 @@ public class RdfPayload {
      * deserialised into an actual data structure.
      * <p>
      * Note that if {@link #getDataset()} or {@link #getPatch()} has already been called and the payload was
-     * successfully deserialised then the raw data would have been cleared as a result as it is no longer needed.  Thus
+     * successfully deserialised then the raw data would have been cleared as a result as it is no longer needed.  Thus,
      * this will only be {@code true} if deserialisation was never attempted, or was attempted but failed due to
      * malformed data.
      * </p>
@@ -131,6 +134,22 @@ public class RdfPayload {
      */
     public boolean hasRawData() {
         return rawData != null;
+    }
+
+    /**
+     * Gets the size in bytes of the original payloads raw data, maybe {@code 0} if not created from a byte sequence by
+     * the {@link RdfPayload#of(String, byte[])} method
+     * <p>
+     * If this payload was created from a byte sequence then this method returns the size of that byte sequence.  This
+     * value will be set even if the payload has been processed such that the actual raw byte sequence is no longer
+     * available, as per notes on {@link #hasRawData()} once we've successfully deserialised the byte sequence we don't
+     * hold it in memory, preferring to hold just the deserialised data structure instead.
+     * </p>
+     *
+     * @return Size in bytes, or {@code 0} if not known
+     */
+    public long sizeInBytes() {
+        return this.sizeInBytes;
     }
 
     /**

--- a/event-sources/pom.xml
+++ b/event-sources/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-sources</artifactId>

--- a/jaxrs-base-server/pom.xml
+++ b/jaxrs-base-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jaxrs-base-server</artifactId>

--- a/jwt-auth-common/pom.xml
+++ b/jwt-auth-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <artifactId>jwt-auth-common</artifactId>
     <name>Telicent Smart Caches - JWT Authentication</name>

--- a/live-reporter/pom.xml
+++ b/live-reporter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <artifactId>live-reporter</artifactId>
     <name>Telicent Smart Caches - Live Reporter</name>

--- a/observability-core/pom.xml
+++ b/observability-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>observability-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.telicent.smart-caches</groupId>
     <artifactId>parent</artifactId>
-    <version>0.26.3-SNAPSHOT</version>
+    <version>0.27.0-SNAPSHOT</version>
     <modules>
         <module>projectors-core</module>
         <module>projector-driver</module>
@@ -19,7 +20,8 @@
     </modules>
     <packaging>pom</packaging>
     <name>Telicent Smart Caches - Parent</name>
-    <description>Provides common libraries for building Java based Smart Caches for the Telicent Core platform</description>
+    <description>Provides common libraries for building Java based Smart Caches for the Telicent Core platform
+    </description>
     <url>https://github.com/telicent-oss/smart-caches-core</url>
 
     <developers>
@@ -44,8 +46,8 @@
         <connection>scm:git:https://github.com/telicent-oss/smart-caches-core</connection>
         <developerConnection>scm:git:ssh://git@github.com/telicent-oss/smart-caches-core</developerConnection>
         <url>https://github.com/telicent-oss/smart-caches-core</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <distributionManagement>
         <snapshotRepository>
@@ -528,8 +530,8 @@
                                 <exclude>**/*.jpeg</exclude>
                                 <exclude>**/template</exclude>
                                 <!-- Trivy Cache -->
-				<exclude>.trivy/**</exclude>
-				<exclude>trivy/**</exclude>
+                                <exclude>.trivy/**</exclude>
+                                <exclude>trivy/**</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>
@@ -584,13 +586,13 @@
                     <source>${jdk.version}</source>
                     <target>${jdk.version}</target>
                     <release>${jdk.version}</release>
-                        <annotationProcessorPaths>
-                            <path>
-                                <groupId>org.projectlombok</groupId>
-                                <artifactId>lombok</artifactId>
-                                <version>${dependency.lombok}</version>
-                            </path>
-                        </annotationProcessorPaths>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${dependency.lombok}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
 
@@ -713,17 +715,28 @@
                             <configuration>
                                 <failOnWarning>${analyze.failOnWarnings}</failOnWarning>
                                 <ignoredNonTestScopedDependencies>
-                                    <ignoredNonTestScopedDependency>org.glassfish.grizzly:grizzly-http</ignoredNonTestScopedDependency>
-                                    <ignoredNonTestScopedDependency>jakarta.ws.rs:jakarta.ws.rs-api</ignoredNonTestScopedDependency>
+                                    <ignoredNonTestScopedDependency>org.glassfish.grizzly:grizzly-http
+                                    </ignoredNonTestScopedDependency>
+                                    <ignoredNonTestScopedDependency>jakarta.ws.rs:jakarta.ws.rs-api
+                                    </ignoredNonTestScopedDependency>
                                 </ignoredNonTestScopedDependencies>
                                 <ignoredUnusedDeclaredDependencies>
-                                    <ignoredUnusedDeclaredDependency>org.glassfish.jersey.inject:jersey-hk2</ignoredUnusedDeclaredDependency>
-                                    <ignoredUnusedDeclaredDependency>org.glassfish.jersey.media:jersey-media-json-jackson</ignoredUnusedDeclaredDependency>
-                                    <ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-sdk</ignoredUnusedDeclaredDependency>
-                                    <ignoredUnusedDeclaredDependency>org.testcontainers:kafka</ignoredUnusedDeclaredDependency>
-                                    <ignoredUnusedDeclaredDependency>org.slf4j:jul-to-slf4j</ignoredUnusedDeclaredDependency>
-                                    <ignoredUnusedDeclaredDependency>io.telicent.smart-caches:event-source-kafka</ignoredUnusedDeclaredDependency>
-                                    <ignoredUnusedDeclaredDependency>io.opentelemetry.javaagent:opentelemetry-javaagent</ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>org.glassfish.jersey.inject:jersey-hk2
+                                    </ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>
+                                        org.glassfish.jersey.media:jersey-media-json-jackson
+                                    </ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>io.opentelemetry:opentelemetry-sdk
+                                    </ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>org.testcontainers:kafka
+                                    </ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>org.slf4j:jul-to-slf4j
+                                    </ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>io.telicent.smart-caches:event-source-kafka
+                                    </ignoredUnusedDeclaredDependency>
+                                    <ignoredUnusedDeclaredDependency>
+                                        io.opentelemetry.javaagent:opentelemetry-javaagent
+                                    </ignoredUnusedDeclaredDependency>
                                 </ignoredUnusedDeclaredDependencies>
                             </configuration>
                         </execution>

--- a/projector-driver/pom.xml
+++ b/projector-driver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Projectors - Driver</name>
@@ -45,6 +45,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${dependency.lombok}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/projectors-core/pom.xml
+++ b/projectors-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.26.3-SNAPSHOT</version>
+        <version>0.27.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Projectors - Core API</name>


### PR DESCRIPTION
In working on CORE-684, which aims to upgrade the Fuseki Kafka codebase to use our Core Libraries for consistency, a couple of deficiencies were identified in features provided by `KafkaEventSource` versus what Fuseki Kafka needed.

- Most notably this adds a new `resetOffsets()` method to `KafkaEventSource` and corresponding `KafkaReadPolicy` implementations
- Added a new `AutoFromExternalOffsetsStore` read policy to support use cases like Fuseki Kafka where the application wants to manage the offsets externally to Kafka

There's various test improvements around this, and other areas of `KafkaEventSource` functionality that code coverage showed could be better.  Plus some minor tweaks to `ProjectorDriver` to aid debugging, and make it easier to inspect a previously constructed driver.