### PR TITLE
Improved external command logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# 0.28.1
+
+- Build and Test Improvements:
+    - `SmartCacheCommandTester.runAsExternalCommand()` now includes the environment variables being set in the logged
+      output and fixes an indentation error in the logged command arguments
+
 # 0.28.0
 
 - Build and Test Improvements:

--- a/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/SmartCacheCommandTester.java
+++ b/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/SmartCacheCommandTester.java
@@ -17,6 +17,7 @@ package io.telicent.smart.cache.cli.commands;
 
 import com.github.rvesse.airline.parser.ParseResult;
 import io.telicent.smart.cache.projectors.utils.WriteOnceReference;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.apache.commons.lang3.StringUtils;
@@ -75,7 +76,7 @@ public class SmartCacheCommandTester {
         } else {
             try {
                 OutputStream output = new FileOutputStream(LAST_ERROR_FILE);
-                ORIGINAL_ERROR.println(
+                ORIGINAL_OUTPUT.println(
                         "Standard error for the next test will be captured to file " + LAST_ERROR_FILE.getAbsolutePath());
                 return output;
             } catch (FileNotFoundException e) {
@@ -246,8 +247,14 @@ public class SmartCacheCommandTester {
         // Actually launch the command, printing what we're launching
         printToOriginalStdOut(
                 "[" + Instant.now()
-                             .toString() + "] Starting external command " + program + " with arguments:\n" + StringUtils.join(
+                             .toString() + "] Starting external command " + program + " with arguments:\n  " + StringUtils.join(
                         args, "\n  "));
+        if (MapUtils.isNotEmpty(envVars)) {
+            printToOriginalStdOut("with environment variables:");
+            for (Map.Entry<String, String> entry : envVars.entrySet()) {
+                printToOriginalStdOut("  " + entry.getKey() + "=" + entry.getValue());
+            }
+        }
         return builder.start();
     }
 

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractCliKafkaIT.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractCliKafkaIT.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.util.Collection;
 
 public class AbstractCliKafkaIT extends AbstractCommandTests {
+    protected static final File DEBUG_SCRIPT = new File("debug.sh");
     protected KafkaTestCluster kafka = new BasicKafkaTestCluster();
 
     protected File propertiesFile;


### PR DESCRIPTION
After applying the new external command testing framework onto Smart Cache Search noticed a couple of quirks in the logged output that would have made debugging over there easier so applying the fixes for a future release:

- Log custom environment variables being set
- Fix indentation of first argument in logs