### PR TITLE
Fix ignore lists (TELDEVOPS-591,CORE-752)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,8 +18,8 @@ jobs:
   maven-build:
     uses: Telicent-oss/shared-workflows/.github/workflows/parallel-maven.yml@main
     with:
-      # Some Docker based tests in this repository but should be fine to pull the images we need without login
-      USES_DOCKERHUB_IMAGES: false
+      # Some Docker based tests in this repository
+      USES_DOCKERHUB_IMAGES: true
       PUBLIC_IMAGES: |
         confluentinc/cp-kafka:7.7.1
       # Want SNAPSHOTs to be published from main

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ hs_err_*
 
 # Trivy Cache
 .trivy/
+
+# GitHub Actions temporary files
+*trivy*
+.images/

--- a/pom.xml
+++ b/pom.xml
@@ -531,7 +531,10 @@
                                 <exclude>**/template</exclude>
                                 <!-- Trivy Cache -->
                                 <exclude>.trivy/**</exclude>
-                                <exclude>trivy/**</exclude>
+				<exclude>trivy/**</exclude>
+				<!-- GitHub Actions temp files -->
+				<exclude>.images/**</exclude>
+				<exclude>*trivy*</exclude>
                             </excludes>
                         </licenseSet>
                     </licenseSets>


### PR DESCRIPTION
Adds additional temporary files related to Trivy refactoring and Docker image caching into the .gitignore and license plugin ignore configurations

These new temporary files were causing some of the license checks to fail on GitHub Actions