### PR TITLE
Adds additional integration testing helpers for CLI Commands (CORE-705)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -46,6 +46,9 @@ jobs:
       USES_MAVEN: true
       # Container image is built for Java 21 to be as up to date as possible
       JAVA_VERSION: 21
+      # As this is a development only image don't care if there's unfixed high criticality vulnerabilities as noone will
+      # be deploying this image in a real deployment
+      GRYPE_SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE: true
     secrets: inherit
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+# 0.28.0
+
+- Build and Test Improvements:
+    - `SmartCacheCommandTester` adds support for easily running commands as external programs to allow writing
+      integration tests that more directly represent how commands are run in deployments
+    - Added version property for Maven Failsafe Plugin
+    - Moved Code Coverage reporting and enforcement to `verify` phase in case any integration tests record additional
+      test coverage
+
 # 0.27.1
 
 - Build and Test Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 - Build and Test Improvements:
     - `SmartCacheCommandTester` adds support for easily running commands as external programs to allow writing
       integration tests that more directly represent how commands are run in deployments
-    - Added version property for Maven Failsafe Plugin
+    - Added default Maven Failsafe Plugin configuration and version control
     - Moved Code Coverage reporting and enforcement to `verify` phase in case any integration tests record additional
-      test coverage
+      test coverage data
 
 # 0.27.1
 

--- a/cli/cli-core/pom.xml
+++ b/cli/cli-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli-core</artifactId>

--- a/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/SmartCacheCommandTester.java
+++ b/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/SmartCacheCommandTester.java
@@ -1,14 +1,17 @@
 /**
  * Copyright (C) Telicent Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.telicent.smart.cache.cli.commands;
 
@@ -22,6 +25,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
@@ -239,7 +243,9 @@ public class SmartCacheCommandTester {
         builder.environment().putAll(envVars);
 
         printToOriginalStdOut(
-                "Starting external command " + program + " with arguments: " + StringUtils.join(args, "\n  "));
+                "[" + Instant.now()
+                             .toString() + "] Starting external command " + program + " with arguments: " + StringUtils.join(
+                        args, "\n  "));
         return builder.start();
     }
 
@@ -256,16 +262,18 @@ public class SmartCacheCommandTester {
         Objects.requireNonNull(process);
         // Wait for completion
         try {
-            printToOriginalStdOut("Waiting for external command to complete...");
+            printToOriginalStdOut("[" + Instant.now().toString() + "] Waiting for external command to complete...");
             process.waitFor(timeout, unit);
             if (process.isAlive()) {
                 SmartCacheCommand.LAST_EXIT_STATUS = Integer.MAX_VALUE;
                 printToOriginalStdOut(
-                        "External command failed to finish within timeout (" + timeout + " " + unit.name() + ")");
+                        "[" + Instant.now()
+                                     .toString() + "] External command failed to finish within timeout (" + timeout + " " + unit.name() + ")");
             } else {
                 SmartCacheCommand.LAST_EXIT_STATUS = process.exitValue();
                 printToOriginalStdOut(
-                        "External command completed with status " + SmartCacheCommand.LAST_EXIT_STATUS);
+                        "[" + Instant.now()
+                                     .toString() + "] External command completed with status " + SmartCacheCommand.LAST_EXIT_STATUS);
             }
         } catch (InterruptedException e) {
             SmartCacheCommand.LAST_EXIT_STATUS = Integer.MAX_VALUE;

--- a/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/SmartCacheCommandTester.java
+++ b/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/SmartCacheCommandTester.java
@@ -1,28 +1,29 @@
 /**
  * Copyright (C) Telicent Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package io.telicent.smart.cache.cli.commands;
 
 import com.github.rvesse.airline.parser.ParseResult;
+import io.telicent.smart.cache.projectors.utils.WriteOnceReference;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.io.output.TeeOutputStream;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Provides the ability to put {@link SmartCacheCommand} derived command classes into a test mode in order to allow
@@ -34,13 +35,16 @@ public class SmartCacheCommandTester {
     private static final ByteArrayOutputStream LAST_OUTPUT = new ByteArrayOutputStream(), LAST_ERROR =
             new ByteArrayOutputStream();
 
-    private static File LAST_OUTPUT_FILE = null, LAST_ERROR_FILE = null;
+    private static File LAST_OUTPUT_FILE = null, LAST_ERROR_FILE = null, EXTERNAL_OUTPUT_FILE = null,
+            EXTERNAL_ERROR_FILE = null;
 
     /**
      * When set to true the captured output and error from each test is also tee'd to the original standard output and
      * error, when set to false it is also captured to files for later review
      */
     public static boolean TEE_TO_ORIGINAL_STREAMS = false;
+
+    private static final WriteOnceReference<String> PROJECT_VERSION = new WriteOnceReference<>();
 
     private SmartCacheCommandTester() {
 
@@ -99,6 +103,8 @@ public class SmartCacheCommandTester {
         SmartCacheCommand.LAST_EXIT_STATUS = Integer.MIN_VALUE;
         LAST_OUTPUT.reset();
         LAST_ERROR.reset();
+        EXTERNAL_OUTPUT_FILE = null;
+        EXTERNAL_ERROR_FILE = null;
 
         if (!TEE_TO_ORIGINAL_STREAMS) {
             Path target = Path.of("target");
@@ -167,7 +173,16 @@ public class SmartCacheCommandTester {
      * @return Standard output
      */
     public static String getLastStdOut() {
-        return LAST_OUTPUT.toString(StandardCharsets.UTF_8);
+        if (EXTERNAL_OUTPUT_FILE != null) {
+            try {
+                return Files.readString(EXTERNAL_OUTPUT_FILE.toPath());
+            } catch (IOException e) {
+                throw new IllegalStateException(
+                        "Failed to read external command output file " + EXTERNAL_OUTPUT_FILE.getAbsolutePath(), e);
+            }
+        } else {
+            return LAST_OUTPUT.toString(StandardCharsets.UTF_8);
+        }
     }
 
     /**
@@ -176,6 +191,125 @@ public class SmartCacheCommandTester {
      * @return Standard error
      */
     public static String getLastStdErr() {
-        return LAST_ERROR.toString(StandardCharsets.UTF_8);
+        if (EXTERNAL_ERROR_FILE != null) {
+            try {
+                return Files.readString(EXTERNAL_ERROR_FILE.toPath());
+            } catch (IOException e) {
+                throw new IllegalStateException(
+                        "Failed to read external command output file " + EXTERNAL_ERROR_FILE.getAbsolutePath(), e);
+            }
+        } else {
+            return LAST_ERROR.toString(StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Runs a command to test as an external standalone process, this is useful for writing integration tests that
+     * verify that the script entrypoint used for real deployments is functioning as intended and any necessary
+     * dependencies are appropriately provided.
+     * <p>
+     * This returns the actual process, depending on the command being tested you may then want to pass this into
+     * {@link #waitForExternalCommand(Process, long, TimeUnit)} to wait for it to complete, or to run tests against the
+     * running application before terminating it yourself.
+     * </p>
+     *
+     * @param program Program that should be invoked, typically a script file that is the entrypoint for the deployed
+     *                application
+     * @param envVars Any environment variables that need to be set for the program being tested to function correctly
+     * @param args    Any arguments to supply to the program
+     * @return The external command process
+     * @throws IOException Thrown if the external command process cannot be started e.g. bad program path
+     */
+    public static Process runAsExternalCommand(String program, Map<String, String> envVars, String[] args) throws
+            IOException {
+        // Prepare the process command
+        ProcessBuilder builder = new ProcessBuilder();
+        List<String> command = new ArrayList<>();
+        command.add(program);
+        command.addAll(Arrays.asList(args));
+        builder.command(command);
+
+        // Since we've already redirected stdout and stderr can just inherit IO from this process
+        EXTERNAL_OUTPUT_FILE = Files.createTempFile("external-stdout", ".txt").toFile();
+        EXTERNAL_ERROR_FILE = Files.createTempFile("external-stderr", ".txt").toFile();
+        builder.redirectOutput(EXTERNAL_OUTPUT_FILE);
+        builder.redirectError(EXTERNAL_ERROR_FILE);
+
+        // Customise environment
+        builder.environment().putAll(envVars);
+
+        printToOriginalStdOut(
+                "Starting external command " + program + " with arguments: " + StringUtils.join(args, "\n  "));
+        return builder.start();
+    }
+
+    /**
+     * Waits for the external command to complete, recording its exit status for later retrieval by
+     * {@link #getLastExitStatus()}.  The process is destroyed after it has completed, or if it does not complete within
+     * the given timeout duration.
+     *
+     * @param process Process
+     * @param timeout Timeout duration
+     * @param unit    Timeout time unit
+     */
+    public static void waitForExternalCommand(Process process, long timeout, TimeUnit unit) {
+        Objects.requireNonNull(process);
+        // Wait for completion
+        try {
+            printToOriginalStdOut("Waiting for external command to complete...");
+            process.waitFor(timeout, unit);
+            if (process.isAlive()) {
+                SmartCacheCommand.LAST_EXIT_STATUS = Integer.MAX_VALUE;
+                printToOriginalStdOut(
+                        "External command failed to finish within timeout (" + timeout + " " + unit.name() + ")");
+            } else {
+                SmartCacheCommand.LAST_EXIT_STATUS = process.exitValue();
+                printToOriginalStdOut(
+                        "External command completed with status " + SmartCacheCommand.LAST_EXIT_STATUS);
+            }
+        } catch (InterruptedException e) {
+            SmartCacheCommand.LAST_EXIT_STATUS = Integer.MAX_VALUE;
+        } finally {
+            process.destroy();
+        }
+    }
+
+    /**
+     * Detects the project version, this can be used to inject it into an external command as an environment variable
+     * (e.g. when using {@link #runAsExternalCommand(String, Map, String[])})
+     * <p>
+     * Detection looks for a {@code project.version} System property, following by reading the {@code pom.xml} file to
+     * find the first {@code <version>} element.
+     * </p>
+     * <p>
+     * The detected project version is cached for the lifetime of the JVM.
+     * </p>
+     *
+     * @return Detected project version, or {@code null} if unable to detect
+     */
+    public static String detectProjectVersion() {
+        return PROJECT_VERSION.computeIfAbsent(() -> {
+            // If injected via System Properties just return that
+            if (System.getProperties().contains("project.version")) {
+                return System.getProperties().getProperty("project.version");
+            }
+
+            // Otherwise read the first <version> element in the pom.xml
+            File pom = new File("pom.xml");
+            List<String> lines;
+            try {
+                lines = Files.readAllLines(pom.toPath());
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to read project pom.xml file", e);
+            }
+            for (String line : lines) {
+                if (line.contains("<version>")) {
+                    line = StringUtils.substringAfter(line, "<version>");
+                    line = StringUtils.substringBefore(line, "</version>");
+                    return StringUtils.trim(line);
+                }
+            }
+            throw new IllegalStateException("Failed to detect project version");
+        });
     }
 }

--- a/cli/cli-debug/pom.xml
+++ b/cli/cli-debug/pom.xml
@@ -226,22 +226,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${plugin.failsafe}</version>
-                        <configuration>
-                            <includes>
-                                <include>**/*IT.java</include>
-                            </includes>
-                            <systemPropertyVariables>
-                                <project.version>${project.version}</project.version>
-                            </systemPropertyVariables>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/cli/cli-debug/pom.xml
+++ b/cli/cli-debug/pom.xml
@@ -11,6 +11,7 @@
 
     <properties>
         <license.header.path>${project.parent.parent.basedir}</license.header.path>
+        <analyze.failOnWarnings>false</analyze.failOnWarnings>
     </properties>
 
     <dependencies>
@@ -87,8 +88,19 @@
         </dependency>
 
         <dependency>
+            <groupId>io.telicent.smart-caches</groupId>
+            <artifactId>projector-driver</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
         </dependency>
 
         <!-- Test Dependencies -->
@@ -113,32 +125,6 @@
             <artifactId>jaxrs-base-server</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.ws.rs</groupId>
-            <artifactId>jakarta.ws.rs-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.telicent.smart-caches</groupId>
-            <artifactId>event-source-file</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.telicent.smart-caches</groupId>
-            <artifactId>projector-driver</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -233,6 +219,20 @@
                             </includes>
                             <forkCount>${test.maxForks}</forkCount>
                             <reuseForks>true</reuseForks>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${plugin.failsafe}</version>
+                        <configuration>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                            <systemPropertyVariables>
+                                <project.version>${project.version}</project.version>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/cli/cli-debug/pom.xml
+++ b/cli/cli-debug/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli-debug</artifactId>
@@ -234,6 +234,14 @@
                                 <project.version>${project.version}</project.version>
                             </systemPropertyVariables>
                         </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/cli/cli-debug/src/main/java/io/telicent/smart/cache/cli/commands/projection/debug/RdfDump.java
+++ b/cli/cli-debug/src/main/java/io/telicent/smart/cache/cli/commands/projection/debug/RdfDump.java
@@ -92,7 +92,7 @@ public class RdfDump extends AbstractKafkaRdfProjectionCommand<Event<Bytes, RdfP
 
     @Override
     protected Projector<Event<Bytes, RdfPayload>, Event<Bytes, RdfPayload>> getProjector() {
-        return new NoOpProjector();
+        return new NoOpProjector<>();
     }
 
     @Override

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractCliKafkaIT.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractCliKafkaIT.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.cli.commands.debug;
+
+import io.telicent.smart.cache.cli.commands.AbstractCommandTests;
+import io.telicent.smart.cache.cli.commands.SmartCacheCommandTester;
+import io.telicent.smart.cache.sources.Header;
+import io.telicent.smart.cache.sources.kafka.BasicKafkaTestCluster;
+import io.telicent.smart.cache.sources.kafka.KafkaTestCluster;
+import io.telicent.smart.cache.sources.kafka.sinks.KafkaSink;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collection;
+
+public class AbstractCliKafkaIT extends AbstractCommandTests {
+    protected KafkaTestCluster kafka = new BasicKafkaTestCluster();
+
+    protected File propertiesFile;
+
+    @BeforeClass
+    @Override
+    public void setup() {
+        this.kafka.setup();
+        try {
+            this.propertiesFile = Files.createTempFile("kafka",".properties").toFile();
+            try (FileOutputStream fos = new FileOutputStream(propertiesFile)) {
+                this.kafka.getClientProperties().store(fos, null);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        super.setup();
+    }
+
+    @AfterMethod
+    @Override
+    public void testCleanup() throws InterruptedException {
+        super.testCleanup();
+
+        // Reset topic and wait briefly for Kafka to clean up
+        this.kafka.resetTestTopic();
+        Thread.sleep(1000);
+    }
+
+    @AfterClass
+    @Override
+    public void teardown() {
+        super.teardown();
+        this.kafka.teardown();
+    }
+
+    protected void generateKafkaEvents(Collection<Header> headers, String format) {
+        try (KafkaSink<String, String> sink = KafkaSink.<String, String>create()
+                                                       .keySerializer(StringSerializer.class)
+                                                       .valueSerializer(StringSerializer.class)
+                                                       .bootstrapServers(this.kafka.getBootstrapServers())
+                                                       .topic(KafkaTestCluster.DEFAULT_TOPIC)
+                                                       .producerConfig(this.kafka.getClientProperties())
+                                                       .lingerMs(5)
+                                                       .build()) {
+            for (int i = 1; i <= 1_000; i++) {
+                sink.send(new SimpleEvent<>(headers, Integer.toString(i), String.format(format, i)));
+            }
+        }
+    }
+
+    protected void dumpStdErrIfFailed() {
+        if (SmartCacheCommandTester.getLastExitStatus() != 0) {
+            String stdErr = SmartCacheCommandTester.getLastStdErr();
+            SmartCacheCommandTester.printToOriginalStdOut("Command Failed, error output below:");
+            SmartCacheCommandTester.printToOriginalStdOut(stdErr);
+        }
+    }
+}

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DebugCliIT.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DebugCliIT.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 public class DebugCliIT extends AbstractCommandTests {
 
-    private static final int DEFAULT_TIMEOUT = 30;
+    public static final int DEFAULT_TIMEOUT = 30;
 
     @Test
     public void givenValidEventsDirectory_whenDumpingAndCapturingRdfAsExternalCommand_thenRdfIsDumped_andCaptureCanBeDumped() throws

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DebugCliIT.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DebugCliIT.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.cli.commands.debug;
+
+import io.telicent.smart.cache.cli.commands.AbstractCommandTests;
+import io.telicent.smart.cache.cli.commands.SmartCacheCommandTester;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class DebugCliIT extends AbstractCommandTests {
+
+    private static final int DEFAULT_TIMEOUT = 30;
+
+    @Test
+    public void givenValidEventsDirectory_whenDumpingAndCapturingRdfAsExternalCommand_thenRdfIsDumped_andCaptureCanBeDumped() throws
+            IOException {
+        // Given
+        File sourceDir = Files.createTempDirectory("dump-events-input").toFile();
+        TestDebugCli.generateSampleEvents(sourceDir, "<https://subject> <https://predicate> \"%d\" .");
+        File captureDir = Files.createTempDirectory("capture-target").toFile();
+        File debugScript = new File("debug.sh");
+        Map<String, String> env = new HashMap<>();
+        env.put("PROJECT_VERSION", SmartCacheCommandTester.detectProjectVersion());
+
+        // When
+        Process process =
+                SmartCacheCommandTester.runAsExternalCommand(debugScript.getAbsolutePath(), env, new String[] {
+                        "rdf-dump",
+                        "--source-dir",
+                        sourceDir.getAbsolutePath(),
+                        "--max-stalls",
+                        "1",
+                        "--poll-timeout",
+                        "3",
+                        "--read-policy",
+                        "BEGINNING",
+                        "--capture-dir",
+                        captureDir.getAbsolutePath()
+                });
+        SmartCacheCommandTester.waitForExternalCommand(process, DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+
+        // Then
+        Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 0);
+        TestDebugCli.verifyEventsDumped("\"%d\"");
+
+        // And
+        SmartCacheCommandTester.resetTestState();
+        process = SmartCacheCommandTester.runAsExternalCommand(debugScript.getAbsolutePath(), env, new String[] {
+                "dump",
+                "--source-dir",
+                captureDir.getAbsolutePath(),
+                "--max-stalls",
+                "1",
+                "--poll-timeout",
+                "3",
+                "--read-policy",
+                "BEGINNING"
+        });
+        SmartCacheCommandTester.waitForExternalCommand(process, DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+        TestDebugCli.verifyEventsDumped("\"%d\"");
+    }
+}

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DebugCliKafkaIT.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DebugCliKafkaIT.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.cli.commands.debug;
+
+import io.telicent.smart.cache.cli.commands.SmartCacheCommandTester;
+import io.telicent.smart.cache.sources.kafka.KafkaTestCluster;
+import org.apache.jena.vocabulary.XSD;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static io.telicent.smart.cache.cli.commands.debug.DebugCliIT.DEFAULT_TIMEOUT;
+
+public class DebugCliKafkaIT extends AbstractCliKafkaIT {
+
+    @Test
+    public void givenKafkaEvents_whenDumpingAndCapturingRdfAsExternalCommand_thenRdfIsDumped_andCaptureCanBeDumped() throws
+            IOException {
+        // Given
+        generateKafkaEvents(Collections.emptyList(), "<https://subject> <https://predicate> \"%d\" .");
+        File captureDir = Files.createTempDirectory("capture-target").toFile();
+        File debugScript = new File("debug.sh");
+        Map<String, String> env = new HashMap<>();
+        env.put("PROJECT_VERSION", SmartCacheCommandTester.detectProjectVersion());
+
+        // When
+        Process process =
+                SmartCacheCommandTester.runAsExternalCommand(debugScript.getAbsolutePath(), env, new String[] {
+                        "rdf-dump",
+                        "--bootstrap-servers", this.kafka.getBootstrapServers(),
+                        "--topic",
+                        KafkaTestCluster.DEFAULT_TOPIC,
+                        "--kafka-properties",
+                        this.propertiesFile.getAbsolutePath(),
+                        "--max-stalls",
+                        "1",
+                        "--poll-timeout",
+                        "5",
+                        "--read-policy",
+                        "BEGINNING",
+                        "--capture-dir",
+                        captureDir.getAbsolutePath()
+                });
+        SmartCacheCommandTester.waitForExternalCommand(process, DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+
+        // Then
+        verifySuccessfulCommandCompletion();
+        TestDebugCli.verifyEventsDumped("\"%d\"");
+
+        // And
+        SmartCacheCommandTester.resetTestState();
+        process = SmartCacheCommandTester.runAsExternalCommand(debugScript.getAbsolutePath(), env, new String[] {
+                "dump",
+                "--source-dir",
+                captureDir.getAbsolutePath(),
+                "--max-stalls",
+                "1",
+                "--poll-timeout",
+                "3",
+                "--read-policy",
+                "BEGINNING"
+        });
+        SmartCacheCommandTester.waitForExternalCommand(process, DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+        verifySuccessfulCommandCompletion();
+        TestDebugCli.verifyEventsDumped("\"%d\"");
+    }
+
+    @Test
+    public void givenCaptureDirectory_whenReplayingToKafkaAsExternalCommand_thenRdfCanBeDumpedFromKafka() throws
+            IOException {
+        // Given
+        File sourceDir = Files.createTempDirectory("dump-events-input").toFile();
+        TestDebugCli.generateSampleEvents(sourceDir, "<https://subject> <https://predicate> \"%d\"^^<" + XSD.integer.getURI() + "> .");
+        File debugScript = new File("debug.sh");
+        Map<String, String> env = new HashMap<>();
+        env.put("PROJECT_VERSION", SmartCacheCommandTester.detectProjectVersion());
+
+        // When
+        Process process =
+                SmartCacheCommandTester.runAsExternalCommand(debugScript.getAbsolutePath(), env, new String[] {
+                        "replay",
+                        "--source-dir",
+                        sourceDir.getAbsolutePath(),
+                        "--max-stalls",
+                        "1",
+                        "--poll-timeout",
+                        "3",
+                        "--bootstrap-servers",
+                        this.kafka.getBootstrapServers(),
+                        "--topic",
+                        KafkaTestCluster.DEFAULT_TOPIC,
+                        "--kafka-properties",
+                        this.propertiesFile.getAbsolutePath(),
+                });
+        SmartCacheCommandTester.waitForExternalCommand(process, DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+        verifySuccessfulCommandCompletion();
+
+        // Then
+        SmartCacheCommandTester.resetTestState();
+        process = SmartCacheCommandTester.runAsExternalCommand(debugScript.getAbsolutePath(), env, new String[] {
+                "rdf-dump",
+                "--bootstrap-server",
+                this.kafka.getBootstrapServers(),
+                "--topic",
+                KafkaTestCluster.DEFAULT_TOPIC,
+                "--kafka-properties",
+                this.propertiesFile.getAbsolutePath(),
+                "--max-stalls",
+                "1",
+                "--poll-timeout",
+                "5",
+                "--read-policy",
+                "BEGINNING"
+        });
+        SmartCacheCommandTester.waitForExternalCommand(process, DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+        verifySuccessfulCommandCompletion();
+        TestDebugCli.verifyEventsDumped("%d");
+    }
+
+    private void verifySuccessfulCommandCompletion() {
+        dumpStdErrIfFailed();
+        Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 0);
+    }
+}

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DebugCliMutualTlsKafkaIT.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DebugCliMutualTlsKafkaIT.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.cli.commands.debug;
+
+import io.telicent.smart.cache.sources.kafka.MutualTlsKafkaTestCluster;
+
+public class DebugCliMutualTlsKafkaIT extends DebugCliKafkaIT {
+
+    public DebugCliMutualTlsKafkaIT() {
+        this.kafka = new MutualTlsKafkaTestCluster();
+    }
+}

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DebugCliSecureKafkaIT.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DebugCliSecureKafkaIT.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.cli.commands.debug;
+
+import io.telicent.smart.cache.sources.kafka.SecureKafkaTestCluster;
+
+public class DebugCliSecureKafkaIT extends DebugCliKafkaIT {
+
+    public DebugCliSecureKafkaIT() {
+        this.kafka = new SecureKafkaTestCluster();
+    }
+}

--- a/cli/cli-probe-server/pom.xml
+++ b/cli/cli-probe-server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>cli</artifactId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>cli-probe-server</artifactId>
     <name>Telicent Smart Caches - CLI - Health Probe Server</name>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli</artifactId>

--- a/configurator/pom.xml
+++ b/configurator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>configurator</artifactId>
     <name>Telicent Smart Caches - Configuration API</name>

--- a/event-sources/event-source-file/pom.xml
+++ b/event-sources/event-source-file/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-source-file</artifactId>

--- a/event-sources/event-source-kafka/pom.xml
+++ b/event-sources/event-source-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-source-kafka</artifactId>

--- a/event-sources/event-sources-core/pom.xml
+++ b/event-sources/event-sources-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Event Sources - Core API</name>

--- a/event-sources/pom.xml
+++ b/event-sources/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-sources</artifactId>

--- a/jaxrs-base-server/pom.xml
+++ b/jaxrs-base-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jaxrs-base-server</artifactId>

--- a/jwt-auth-common/pom.xml
+++ b/jwt-auth-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>jwt-auth-common</artifactId>
     <name>Telicent Smart Caches - JWT Authentication</name>

--- a/live-reporter/pom.xml
+++ b/live-reporter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>live-reporter</artifactId>
     <name>Telicent Smart Caches - Live Reporter</name>

--- a/observability-core/pom.xml
+++ b/observability-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>observability-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -828,6 +828,29 @@
                         <ignoredVersions>.*[-\.]M.*,.*-alpha.*,.*-beta.*,.*-RC.*,.*rc.*</ignoredVersions>
                     </configuration>
                 </plugin>
+
+                <!-- Integration Testing -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${plugin.failsafe}</version>
+                    <configuration>
+                        <includes>
+                            <include>**/*IT.java</include>
+                        </includes>
+                        <systemPropertyVariables>
+                            <project.version>${project.version}</project.version>
+                        </systemPropertyVariables>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.telicent.smart-caches</groupId>
     <artifactId>parent</artifactId>
-    <version>0.27.2-SNAPSHOT</version>
+    <version>0.28.0-SNAPSHOT</version>
     <modules>
         <module>projectors-core</module>
         <module>projector-driver</module>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <plugin.dependency>3.8.1</plugin.dependency>
         <plugin.enforcer>3.5.0</plugin.enforcer>
         <plugin.exec>3.5.0</plugin.exec>
+        <plugin.failsafe>3.5.1</plugin.failsafe>
         <plugin.gpg>3.2.7</plugin.gpg>
         <plugin.jacoco>0.8.12</plugin.jacoco>
         <plugin.jar>3.4.2</plugin.jar>
@@ -764,14 +765,14 @@
                         </execution>
                         <execution>
                             <id>report</id>
-                            <phase>package</phase>
+                            <phase>verify</phase>
                             <goals>
                                 <goal>report</goal>
                             </goals>
                         </execution>
                         <execution>
                             <id>require-test-coverage</id>
-                            <phase>package</phase>
+                            <phase>verify</phase>
                             <goals>
                                 <goal>check</goal>
                             </goals>

--- a/projector-driver/pom.xml
+++ b/projector-driver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Projectors - Driver</name>

--- a/projectors-core/pom.xml
+++ b/projectors-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.27.2-SNAPSHOT</version>
+        <version>0.28.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Projectors - Core API</name>


### PR DESCRIPTION
This PR adds additional integration testing helper methods into `SmartCacheCommandTester` to make it easy to run commands as external processes, i.e. as close to how they would run in a real deployment as possible.  This aims to help developers have tests in place that will reliably fail if dependency scopes are incorrectly changed such that necessary dependencies are not present at runtime, these failures can't easily be detected by existing unit/integration tests because typically the "missing" dependencies are present in `test` scope allowing normal unit/integration tests to pass.  By running the commands as external processes via their normal wrapper scripts used for deployment they will only pick up the dependencies they will have at runtime and thus fail if any dependencies are missing.

A number of example new style integration tests are added into the `cli-debug` module, and some fixes were made to that modules dependencies based on failures seen when developing those tests.

# Related Issues and PRs

- This relates to process changes proposed in response to CORE-705