### PR TITLE
Adds `toString()` implementations to most `Sink` implementations to improve debugging experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # 0.28.1
 
+- Projector Improvements:
+    - Added `toString()` methods to most `Sink` implementations to improve developer debugging experience
 - Build and Test Improvements:
     - `SmartCacheCommandTester.runAsExternalCommand()` now includes the environment variables being set in the logged
       output and fixes an indentation error in the logged command arguments

--- a/cli/cli-core/pom.xml
+++ b/cli/cli-core/pom.xml
@@ -109,6 +109,12 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/projection/PeriodicDeadLetterSink.java
+++ b/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/projection/PeriodicDeadLetterSink.java
@@ -16,12 +16,15 @@
 package io.telicent.smart.cache.cli.commands.projection;
 
 import io.telicent.smart.cache.projectors.Sink;
+import lombok.ToString;
 
 import java.util.Objects;
 
+@ToString
 public class PeriodicDeadLetterSink<T> implements Sink<T> {
 
     private final Sink<T> destination, deadLetters;
+    @ToString.Exclude
     private long count = 0;
     private final long deadLetterFrequency;
 

--- a/event-sources/event-source-file/pom.xml
+++ b/event-sources/event-source-file/pom.xml
@@ -79,6 +79,12 @@
             <artifactId>jackson-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/projectors/sinks/events/file/EventCapturingSink.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/projectors/sinks/events/file/EventCapturingSink.java
@@ -23,6 +23,7 @@ import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.file.FileEventWriter;
 import io.telicent.smart.cache.sources.file.yaml.YamlEventReaderWriter;
+import lombok.ToString;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -45,15 +46,18 @@ import java.util.function.Function;
  * @param <TKey>   Key type
  * @param <TValue> Value type
  */
+@ToString(callSuper = true)
 public class EventCapturingSink<TKey, TValue>
         extends AbstractTransformingSink<Event<TKey, TValue>, Event<TKey, TValue>> {
 
+    @ToString.Exclude
     private long nextFileNumber = -1;
     private final int padding;
     private final String prefix, extension;
     private final File targetDirectory;
     private final FileEventWriter<TKey, TValue> writer;
     private final List<Header> additionalHeaders;
+    @ToString.Exclude
     private final List<Function<Event<TKey, TValue>, Header>> additionalHeaderGenerators;
 
     /**

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/sinks/KafkaSink.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/sinks/KafkaSink.java
@@ -22,6 +22,7 @@ import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.kafka.KafkaSecurity;
 import lombok.NonNull;
+import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.producer.*;
@@ -41,20 +42,27 @@ import java.util.stream.Stream;
 /**
  * A sink that sends the received events to a Kafka topic
  * <p>
- * This uses a {@link KafkaProducer} internally so all the sent events are sent asynchronously.
+ * This uses a {@link KafkaProducer} internally so all the events are sent asynchronously by default.  Since
+ * {@code 0.24.0} there is the option to configure this to use synchronous sends, but that has performance downsides,
+ * see {@link KafkaSinkBuilder#async()}, {@link KafkaSinkBuilder#async(Callback)} and {@link KafkaSinkBuilder#noAsync()}
+ * for the various sending modes available and discussions of their pros and cons.
  * </p>
  *
  * @param <TKey>   Key type
  * @param <TValue> Value type
  */
+@ToString
 public class KafkaSink<TKey, TValue> implements Sink<Event<TKey, TValue>> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaSink.class);
 
+    @ToString.Exclude
     private final KafkaProducer<TKey, TValue> producer;
     private final String topic;
     private final boolean async;
+    @ToString.Exclude
     private final Callback callback;
+    @ToString.Exclude
     private final List<Exception> producerErrors = new ArrayList<>();
 
     /**

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventHeaderSink.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventHeaderSink.java
@@ -21,6 +21,7 @@ import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBu
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.TelicentHeaders;
+import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
@@ -33,7 +34,9 @@ import java.util.stream.Stream;
  * @param <TKey>   Key type
  * @param <TValue> Value type
  */
+@ToString(callSuper = true)
 public class EventHeaderSink<TKey, TValue> extends AbstractTransformingSink<Event<TKey, TValue>, Event<TKey, TValue>> {
+    @ToString.Exclude
     private final List<Function<Event<TKey, TValue>, Header>> headerGenerators = new ArrayList<>();
 
     /**

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventKeySink.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventKeySink.java
@@ -20,6 +20,7 @@ import io.telicent.smart.cache.projectors.sinks.AbstractTransformingSink;
 import io.telicent.smart.cache.projectors.sinks.NullSink;
 import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBuilder;
 import io.telicent.smart.cache.sources.Event;
+import lombok.ToString;
 
 /**
  * A sink that outputs just the event key
@@ -27,6 +28,7 @@ import io.telicent.smart.cache.sources.Event;
  * @param <TKey>   Event key type
  * @param <TValue> Event value type
  */
+@ToString(callSuper = true)
 public class EventKeySink<TKey, TValue> extends AbstractTransformingSink<Event<TKey, TValue>, TKey> {
     /**
      * Creates a new sink with an optional forwarding destination

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventProcessedSink.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventProcessedSink.java
@@ -19,6 +19,7 @@ import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.sinks.builder.SinkBuilder;
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.EventSource;
+import lombok.ToString;
 
 import java.util.*;
 
@@ -29,13 +30,16 @@ import java.util.*;
  * @param <TKey>   Event Key type
  * @param <TValue> Event Value type
  */
+@ToString
 public class EventProcessedSink<TKey, TValue> implements Sink<Event<TKey, TValue>> {
 
     /**
      * Batch size used to request that no batching be performed
      */
     public static final int NO_BATCHING = 1;
+
     @SuppressWarnings("rawtypes")
+    @ToString.Exclude
     private final Map<EventSource, List<Event<TKey, TValue>>> events = new HashMap<>();
     private final int batchSize;
 

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventValueSink.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventValueSink.java
@@ -20,6 +20,7 @@ import io.telicent.smart.cache.projectors.sinks.AbstractTransformingSink;
 import io.telicent.smart.cache.projectors.sinks.NullSink;
 import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBuilder;
 import io.telicent.smart.cache.sources.Event;
+import lombok.ToString;
 
 /**
  * A sink that outputs just the event value
@@ -27,6 +28,7 @@ import io.telicent.smart.cache.sources.Event;
  * @param <TKey>   Event key type
  * @param <TValue> Event value type
  */
+@ToString(callSuper = true)
 public class EventValueSink<TKey, TValue> extends AbstractTransformingSink<Event<TKey, TValue>, TValue> {
     /**
      * Creates a new sink with an optional forwarding destination

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/TestEventHeaderSink.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/TestEventHeaderSink.java
@@ -60,7 +60,8 @@ public class TestEventHeaderSink extends AbstractEventSinkTests {
     }
 
     @Test(dataProvider = "badHeaderParams", expectedExceptions = IllegalArgumentException.class)
-    public void givenBadHeaderParameters_whenBuildingFixedIfMissingHeader_thenIllegalArgument(String name, String value) {
+    public void givenBadHeaderParameters_whenBuildingFixedIfMissingHeader_thenIllegalArgument(String name,
+                                                                                              String value) {
         // Given, When and Then
         try (EventHeaderSink<String, String> sink = EventHeaderSink.<String, String>create()
                                                                    .fixedHeaderIfMissing(name, value)
@@ -442,6 +443,24 @@ public class TestEventHeaderSink extends AbstractEventSinkTests {
                     }
                 });
             }
+        }
+    }
+
+    @Test
+    public void givenEventHeaderSink_whenToString_thenBasicOutput() {
+        // Given
+        try (EventHeaderSink<Integer, String> sink = EventHeaderSink.<Integer, String>create()
+                                                                    .fixedHeader("foo", "bar")
+                                                                    .build()) {
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertNotNull(output);
+            Assert.assertEquals(output, """
+                    EventHeaderSink(super={
+                      destination=NullSink(counter=0)
+                    })""");
         }
     }
 }

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/TestEventKeySink.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/TestEventKeySink.java
@@ -16,6 +16,7 @@
 package io.telicent.smart.cache.projectors.sinks.events;
 
 import io.telicent.smart.cache.projectors.sinks.CollectorSink;
+import io.telicent.smart.cache.projectors.sinks.NullSink;
 import io.telicent.smart.cache.projectors.sinks.Sinks;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -47,6 +48,22 @@ public class TestEventKeySink extends AbstractEventSinkTests {
             List<String> actual = collector.get();
             Assert.assertEquals(actual.size(), KEYS.size());
             Assert.assertEquals(actual, KEYS);
+        }
+    }
+
+    @Test
+    public void givenSink_whenToString_thenBasicOutput() {
+        // Given
+        try (EventKeySink<String, String> sink = new EventKeySink<>(NullSink.of())) {
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertNotNull(output);
+            Assert.assertEquals(output, """
+                    EventKeySink(super={
+                      destination=NullSink(counter=0)
+                    })""");
         }
     }
 }

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/TestEventProcessedSink.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/TestEventProcessedSink.java
@@ -15,6 +15,7 @@
  */
 package io.telicent.smart.cache.projectors.sinks.events;
 
+import io.telicent.smart.cache.projectors.sinks.NullSink;
 import io.telicent.smart.cache.sources.memory.InMemoryEventSource;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -132,6 +133,19 @@ public class TestEventProcessedSink extends AbstractEventSinkTests {
             // When and Then
             Assert.assertEquals(sink.incompleteBatches(), 0);
             Assert.assertEquals(sink.batchedEvents(), 0);
+        }
+    }
+
+    @Test
+    public void givenSink_whenToString_thenBasicOutput() {
+        // Given
+        try (EventProcessedSink<String, String> sink = new EventProcessedSink<String, String>(17)) {
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertNotNull(output);
+            Assert.assertEquals(output, "EventProcessedSink(batchSize=17)");
         }
     }
 }

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/TestEventValueSink.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/TestEventValueSink.java
@@ -16,6 +16,7 @@
 package io.telicent.smart.cache.projectors.sinks.events;
 
 import io.telicent.smart.cache.projectors.sinks.CollectorSink;
+import io.telicent.smart.cache.projectors.sinks.NullSink;
 import io.telicent.smart.cache.projectors.sinks.Sinks;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -47,6 +48,22 @@ public class TestEventValueSink extends AbstractEventSinkTests {
                                                                  .build()) {
             // Then
             Assert.assertNotNull(sink);
+        }
+    }
+
+    @Test
+    public void givenSink_whenToString_thenBasicOutput() {
+        // Given
+        try (EventValueSink<String, String> sink = new EventValueSink<>(NullSink.of())) {
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertNotNull(output);
+            Assert.assertEquals(output, """
+                    EventValueSink(super={
+                      destination=NullSink(counter=0)
+                    })""");
         }
     }
 }

--- a/projectors-core/pom.xml
+++ b/projectors-core/pom.xml
@@ -41,6 +41,13 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${dependency.lombok}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/RejectSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/RejectSink.java
@@ -17,6 +17,7 @@ package io.telicent.smart.cache.projectors;
 
 import io.telicent.smart.cache.projectors.sinks.FilterSink;
 import io.telicent.smart.cache.projectors.sinks.builder.AbstractFilteringSinkBuilder;
+import lombok.ToString;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -29,8 +30,10 @@ import java.util.function.Predicate;
  *
  * @param <T> Item type
  */
+@ToString(callSuper = true)
 public class RejectSink<T> extends FilterSink<T> {
 
+    @ToString.Exclude
     private final Function<T, String> errorMessageGenerator;
 
     RejectSink(Sink<T> destination, Predicate<T> filter, Function<T, String> errorMessageGenerator,

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/AbstractTransformingSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/AbstractTransformingSink.java
@@ -17,6 +17,10 @@ package io.telicent.smart.cache.projectors.sinks;
 
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.SinkException;
+import lombok.ToString;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /**
  * An abstract sink that transforms its input and forwards it onto another sink
@@ -87,5 +91,12 @@ public abstract class AbstractTransformingSink<TInput, TOutput> implements Sink<
     public void close() {
         // Pass onwards to destination sink
         this.destination.close();
+    }
+
+    @Override
+    public String toString() {
+        String destinationOutput = this.destination.toString();
+        destinationOutput = Arrays.stream(destinationOutput.split("\n")).map(line -> "  " + line).collect(Collectors.joining("\n"));
+        return "{\n  destination=" + destinationOutput.substring(2) + "\n}";
     }
 }

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/CleanupSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/CleanupSink.java
@@ -17,6 +17,7 @@ package io.telicent.smart.cache.projectors.sinks;
 
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBuilder;
+import lombok.ToString;
 import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,7 @@ import java.util.Objects;
  *
  * @param <T> Item type
  */
+@ToString(callSuper = true)
 public class CleanupSink<T> extends AbstractTransformingSink<T, T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CleanupSink.class);

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/CollectorSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/CollectorSink.java
@@ -18,6 +18,7 @@ package io.telicent.smart.cache.projectors.sinks;
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.sinks.builder.SinkBuilder;
 import io.telicent.smart.cache.projectors.SinkException;
+import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -27,8 +28,10 @@ import java.util.List;
  *
  * @param <T> Input type
  */
+@ToString
 public class CollectorSink<T> implements Sink<T> {
 
+    @ToString.Exclude
     private final List<T> collection = new ArrayList<>();
 
     CollectorSink() {

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/FilterSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/FilterSink.java
@@ -26,6 +26,7 @@ import io.telicent.smart.cache.projectors.Library;
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.SinkException;
 import io.telicent.smart.cache.projectors.sinks.builder.AbstractFilteringSinkBuilder;
+import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.UUID;
@@ -40,6 +41,7 @@ import java.util.function.Predicate;
  *
  * @param <T> Input type
  */
+@ToString(callSuper = true, onlyExplicitlyIncluded = true)
 public class FilterSink<T> extends AbstractTransformingSink<T, T> {
 
     private final Predicate<T> filter;
@@ -115,7 +117,7 @@ public class FilterSink<T> extends AbstractTransformingSink<T, T> {
             extends AbstractFilteringSinkBuilder<TItem, FilterSink<TItem>, FilterSink.Builder<TItem>> {
 
         @Override
-        public FilterSink<TItem> buildInternal(Predicate<TItem> predicate, String metricsLabel) {
+        protected FilterSink<TItem> buildInternal(Predicate<TItem> predicate, String metricsLabel) {
             return new FilterSink<>(this.getDestination(), predicate, metricsLabel);
         }
     }

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/JacksonJsonSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/JacksonJsonSink.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.SinkException;
 import io.telicent.smart.cache.projectors.sinks.builder.SinkBuilder;
+import lombok.ToString;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -33,6 +34,7 @@ import java.util.Objects;
  * pipelines the serialization to JSON is most likely handled directly by the sink that writes to a smart-cache.
  * </p>
  */
+@ToString(onlyExplicitlyIncluded = true)
 public class JacksonJsonSink<T> implements Sink<T> {
     /**
      * The Jackson Object Mapper that the sink will use
@@ -42,6 +44,9 @@ public class JacksonJsonSink<T> implements Sink<T> {
      * The output stream that the sink will write to
      */
     protected final OutputStream output;
+
+    @ToString.Include
+    private final boolean prettyPrint;
 
     /**
      * Creates a new sink with default options (standard out and compact printing)
@@ -70,6 +75,7 @@ public class JacksonJsonSink<T> implements Sink<T> {
         if (prettyPrint) {
             this.mapper.enable(SerializationFeature.INDENT_OUTPUT);
         }
+        this.prettyPrint = prettyPrint;
         this.mapper.getFactory().disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
         Objects.requireNonNull(output, "Output cannot be null");
         this.output = output;

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/NullSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/NullSink.java
@@ -30,7 +30,6 @@ import lombok.ToString;
  */
 @ToString
 public class NullSink<T> implements Sink<T> {
-    @ToString.Exclude
     private long counter = 0;
 
     NullSink() {

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/NullSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/NullSink.java
@@ -17,6 +17,7 @@ package io.telicent.smart.cache.projectors.sinks;
 
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.sinks.builder.SinkBuilder;
+import lombok.ToString;
 
 /**
  * A sink that simply throws away all items it receives
@@ -27,7 +28,9 @@ import io.telicent.smart.cache.projectors.sinks.builder.SinkBuilder;
  *
  * @param <T> Input type
  */
+@ToString
 public class NullSink<T> implements Sink<T> {
+    @ToString.Exclude
     private long counter = 0;
 
     NullSink() {

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressDuplicatesSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressDuplicatesSink.java
@@ -44,26 +44,22 @@ import java.util.function.Supplier;
  *
  * @param <T> Item type
  */
-@ToString(callSuper = true)
+@ToString(callSuper = true, onlyExplicitlyIncluded = true)
 public class SuppressDuplicatesSink<T> extends AbstractTransformingSink<T, T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SuppressDuplicatesSink.class);
 
-    @ToString.Exclude
     private final CacheSet<T> cache;
-    @ToString.Exclude
+    @ToString.Include
     private long suppressed = 0;
-    @ToString.Exclude
     private final LongCounter suppressedMetric;
-    @ToString.Exclude
     private final Attributes metricAttributes;
 
-    @ToString.Exclude
+    @ToString.Include
     private long lastCacheOperationAt = -1;
+    @ToString.Include
     private final long expireCacheAfter;
-    @ToString.Exclude
     private final Supplier<Boolean> invalidateWholeCache;
-    @ToString.Exclude
     private final Function<T, Boolean> invalidateCache;
 
     /**

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressDuplicatesSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressDuplicatesSink.java
@@ -25,6 +25,7 @@ import io.telicent.smart.cache.observability.TelicentMetrics;
 import io.telicent.smart.cache.projectors.Library;
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBuilder;
+import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.lib.CacheFactory;
 import org.apache.jena.atlas.lib.CacheSet;
@@ -43,18 +44,26 @@ import java.util.function.Supplier;
  *
  * @param <T> Item type
  */
+@ToString(callSuper = true)
 public class SuppressDuplicatesSink<T> extends AbstractTransformingSink<T, T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SuppressDuplicatesSink.class);
 
+    @ToString.Exclude
     private final CacheSet<T> cache;
+    @ToString.Exclude
     private long suppressed = 0;
+    @ToString.Exclude
     private final LongCounter suppressedMetric;
+    @ToString.Exclude
     private final Attributes metricAttributes;
 
+    @ToString.Exclude
     private long lastCacheOperationAt = -1;
     private final long expireCacheAfter;
+    @ToString.Exclude
     private final Supplier<Boolean> invalidateWholeCache;
+    @ToString.Exclude
     private final Function<T, Boolean> invalidateCache;
 
     /**

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressUnmodifiedSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressUnmodifiedSink.java
@@ -25,6 +25,7 @@ import io.telicent.smart.cache.observability.TelicentMetrics;
 import io.telicent.smart.cache.projectors.Library;
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBuilder;
+import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.lib.Cache;
 import org.apache.jena.atlas.lib.CacheFactory;
@@ -50,20 +51,31 @@ import java.util.function.Supplier;
  *
  * @param <T> Item type
  */
+@ToString(callSuper = true)
 public class SuppressUnmodifiedSink<T, TKey, TValue> extends AbstractTransformingSink<T, T> {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(SuppressUnmodifiedSink.class);
 
+    @ToString.Exclude
     private final Cache<TKey, TValue> cache;
+    @ToString.Exclude
     private final Function<T, TKey> keyFunction;
+    @ToString.Exclude
     private final Function<T, TValue> valueFunction;
+    @ToString.Exclude
     private final Comparator<TValue> valueComparator;
+    @ToString.Exclude
     private long suppressed = 0;
+    @ToString.Exclude
     private final LongCounter suppressedMetric;
+    @ToString.Exclude
     private final Attributes metricAttributes;
+    @ToString.Exclude
     private final Function<T, Boolean> invalidateCache;
+    @ToString.Exclude
     private long lastCacheOperationAt = -1;
     private final long expireCacheAfter;
+    @ToString.Exclude
     private final Supplier<Boolean> invalidateWholeCache;
 
     /**

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressUnmodifiedSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressUnmodifiedSink.java
@@ -51,31 +51,24 @@ import java.util.function.Supplier;
  *
  * @param <T> Item type
  */
-@ToString(callSuper = true)
+@ToString(callSuper = true, onlyExplicitlyIncluded = true)
 public class SuppressUnmodifiedSink<T, TKey, TValue> extends AbstractTransformingSink<T, T> {
 
     private final static Logger LOGGER = LoggerFactory.getLogger(SuppressUnmodifiedSink.class);
 
-    @ToString.Exclude
     private final Cache<TKey, TValue> cache;
-    @ToString.Exclude
     private final Function<T, TKey> keyFunction;
-    @ToString.Exclude
     private final Function<T, TValue> valueFunction;
-    @ToString.Exclude
     private final Comparator<TValue> valueComparator;
-    @ToString.Exclude
+    @ToString.Include
     private long suppressed = 0;
-    @ToString.Exclude
     private final LongCounter suppressedMetric;
-    @ToString.Exclude
     private final Attributes metricAttributes;
-    @ToString.Exclude
     private final Function<T, Boolean> invalidateCache;
-    @ToString.Exclude
+    @ToString.Include
     private long lastCacheOperationAt = -1;
+    @ToString.Include
     private final long expireCacheAfter;
-    @ToString.Exclude
     private final Supplier<Boolean> invalidateWholeCache;
 
     /**

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/ThroughputSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/ThroughputSink.java
@@ -20,6 +20,7 @@ import io.telicent.smart.cache.projectors.SinkException;
 import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBuilder;
 import io.telicent.smart.cache.projectors.utils.ThroughputTracker;
 import io.telicent.smart.cache.projectors.utils.ThroughputTrackerBuilder;
+import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,9 +33,11 @@ import java.util.function.Function;
  *
  * @param <T> Input type
  */
+@ToString(callSuper = true)
 public class ThroughputSink<T> extends AbstractTransformingSink<T, T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ThroughputSink.class);
 
+    @ToString.Exclude
     private final ThroughputTracker tracker;
 
     /**

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/ThroughputSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/ThroughputSink.java
@@ -37,7 +37,6 @@ import java.util.function.Function;
 public class ThroughputSink<T> extends AbstractTransformingSink<T, T> {
     private static final Logger LOGGER = LoggerFactory.getLogger(ThroughputSink.class);
 
-    @ToString.Exclude
     private final ThroughputTracker tracker;
 
     /**

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/utils/ThroughputTracker.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/utils/ThroughputTracker.java
@@ -24,6 +24,7 @@ import io.telicent.smart.cache.observability.AttributeNames;
 import io.telicent.smart.cache.observability.MetricNames;
 import io.telicent.smart.cache.observability.TelicentMetrics;
 import io.telicent.smart.cache.projectors.Library;
+import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.slf4j.Logger;
@@ -36,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Utility class for tracking the throughput of various components
  */
+@ToString(onlyExplicitlyIncluded = true)
 public class ThroughputTracker {
 
     /**
@@ -62,10 +64,13 @@ public class ThroughputTracker {
     public static final String TRACKING_MISMATCH_ERROR = "Must call itemReceived prior to itemProcessed";
 
     private final Logger logger;
+    @ToString.Include
     private long processed = 0, received = 0;
     private long first = -1, last = -1;
+    @ToString.Include
     private final long reportBatchSize;
     private final TimeUnit reportTimeUnit;
+    @ToString.Include
     private final String action, itemsName;
 
     private final boolean metricsEnabled;

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/DelaySink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/DelaySink.java
@@ -16,12 +16,14 @@
 package io.telicent.smart.cache.projectors.sinks;
 
 import io.telicent.smart.cache.projectors.Sink;
+import lombok.ToString;
 
 /**
  * A test sink implementation that introduces delays into proceedings
  *
  * @param <T> Item type
  */
+@ToString(callSuper = true)
 public class DelaySink<T> extends AbstractTransformingSink<T, T> {
     private final long delay;
 

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/ErrorSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/ErrorSink.java
@@ -17,6 +17,7 @@ package io.telicent.smart.cache.projectors.sinks;
 
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.SinkException;
+import lombok.ToString;
 
 import java.util.function.Supplier;
 
@@ -25,6 +26,7 @@ import java.util.function.Supplier;
  *
  * @param <T> Input type
  */
+@ToString
 public class ErrorSink<T> implements Sink<T> {
     private final Supplier<SinkException> errorSupplier;
 

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/InspectableJacksonJsonSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/InspectableJacksonJsonSink.java
@@ -20,10 +20,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.OutputStream;
 
 /**
- * An extension of the {@link JacksonJsonSink} purely for test purposes, so we can examine the auto-configured output and
+ * An extension of the {@link JacksonJsonSink} purely for test purposes, so we can examine the autoconfigured output and
  * object mapper without having to expose that on the original class
  */
-public class InspectableJacksonJsonSink extends JacksonJsonSink {
+public class InspectableJacksonJsonSink<T> extends JacksonJsonSink<T> {
 
     /**
      * Creates a new sink with default options (standard out and compact printing)
@@ -39,16 +39,6 @@ public class InspectableJacksonJsonSink extends JacksonJsonSink {
      */
     public InspectableJacksonJsonSink(boolean prettyPrint) {
         super(prettyPrint);
-    }
-
-    /**
-     * Creates a new sink with custom options
-     *
-     * @param output      Destination output stream
-     * @param prettyPrint Whether to pretty print output
-     */
-    public InspectableJacksonJsonSink(OutputStream output, boolean prettyPrint) {
-        super(output, prettyPrint);
     }
 
     /**

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestCleanupSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestCleanupSink.java
@@ -153,6 +153,20 @@ public class TestCleanupSink {
         }
     }
 
+    @Test
+    public void givenCleanupSinkWithAutoCloseable_whenClosing_thenResourcesAreClosed() {
+        // Given
+        AtomicBoolean closed = new AtomicBoolean(false);
+        AutoCloseable resource = () -> closed.set(true);
+        CleanupSink<String> sink = Sinks.<String>cleanup().resource(resource).build();
+
+        // When
+        sink.close();
+
+        // Then
+        Assert.assertTrue(closed.get());
+    }
+
     @DataProvider(name = "closeables")
     public Object[][] closeables() {
         return new Object[][] {
@@ -213,7 +227,6 @@ public class TestCleanupSink {
             Assert.assertEquals(resource.count.get(), 2);
         }
     }
-
 
     private final class GoodCloseable implements Closeable {
 

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestCollectorSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestCollectorSink.java
@@ -50,6 +50,18 @@ public class TestCollectorSink extends AbstractSinkTests {
         verifyCollectorSink(values);
     }
 
+    @Test
+    public void givenCollectorSink_whenToString_thenBasicOutput() {
+        // Given
+        try (CollectorSink<String> sink = CollectorSink.of()) {
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertEquals(output, "CollectorSink()");
+        }
+    }
+
     protected void verifyCollectorSink(List<String> values) {
         // When
         try (CollectorSink<String> sink = new CollectorSink<>()) {

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestFilterSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestFilterSink.java
@@ -187,9 +187,9 @@ public class TestFilterSink extends AbstractSinkTests {
                                         FilterSink(super={
                                           destination=SuppressDuplicatesSink(super={
                                             destination=FilterSink(super={
-                                              destination=NullSink()
+                                              destination=NullSink(counter=0)
                                             })
-                                          }, expireCacheAfter=300000)
+                                          }, suppressed=0, lastCacheOperationAt=-1, expireCacheAfter=300000)
                                         })""");
         }
     }

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestFilterSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestFilterSink.java
@@ -19,11 +19,14 @@ import io.telicent.smart.cache.observability.AttributeNames;
 import io.telicent.smart.cache.observability.MetricNames;
 import io.telicent.smart.cache.observability.metrics.MetricTestUtils;
 import io.telicent.smart.cache.projectors.SinkException;
+import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.time.Duration;
 import java.util.*;
 import java.util.function.Predicate;
 
@@ -145,8 +148,49 @@ public class TestFilterSink extends AbstractSinkTests {
         // And
         // If metrics were enabled then the appropriate number of filtered items should have been reported
         if (StringUtils.isNotBlank(metricsLabel)) {
-            double metricValue = MetricTestUtils.getReportedMetric(MetricNames.ITEMS_FILTERED, AttributeNames.ITEMS_TYPE, metricsLabel);
+            double metricValue =
+                    MetricTestUtils.getReportedMetric(MetricNames.ITEMS_FILTERED, AttributeNames.ITEMS_TYPE,
+                                                      metricsLabel);
             Assert.assertEquals(metricValue, values.size() - expected.size());
+        }
+    }
+
+    @Test
+    public void givenFilterSinkWithSimpleDestination_whenToString_thenOutputIndicatesDestination() {
+        // Given
+        try (FilterSink<String> sink = Sinks.<String>filter().collect().build()) {
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertEquals(output, """
+                    FilterSink(super={
+                      destination=CollectorSink()
+                    })""");
+        }
+    }
+
+    @Test
+    public void givenFilterSinkWithComplexDestination_whenToString_thenOutputIndicatesDestination() {
+        // Given
+        try (FilterSink<String> sink = Sinks.<String>filter()
+                                            .suppressDuplicates(s -> s.cacheSize(100)
+                                                                      .expireCacheAfter(Duration.ofMinutes(5))
+                                                                      .filter(AbstractForwardingSinkBuilder::discard))
+                                            .build()) {
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertEquals(output,
+                                """
+                                        FilterSink(super={
+                                          destination=SuppressDuplicatesSink(super={
+                                            destination=FilterSink(super={
+                                              destination=NullSink()
+                                            })
+                                          }, expireCacheAfter=300000)
+                                        })""");
         }
     }
 }

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestJacksonJsonSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestJacksonJsonSink.java
@@ -114,7 +114,7 @@ public class TestJacksonJsonSink extends AbstractSinkTests {
     @Test
     public void givenNoParameters_whenCreatingSink_thenDefaultsAreUsed() {
         // Given and When
-        try (InspectableJacksonJsonSink sink = new InspectableJacksonJsonSink()) {
+        try (InspectableJacksonJsonSink<String> sink = new InspectableJacksonJsonSink<>()) {
             // Then
             Assert.assertEquals(sink.getOutputStream(), System.out);
             Assert.assertFalse(sink.getObjectMapper().isEnabled(SerializationFeature.INDENT_OUTPUT));
@@ -124,7 +124,7 @@ public class TestJacksonJsonSink extends AbstractSinkTests {
     @Test
     public void givenPrettyPrinting_whenCreatingSink_thenPrettyPrintingEnabled() {
         // Given and When
-        try (InspectableJacksonJsonSink sink = new InspectableJacksonJsonSink(true)) {
+        try (InspectableJacksonJsonSink<String> sink = new InspectableJacksonJsonSink<>(true)) {
             // Then
             Assert.assertEquals(sink.getOutputStream(), System.out);
             Assert.assertTrue(sink.getObjectMapper().isEnabled(SerializationFeature.INDENT_OUTPUT));
@@ -145,6 +145,33 @@ public class TestJacksonJsonSink extends AbstractSinkTests {
                                     "Object at Index " + i + " did not produce the expected JSON");
                 output.reset();
             }
+        }
+    }
+
+    @Test
+    public void givenJacksonJsonSink_whenToString_thenUsefulOutput() {
+        // Given
+        try (JacksonJsonSink<String> sink = JacksonJsonSink.<String>create().toStdOut().build()) {
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertEquals(output, "JacksonJsonSink(prettyPrint=false)");
+        }
+    }
+
+    @Test
+    public void givenJacksonJsonSinkWithPrettyPrinting_whenToString_thenUsefulOutput() {
+        // Given
+        try (JacksonJsonSink<String> sink = JacksonJsonSink.<String>create()
+                                                           .prettyPrint()
+                                                           .toStdOut()
+                                                           .build()) {
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertEquals(output, "JacksonJsonSink(prettyPrint=true)");
         }
     }
 }

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestNullSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestNullSink.java
@@ -44,7 +44,23 @@ public class TestNullSink extends AbstractSinkTests {
 
             // Then
             Assert.assertNotNull(output);
-            Assert.assertEquals(output, "NullSink()");
+            Assert.assertEquals(output, "NullSink(counter=0)");
+        }
+    }
+
+    @Test
+    public void givenNullSink_whenSomeItemsOutput_thenToStringOutputIncludesCorrectCount() {
+        // Given
+        try (NullSink<String> sink = NullSink.of()) {
+            // When
+            for (int i = 0; i < 100; i++) {
+                sink.send(Integer.toString(i));
+            }
+
+            // Then
+            String output = sink.toString();
+            Assert.assertNotNull(output);
+            Assert.assertEquals(output, "NullSink(counter=100)");
         }
     }
 

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestNullSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestNullSink.java
@@ -34,6 +34,20 @@ public class TestNullSink extends AbstractSinkTests {
         verifyNullSink(Arrays.asList("a", "b", "c"));
     }
 
+    @Test
+    public void givenNullSink_whenToString_thenBasicOutput() {
+        // Given
+        try (NullSink<String> sink = NullSink.of()) {
+
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertNotNull(output);
+            Assert.assertEquals(output, "NullSink()");
+        }
+    }
+
     protected void verifyNullSink(List<String> values) {
         // When
         try (NullSink<String> sink = new NullSink<>()) {

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestRejectSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestRejectSink.java
@@ -192,9 +192,9 @@ public class TestRejectSink extends AbstractSinkTests {
                                         RejectSink(super=FilterSink(super={
                                           destination=SuppressDuplicatesSink(super={
                                             destination=FilterSink(super={
-                                              destination=NullSink()
+                                              destination=NullSink(counter=0)
                                             })
-                                          }, expireCacheAfter=300000)
+                                          }, suppressed=0, lastCacheOperationAt=-1, expireCacheAfter=300000)
                                         }))""");
         }
     }

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestRejectSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestRejectSink.java
@@ -21,10 +21,12 @@ import io.telicent.smart.cache.observability.metrics.MetricTestUtils;
 import io.telicent.smart.cache.projectors.RejectSink;
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.SinkException;
+import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBuilder;
 import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -155,6 +157,45 @@ public class TestRejectSink extends AbstractSinkTests {
                     MetricTestUtils.getReportedMetric(MetricNames.ITEMS_FILTERED, AttributeNames.ITEMS_TYPE,
                                                       metricsLabel);
             Assert.assertEquals(metricValue, values.size() - expected.size());
+        }
+    }
+
+    @Test
+    public void givenRejectSinkWithSimpleDestination_whenToString_thenOutputIndicatesDestination() {
+        // Given
+        try (RejectSink<String> sink = Sinks.<String>reject().collect().build()) {
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertEquals(output, """
+                    RejectSink(super=FilterSink(super={
+                      destination=CollectorSink()
+                    }))""");
+        }
+    }
+
+    @Test
+    public void givenRejectSinkWithComplexDestination_whenToString_thenOutputIndicatesDestination() {
+        // Given
+        try (RejectSink<String> sink = Sinks.<String>reject()
+                                            .suppressDuplicates(s -> s.cacheSize(100)
+                                                                      .expireCacheAfter(Duration.ofMinutes(5))
+                                                                      .filter(AbstractForwardingSinkBuilder::discard))
+                                            .build()) {
+            // When
+            String output = sink.toString();
+
+            // Then
+            Assert.assertEquals(output,
+                                """
+                                        RejectSink(super=FilterSink(super={
+                                          destination=SuppressDuplicatesSink(super={
+                                            destination=FilterSink(super={
+                                              destination=NullSink()
+                                            })
+                                          }, expireCacheAfter=300000)
+                                        }))""");
         }
     }
 }


### PR DESCRIPTION
Smart Cache projectors use the `Sink` interface to compose complex processing pipelines which sometimes require debugging.  Previously there were no `toString()` implementations provided on most `Sink` implementations meaning developers had to dig through fields manually.  With this PR we now have Lombok generated `toString()` methods for most implementations, with manually created implementations where appropriate e.g. see `AbstractTransformingSink` base class.

On a related note also fixes a limitation in the `CleanupSink` that it couldn't directly handle `AutoCloseable` resources, which it now does by wrapping them into a suitable `Closeable`.

Various unit tests added across the modules to test that the new `toString()` methods are returning some useful content for debugging.