### PR TITLE
Enables caching of Kafka image (CORE-752)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,6 +20,8 @@ jobs:
     with:
       # Some Docker based tests in this repository but should be fine to pull the images we need without login
       USES_DOCKERHUB_IMAGES: false
+      PUBLIC_IMAGES: |
+        confluentinc/cp-kafka:7.7.1
       # Want SNAPSHOTs to be published from main
       PUBLISH_SNAPSHOTS: true
       MAIN_BRANCH: main


### PR DESCRIPTION
Enables Docker image caching feature in our workflow for the Confluent Kafka image we use, this should speed up build times by removing the need for the image to be pulled multiple times during a build.

Note that since the shared workflow only caches images on `main` this won't affect build speed until after this has been merged to `main`