### PR TITLE
Introduce EventHeader interface (CORE-761)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+# 0.29.0
+
+- Event Source Improvements:
+    - **BREAKING** Introduced an `EventHeader` interface which the existing `Header` class implements
+        - Various APIs that interact with `Event` have breaking signature changes on some methods to use the 
+          `EventHeader` interface rather than the `Header` implementation
+        - Added new `RawHeader` implementation for event sources that treat header values as byte sequences e.g. Kafka
+
 # 0.28.2
 - Build improvements
   - Updating Telicent Java Base Image - v1.2.5 

--- a/cli/cli-core/pom.xml
+++ b/cli/cli-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli-core</artifactId>

--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/commands/projection/AbstractKafkaRdfProjectionCommand.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/commands/projection/AbstractKafkaRdfProjectionCommand.java
@@ -17,6 +17,7 @@ package io.telicent.smart.cache.cli.commands.projection;
 
 import io.telicent.smart.cache.payloads.RdfPayload;
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.EventSource;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.kafka.KafkaDatasetGraphSource;
@@ -54,9 +55,9 @@ public abstract class AbstractKafkaRdfProjectionCommand<TOutput>
     }
 
     @Override
-    protected List<Function<Event<Bytes, RdfPayload>, Header>> additionalCaptureHeaderGenerators() {
+    protected List<Function<Event<Bytes, RdfPayload>, EventHeader>> additionalCaptureHeaderGenerators() {
         // Force the Content-Type header of captured events to the simplest and most portable format regardless of their input Content-Type header
-        Function<Event<Bytes, RdfPayload>, Header> generator = e -> e.value() == null ? null : e.value().isDataset() ?
+        Function<Event<Bytes, RdfPayload>, EventHeader> generator = e -> e.value() == null ? null : e.value().isDataset() ?
                                                                                                new Header(
                                                                                                        HttpNames.hContentType,
                                                                                                        WebContent.contentTypeNQuads) :

--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/commands/projection/AbstractProjectorCommand.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/commands/projection/AbstractProjectorCommand.java
@@ -28,10 +28,7 @@ import io.telicent.smart.cache.projectors.driver.ProjectorDriver;
 import io.telicent.smart.cache.projectors.sinks.Sinks;
 import io.telicent.smart.cache.projectors.sinks.ThroughputSink;
 import io.telicent.smart.cache.server.jaxrs.model.HealthStatus;
-import io.telicent.smart.cache.sources.CapturingEventSource;
-import io.telicent.smart.cache.sources.Event;
-import io.telicent.smart.cache.sources.EventSource;
-import io.telicent.smart.cache.sources.Header;
+import io.telicent.smart.cache.sources.*;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.serialization.BytesSerializer;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -158,7 +155,7 @@ public abstract class AbstractProjectorCommand<TKey, TValue, TOutput> extends Sm
      *
      * @return Additional capture headers
      */
-    protected List<Header> additionalCaptureHeaders() {
+    protected List<EventHeader> additionalCaptureHeaders() {
         return null;
     }
 
@@ -171,7 +168,7 @@ public abstract class AbstractProjectorCommand<TKey, TValue, TOutput> extends Sm
      *
      * @return Additional capture header generators
      */
-    protected List<Function<Event<TKey, TValue>, Header>> additionalCaptureHeaderGenerators() {
+    protected List<Function<Event<TKey, TValue>, EventHeader>> additionalCaptureHeaderGenerators() {
         return null;
     }
 

--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/FileSourceOptions.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/FileSourceOptions.java
@@ -22,6 +22,7 @@ import io.telicent.smart.cache.cli.restrictions.SourceRequired;
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.sinks.events.file.EventCapturingSink;
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.EventSource;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.file.FileEventFormatProvider;
@@ -139,8 +140,8 @@ public class FileSourceOptions<TKey, TValue> {
      * @return Capture sink (if capture is enabled), otherwise returns {@code null}
      */
     public Sink<Event<TKey, TValue>> getCaptureSink(Serializer<TKey> keySerializer,
-                                                    Serializer<TValue> valueSerializer, List<Header> additionalHeaders,
-                                                    List<Function<Event<TKey, TValue>, Header>> additionalHeaderGenerators) {
+                                                    Serializer<TValue> valueSerializer, List<EventHeader> additionalHeaders,
+                                                    List<Function<Event<TKey, TValue>, EventHeader>> additionalHeaderGenerators) {
         if (this.captureDirectory == null) {
             return null;
         }

--- a/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/projection/DockerTestDeadLetterQueue.java
+++ b/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/projection/DockerTestDeadLetterQueue.java
@@ -19,6 +19,7 @@ import io.telicent.smart.cache.cli.commands.AbstractCommandTests;
 import io.telicent.smart.cache.cli.commands.SmartCacheCommand;
 import io.telicent.smart.cache.cli.commands.SmartCacheCommandTester;
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.kafka.BasicKafkaTestCluster;
 import io.telicent.smart.cache.sources.kafka.KafkaEventSource;
@@ -80,7 +81,7 @@ public class DockerTestDeadLetterQueue extends AbstractCommandTests {
         super.teardown();
     }
 
-    private void generateKafkaEvents(Collection<Header> headers, String format) {
+    private void generateKafkaEvents(Collection<EventHeader> headers, String format) {
         try (KafkaSink<String, String> sink = KafkaSink.<String, String>create()
                                                        .keySerializer(StringSerializer.class)
                                                        .valueSerializer(StringSerializer.class)

--- a/cli/cli-debug/pom.xml
+++ b/cli/cli-debug/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli-debug</artifactId>

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractCliKafkaIT.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractCliKafkaIT.java
@@ -17,6 +17,7 @@ package io.telicent.smart.cache.cli.commands.debug;
 
 import io.telicent.smart.cache.cli.commands.AbstractCommandTests;
 import io.telicent.smart.cache.cli.commands.SmartCacheCommandTester;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.kafka.BasicKafkaTestCluster;
 import io.telicent.smart.cache.sources.kafka.KafkaTestCluster;
@@ -71,7 +72,7 @@ public class AbstractCliKafkaIT extends AbstractCommandTests {
         this.kafka.teardown();
     }
 
-    protected void generateKafkaEvents(Collection<Header> headers, String format) {
+    protected void generateKafkaEvents(Collection<EventHeader> headers, String format) {
         try (KafkaSink<String, String> sink = KafkaSink.<String, String>create()
                                                        .keySerializer(StringSerializer.class)
                                                        .valueSerializer(StringSerializer.class)

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractDockerDebugCliTests.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractDockerDebugCliTests.java
@@ -31,6 +31,7 @@ import io.telicent.smart.cache.live.serializers.LiveHeartbeatDeserializer;
 import io.telicent.smart.cache.projectors.driver.ProjectorDriver;
 import io.telicent.smart.cache.projectors.sinks.events.file.EventCapturingSink;
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.file.FileEventFormatProvider;
 import io.telicent.smart.cache.sources.file.FileEventFormats;
@@ -219,7 +220,7 @@ public class AbstractDockerDebugCliTests extends AbstractCommandTests {
         generateKafkaEvents(Collections.emptyList(), format);
     }
 
-    protected void generateKafkaEvents(Collection<Header> headers, String format) {
+    protected void generateKafkaEvents(Collection<EventHeader> headers, String format) {
         try (KafkaSink<String, String> sink = KafkaSink.<String, String>create()
                                                        .keySerializer(StringSerializer.class)
                                                        .valueSerializer(StringSerializer.class)
@@ -233,7 +234,7 @@ public class AbstractDockerDebugCliTests extends AbstractCommandTests {
         }
     }
 
-    protected void generateCapturedEvents(File captureDir, FileEventFormatProvider provider, Collection<Header> headers,
+    protected void generateCapturedEvents(File captureDir, FileEventFormatProvider provider, Collection<EventHeader> headers,
                                           String format) {
         try (EventCapturingSink<String, String> sink = EventCapturingSink.<String, String>create()
                                                                          .directory(captureDir)

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliMutualTlsKafka.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliMutualTlsKafka.java
@@ -19,6 +19,7 @@ import ch.qos.logback.classic.Level;
 import io.telicent.smart.cache.cli.commands.AbstractCommandTests;
 import io.telicent.smart.cache.cli.commands.SmartCacheCommandTester;
 import io.telicent.smart.cache.live.LiveReporter;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.kafka.*;
 import io.telicent.smart.cache.sources.kafka.sinks.KafkaSink;
@@ -88,7 +89,7 @@ public class DockerTestDebugCliMutualTlsKafka extends AbstractCommandTests {
         generateKafkaEvents(Collections.emptyList(), format);
     }
 
-    private void generateKafkaEvents(Collection<Header> headers, String format) {
+    private void generateKafkaEvents(Collection<EventHeader> headers, String format) {
         try (KafkaSink<String, String> sink = KafkaSink.<String, String>create()
                                                        .keySerializer(StringSerializer.class)
                                                        .valueSerializer(StringSerializer.class)

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliSecureKafka.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliSecureKafka.java
@@ -19,6 +19,7 @@ import ch.qos.logback.classic.Level;
 import io.telicent.smart.cache.cli.commands.AbstractCommandTests;
 import io.telicent.smart.cache.cli.commands.SmartCacheCommandTester;
 import io.telicent.smart.cache.live.LiveReporter;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.kafka.FlakyKafkaTest;
 import io.telicent.smart.cache.sources.kafka.KafkaEventSource;
@@ -86,7 +87,7 @@ public class DockerTestDebugCliSecureKafka extends AbstractCommandTests {
         generateKafkaEvents(Collections.emptyList(), format);
     }
 
-    private void generateKafkaEvents(Collection<Header> headers, String format) {
+    private void generateKafkaEvents(Collection<EventHeader> headers, String format) {
         try (KafkaSink<String, String> sink = KafkaSink.<String, String>create()
                                                        .keySerializer(StringSerializer.class)
                                                        .valueSerializer(StringSerializer.class)

--- a/cli/cli-probe-server/pom.xml
+++ b/cli/cli-probe-server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>cli</artifactId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <artifactId>cli-probe-server</artifactId>
     <name>Telicent Smart Caches - CLI - Health Probe Server</name>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli</artifactId>

--- a/configurator/pom.xml
+++ b/configurator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <artifactId>configurator</artifactId>
     <name>Telicent Smart Caches - Configuration API</name>

--- a/docs/event-sources/index.md
+++ b/docs/event-sources/index.md
@@ -14,11 +14,11 @@ An Event Source is typically used as the starting point of a data processing pip
 The `Event` interface provides a common representation of events regardless of how the underlying `EventSource` might
 represent them.  This is a strongly typed interface taking type parameters for both the key and value e.g.
 `Event<Integer, String>` would be an event with an `Integer` key and a `String` value.  An event may also include
-zero/more headers which are key value pairs represented using the `Header` record class.
+zero/more headers which are key value pairs represented using the `EventHeader` interface.
 
-The `key()` and `value()` methods provide access to the key and value of the event.
+The `key()` and `value()`/`rawValue()` methods provide access to the key and value of the event.
 
-The `headers()` method provides a `Stream<Header>` over all the available headers, while the corresponding
+The `headers()` method provides a `Stream<EventHeader>` over all the available headers, while the corresponding
 `headers(String)` method provides the header values for the given key.  For example `event.headers("Content-Type")`
 would return a `Stream<String>` values for the `Content-Type` header.  Additionally, the `lastHeader(String)` method
 provides only the last value for a given key e.g. `event.lastHeader("Content-Type")` would return only the last value
@@ -30,6 +30,8 @@ using the various replace methods:
 - `replaceKey()` - Creates a new copy of the event with a new key.
 - `replaceValue()` - Creates a new copy of the event with a new value.
 - `replace()` - Creates a new copy of the event with a new key and value.
+- `replaceHeaders()` - Creates a new copy of the event with new headers.
+- `addHeaders()` - Creates a new copy of the event with additional headers appended.
 
 ## `EventSource`
 

--- a/event-sources/event-source-file/pom.xml
+++ b/event-sources/event-source-file/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-source-file</artifactId>

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/projectors/sinks/events/file/EventCapturingSink.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/projectors/sinks/events/file/EventCapturingSink.java
@@ -20,6 +20,7 @@ import io.telicent.smart.cache.projectors.SinkException;
 import io.telicent.smart.cache.projectors.sinks.AbstractTransformingSink;
 import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBuilder;
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.file.FileEventWriter;
 import io.telicent.smart.cache.sources.file.yaml.YamlEventReaderWriter;
@@ -56,9 +57,9 @@ public class EventCapturingSink<TKey, TValue>
     private final String prefix, extension;
     private final File targetDirectory;
     private final FileEventWriter<TKey, TValue> writer;
-    private final List<Header> additionalHeaders;
+    private final List<EventHeader> additionalHeaders;
     @ToString.Exclude
-    private final List<Function<Event<TKey, TValue>, Header>> additionalHeaderGenerators;
+    private final List<Function<Event<TKey, TValue>, EventHeader>> additionalHeaderGenerators;
 
     /**
      * Creates a new sink
@@ -72,8 +73,8 @@ public class EventCapturingSink<TKey, TValue>
      */
     EventCapturingSink(Sink<Event<TKey, TValue>> destination, File targetDirectory,
                        FileEventWriter<TKey, TValue> writer, String prefix, int padding, String extension,
-                       List<Header> additionalHeaders,
-                       List<Function<Event<TKey, TValue>, Header>> additionalHeaderGenerators) {
+                       List<EventHeader> additionalHeaders,
+                       List<Function<Event<TKey, TValue>, EventHeader>> additionalHeaderGenerators) {
         super(destination);
         Objects.requireNonNull(targetDirectory, "Target directory cannot be null");
         Objects.requireNonNull(writer, "Event writer cannot be null");
@@ -97,7 +98,7 @@ public class EventCapturingSink<TKey, TValue>
         }
 
         // Prepare the extra headers (if any)
-        List<Header> extraHeaders = new ArrayList<>(this.additionalHeaders);
+        List<EventHeader> extraHeaders = new ArrayList<>(this.additionalHeaders);
         final Event<TKey, TValue> finalEvent = event;
         this.additionalHeaderGenerators.stream()
                                        .map(g -> g.apply(finalEvent))
@@ -157,8 +158,8 @@ public class EventCapturingSink<TKey, TValue>
         private String prefix = "event-", extension = ".yaml";
         private File targetDirectory;
         private FileEventWriter<TKey, TValue> writer;
-        private final List<Header> additionalHeaders = new ArrayList<>();
-        private final List<Function<Event<TKey, TValue>, Header>> additionalHeaderGenerators = new ArrayList<>();
+        private final List<EventHeader> additionalHeaders = new ArrayList<>();
+        private final List<Function<Event<TKey, TValue>, EventHeader>> additionalHeaderGenerators = new ArrayList<>();
 
         /**
          * Sets the target directory to which event files will be written
@@ -245,7 +246,7 @@ public class EventCapturingSink<TKey, TValue>
          * @param header Header
          * @return Builder
          */
-        public Builder<TKey, TValue> addHeader(Header header) {
+        public Builder<TKey, TValue> addHeader(EventHeader header) {
             if (header == null) {
                 return this;
             }
@@ -259,7 +260,7 @@ public class EventCapturingSink<TKey, TValue>
          * @param headers Headers
          * @return Builder
          */
-        public Builder<TKey, TValue> addHeaders(List<Header> headers) {
+        public Builder<TKey, TValue> addHeaders(List<EventHeader> headers) {
             if (headers == null) {
                 return this;
             }
@@ -276,7 +277,7 @@ public class EventCapturingSink<TKey, TValue>
          *                  be added for an event
          * @return Builder
          */
-        public Builder<TKey, TValue> generateHeaders(Function<Event<TKey, TValue>, Header> generator) {
+        public Builder<TKey, TValue> generateHeaders(Function<Event<TKey, TValue>, EventHeader> generator) {
             if (generator == null) {
                 return this;
             }
@@ -292,7 +293,7 @@ public class EventCapturingSink<TKey, TValue>
          *                   should be added for an event
          * @return Builder
          */
-        public Builder<TKey, TValue> generateHeaders(List<Function<Event<TKey, TValue>, Header>> generators) {
+        public Builder<TKey, TValue> generateHeaders(List<Function<Event<TKey, TValue>, EventHeader>> generators) {
             if (generators == null) {
                 return this;
             }

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/jackson/AbstractJacksonEventReaderWriter.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/jackson/AbstractJacksonEventReaderWriter.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.file.FileEventAccessMode;
 import io.telicent.smart.cache.sources.file.kafka.AbstractKafkaDelegatingEventReaderWriter;
@@ -98,7 +99,7 @@ public class AbstractJacksonEventReaderWriter<TKey, TValue> extends
      * @throws IOException Thrown if the event cannot be read
      */
     protected final Event<TKey, TValue> readEvent(JsonParser parser) throws IOException {
-        List<Header> headers = new ArrayList<>();
+        List<EventHeader> headers = new ArrayList<>();
         TKey key = null;
         TValue value = null;
 
@@ -128,7 +129,7 @@ public class AbstractJacksonEventReaderWriter<TKey, TValue> extends
         return new SimpleEvent<>(headers, key, value);
     }
 
-    private void readHeaders(JsonParser parser, List<Header> headers) throws IOException {
+    private void readHeaders(JsonParser parser, List<EventHeader> headers) throws IOException {
         requireToken(parser, true, JsonToken.START_ARRAY);
 
         while (parser.nextToken() == JsonToken.START_OBJECT) {
@@ -145,7 +146,7 @@ public class AbstractJacksonEventReaderWriter<TKey, TValue> extends
      * @return Key
      * @throws IOException Thrown if the key cannot be read successfully
      */
-    protected TKey readKey(List<Header> headers, JsonParser parser) throws IOException {
+    protected TKey readKey(List<EventHeader> headers, JsonParser parser) throws IOException {
         return parseValue(headers, parser, this.keyDeserializer);
     }
 
@@ -159,7 +160,7 @@ public class AbstractJacksonEventReaderWriter<TKey, TValue> extends
      * @return Value
      * @throws IOException Thrown if the value cannot be parsed successfully
      */
-    protected <T> T parseValue(List<Header> headers, JsonParser parser, Deserializer<T> deserializer) throws
+    protected <T> T parseValue(List<EventHeader> headers, JsonParser parser, Deserializer<T> deserializer) throws
             IOException {
         requireValue(parser);
         if (parser.currentToken() == JsonToken.VALUE_NULL) {
@@ -203,7 +204,7 @@ public class AbstractJacksonEventReaderWriter<TKey, TValue> extends
      * @return Value
      * @throws IOException Thrown if the value cannot be read
      */
-    protected TValue readValue(List<Header> headers, JsonParser parser) throws IOException {
+    protected TValue readValue(List<EventHeader> headers, JsonParser parser) throws IOException {
         return parseValue(headers, parser, this.valueDeserializer);
     }
 
@@ -244,7 +245,7 @@ public class AbstractJacksonEventReaderWriter<TKey, TValue> extends
             if (event.headers().findAny().isPresent()) {
                 generator.writeFieldName("headers");
                 generator.writeStartArray();
-                for (Header header : event.headers().toList()) {
+                for (EventHeader header : event.headers().toList()) {
                     generator.writePOJO(header);
                 }
                 generator.writeEndArray();
@@ -281,7 +282,7 @@ public class AbstractJacksonEventReaderWriter<TKey, TValue> extends
      * @param <T>        Value type
      * @throws IOException Thrown if the value cannot be serialized
      */
-    protected <T> void writeBase64(Stream<Header> headers, String field, T value, Serializer<T> serializer,
+    protected <T> void writeBase64(Stream<EventHeader> headers, String field, T value, Serializer<T> serializer,
                                    JsonGenerator generator) throws
             IOException {
         byte[] data =

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/rdf/RdfEventReaderWriter.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/rdf/RdfEventReaderWriter.java
@@ -16,6 +16,7 @@
 package io.telicent.smart.cache.sources.file.rdf;
 
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.file.FileEventAccessMode;
 import io.telicent.smart.cache.sources.file.kafka.AbstractKafkaDelegatingEventReaderWriter;
@@ -101,7 +102,7 @@ public class RdfEventReaderWriter<TKey, TValue> extends AbstractKafkaDelegatingE
         Lang lang = RDFLanguages.filenameToLang(f.getAbsolutePath());
 
         // Infer Content-Type header from filename
-        List<Header> headers = new ArrayList<>();
+        List<EventHeader> headers = new ArrayList<>();
         if (lang != null) {
             headers.add(new Header(HttpNames.hContentType, lang.getContentType().getContentTypeStr()));
         }
@@ -124,7 +125,7 @@ public class RdfEventReaderWriter<TKey, TValue> extends AbstractKafkaDelegatingE
     public void write(Event<TKey, TValue> event, File f) throws IOException {
         Lang lang = RDFLanguages.filenameToLang(f.getAbsolutePath());
 
-        List<Header> headers = new ArrayList<>(event.headers().toList());
+        List<EventHeader> headers = new ArrayList<>(event.headers().toList());
         if (lang != null) {
             headers.add(new Header(HttpNames.hContentType, lang.getContentType().getContentTypeStr()));
         }

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/text/PlainTextEventReaderWriter.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/text/PlainTextEventReaderWriter.java
@@ -16,6 +16,7 @@
 package io.telicent.smart.cache.sources.file.text;
 
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.file.FileEventAccessMode;
 import io.telicent.smart.cache.sources.file.FileEventReaderWriter;
@@ -113,7 +114,7 @@ public class PlainTextEventReaderWriter<TKey, TValue> implements FileEventReader
     public Event<TKey, TValue> read(InputStream input) throws IOException {
         AbstractKafkaDelegatingEventReaderWriter.ensureReadsPermitted(this.mode);
 
-        List<Header> headers = new ArrayList<>();
+        List<EventHeader> headers = new ArrayList<>();
         while (true) {
             String line = readLine(input);
             if (line.isEmpty()) {
@@ -171,10 +172,12 @@ public class PlainTextEventReaderWriter<TKey, TValue> implements FileEventReader
 
         Headers kafkaHeaders = new RecordHeaders(KafkaSink.toKafkaHeaders(event.headers()));
         // Header lines
-        for (Header h : event.headers().toList()) {
+        for (EventHeader h : event.headers().toList()) {
             output.write(h.key().getBytes(StandardCharsets.UTF_8));
             output.write(": ".getBytes(StandardCharsets.UTF_8));
-            output.write(h.value().getBytes(StandardCharsets.UTF_8));
+            if (h.rawValue() != null) {
+                output.write(h.rawValue());
+            }
             output.write('\n');
         }
 

--- a/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/projectors/sinks/events/file/TestEventCapturingSink.java
+++ b/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/projectors/sinks/events/file/TestEventCapturingSink.java
@@ -17,6 +17,7 @@ package io.telicent.smart.cache.projectors.sinks.events.file;
 
 import io.telicent.smart.cache.projectors.SinkException;
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.EventSource;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.file.FileEventFormatProvider;
@@ -214,7 +215,7 @@ public class TestEventCapturingSink {
                                                                                                         "Even-Number",
                                                                                                         "true") : null)
                                                                           .generateHeaders(
-                                                                                  (Function<Event<Integer, String>, Header>) null)
+                                                                                  (Function<Event<Integer, String>, EventHeader>) null)
                                                                           .build()) {
             sink.send(new SimpleEvent<>(Collections.emptyList(), 1, "test"));
             sink.send(new SimpleEvent<>(Collections.emptyList(), 2, "test"));
@@ -251,7 +252,7 @@ public class TestEventCapturingSink {
                                                                                "Even-Number",
                                                                                "true") :
                                                                        null))
-                                         .generateHeaders((List<Function<Event<Integer, String>, Header>>) null)
+                                         .generateHeaders((List<Function<Event<Integer, String>, EventHeader>>) null)
                                          .build()) {
             sink.send(new SimpleEvent<>(Collections.emptyList(), 1, "test"));
             sink.send(new SimpleEvent<>(Collections.emptyList(), 2, "test"));

--- a/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/sources/file/GenerateTestData.java
+++ b/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/sources/file/GenerateTestData.java
@@ -15,6 +15,7 @@
  */
 package io.telicent.smart.cache.sources.file;
 
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.TelicentHeaders;
 import io.telicent.smart.cache.sources.file.gzip.GZipEventReaderWriter;
@@ -43,7 +44,7 @@ public class GenerateTestData {
             new Header("Content-Type", Lang.NQUADS.getContentType().getContentTypeStr());
     public static final Header TOP_SECRET_CLEARANCE_REQUIRED = new Header(
             TelicentHeaders.SECURITY_LABEL, "clearance=TS");
-    public static final List<Header> DEFAULT_TEST_HEADERS = List.of(NQUADS_CONTENT_TYPE, TOP_SECRET_CLEARANCE_REQUIRED);
+    public static final List<EventHeader> DEFAULT_TEST_HEADERS = List.of(NQUADS_CONTENT_TYPE, TOP_SECRET_CLEARANCE_REQUIRED);
     public static final String SIMPLE_RDF_VALUE = """
             <http://subject> <http://predicate> <http://object> .
             <http://other> <http://predicate> "value" .
@@ -80,13 +81,13 @@ public class GenerateTestData {
         return event;
     }
 
-    private static SimpleEvent<Integer, String> createEvent(List<Header> headers, Integer key, String value) {
+    private static SimpleEvent<Integer, String> createEvent(List<EventHeader> headers, Integer key, String value) {
         return new SimpleEvent<>(
                 headers, key, value);
     }
 
     private static void complex() throws IOException {
-        List<Header> headers = DEFAULT_TEST_HEADERS;
+        List<EventHeader> headers = DEFAULT_TEST_HEADERS;
         Header key = new Header("Key", "Value");
         Map<String, Object> value =
                 Map.of("a", 1, "b", 2, "c", 3, "d", List.of(4, 5, 6), "e", Map.of("f", 7, "g", false));

--- a/event-sources/event-source-kafka/pom.xml
+++ b/event-sources/event-source-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-source-kafka</artifactId>

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/sinks/KafkaSink.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/sinks/KafkaSink.java
@@ -19,6 +19,7 @@ import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.SinkException;
 import io.telicent.smart.cache.projectors.sinks.builder.SinkBuilder;
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.kafka.KafkaSecurity;
 import lombok.NonNull;
@@ -173,10 +174,8 @@ public class KafkaSink<TKey, TValue> implements Sink<Event<TKey, TValue>> {
      * @param headers Event headers
      * @return Kafka headers
      */
-    public static List<org.apache.kafka.common.header.Header> toKafkaHeaders(Stream<Header> headers) {
-        return headers.map(h -> (org.apache.kafka.common.header.Header) new RecordHeader(h.key(), h.value()
-                                                                                                   .getBytes(
-                                                                                                           StandardCharsets.UTF_8)))
+    public static List<org.apache.kafka.common.header.Header> toKafkaHeaders(Stream<EventHeader> headers) {
+        return headers.map(h -> (org.apache.kafka.common.header.Header) new RecordHeader(h.key(), h.rawValue()))
                       .toList();
     }
 

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEvents.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEvents.java
@@ -15,6 +15,7 @@
  */
 package io.telicent.smart.cache.sources.kafka;
 
+import io.telicent.smart.cache.sources.EventHeader;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -58,8 +59,7 @@ public class TestKafkaEvents {
     @Test
     public void kafka_event_02() {
         Headers headers = new RecordHeaders(new Header[] {
-                new RecordHeader("Content-Type", "text/plain".getBytes(
-                        StandardCharsets.UTF_8))
+                new RecordHeader("Content-Type", "text/plain".getBytes(StandardCharsets.UTF_8))
         });
         KafkaEvent<Integer, String> event = new KafkaEvent<>(createConsumerRecord(TEST_KEY, TEST_VALUE, headers), null);
         Assert.assertEquals(event.key(), TEST_KEY);
@@ -68,9 +68,9 @@ public class TestKafkaEvents {
         Assert.assertEquals(event.headers("Content-Type").count(), 1);
         Assert.assertEquals(event.headers("Content-Type").findFirst().orElse(null), "text/plain");
 
-        List<io.telicent.smart.cache.sources.Header> actualHeaders = event.headers().toList();
+        List<EventHeader> actualHeaders = event.headers().toList();
         Assert.assertEquals(actualHeaders.size(), 1);
-        io.telicent.smart.cache.sources.Header actual = actualHeaders.get(0);
+        EventHeader actual = actualHeaders.get(0);
         Assert.assertEquals(actual.key(), "Content-Type");
         Assert.assertEquals(actual.value(), "text/plain");
     }
@@ -78,8 +78,7 @@ public class TestKafkaEvents {
     @Test
     public void kafka_event_03() {
         Headers headers = new RecordHeaders(new Header[] {
-                new RecordHeader("Content-Type", "".getBytes(
-                        StandardCharsets.UTF_8))
+                new RecordHeader("Content-Type", "".getBytes(StandardCharsets.UTF_8))
         });
         KafkaEvent<Integer, String> event = new KafkaEvent<>(createConsumerRecord(TEST_KEY, TEST_VALUE, headers), null);
         Assert.assertEquals(event.key(), TEST_KEY);
@@ -88,9 +87,9 @@ public class TestKafkaEvents {
         Assert.assertEquals(event.headers("Content-Type").count(), 1);
         Assert.assertEquals(event.headers("Content-Type").findFirst().orElse(null), "");
 
-        List<io.telicent.smart.cache.sources.Header> actualHeaders = event.headers().toList();
+        List<EventHeader> actualHeaders = event.headers().toList();
         Assert.assertEquals(actualHeaders.size(), 1);
-        io.telicent.smart.cache.sources.Header actual = actualHeaders.get(0);
+        EventHeader actual = actualHeaders.get(0);
         Assert.assertEquals(actual.key(), "Content-Type");
         Assert.assertEquals(actual.value(), "");
     }
@@ -113,9 +112,9 @@ public class TestKafkaEvents {
             // Ok, we expect findFirst() to throw this if the first element is null
         }
 
-        List<io.telicent.smart.cache.sources.Header> actualHeaders = event.headers().toList();
+        List<EventHeader> actualHeaders = event.headers().toList();
         Assert.assertEquals(actualHeaders.size(), 1);
-        io.telicent.smart.cache.sources.Header actual = actualHeaders.get(0);
+        EventHeader actual = actualHeaders.get(0);
         Assert.assertEquals(actual.key(), "Content-Type");
         Assert.assertNull(actual.value());
     }
@@ -136,9 +135,9 @@ public class TestKafkaEvents {
         Assert.assertEquals(event.headers("Content-Type").findFirst().orElse(null), "text/plain");
         Assert.assertEquals(event.headers("Exec-Path").findFirst().orElse(null), "foo,bar");
 
-        List<io.telicent.smart.cache.sources.Header> actualHeaders = event.headers().toList();
+        List<EventHeader> actualHeaders = event.headers().toList();
         Assert.assertEquals(actualHeaders.size(), 2);
-        io.telicent.smart.cache.sources.Header actual = actualHeaders.get(0);
+        EventHeader actual = actualHeaders.get(0);
         Assert.assertEquals(actual.key(), "Content-Type");
         Assert.assertEquals(actual.value(), "text/plain");
         actual = actualHeaders.get(1);
@@ -194,34 +193,26 @@ public class TestKafkaEvents {
 
         KafkaEvent<Integer, String> withHeaders =
                 new KafkaEvent<>(createConsumerRecord(TEST_KEY, TEST_VALUE, new RecordHeaders(new Header[] {
-                        new RecordHeader("Content-Type", "text/plain".getBytes(
-                                StandardCharsets.UTF_8))
+                        new RecordHeader("Content-Type", "text/plain".getBytes(StandardCharsets.UTF_8))
                 })), null);
         Assert.assertNotEquals(event, withHeaders);
         Assert.assertFalse(event.equals(withHeaders));
         Assert.assertFalse(withHeaders.equals(event));
 
         KafkaEvent<Integer, String> withOtherHeaders =
-                new KafkaEvent<>(
-                        createConsumerRecord(TEST_KEY,
-                                             TEST_VALUE, new RecordHeaders(new Header[] {
-                                        new RecordHeader("Content-Type", "text/plain".getBytes(
-                                                StandardCharsets.UTF_8)), new RecordHeader("foo", "bar".getBytes(
-                                        StandardCharsets.UTF_8))
-                                })), null);
+                new KafkaEvent<>(createConsumerRecord(TEST_KEY, TEST_VALUE, new RecordHeaders(new Header[] {
+                        new RecordHeader("Content-Type", "text/plain".getBytes(StandardCharsets.UTF_8)),
+                        new RecordHeader("foo", "bar".getBytes(StandardCharsets.UTF_8))
+                })), null);
         Assert.assertNotEquals(withHeaders, withOtherHeaders);
         Assert.assertFalse(withHeaders.equals(withOtherHeaders));
         Assert.assertFalse(withOtherHeaders.equals(withHeaders));
 
         KafkaEvent<Integer, String> withOtherHeadersDifferentOrder =
-                new KafkaEvent<>(
-                        createConsumerRecord(TEST_KEY,
-                                             TEST_VALUE, new RecordHeaders(new Header[] {
-                                        new RecordHeader("foo", "bar".getBytes(
-                                                StandardCharsets.UTF_8)),
-                                        new RecordHeader("Content-Type", "text/plain".getBytes(
-                                                StandardCharsets.UTF_8))
-                                })), null);
+                new KafkaEvent<>(createConsumerRecord(TEST_KEY, TEST_VALUE, new RecordHeaders(new Header[] {
+                        new RecordHeader("foo", "bar".getBytes(StandardCharsets.UTF_8)),
+                        new RecordHeader("Content-Type", "text/plain".getBytes(StandardCharsets.UTF_8))
+                })), null);
         Assert.assertEquals(withOtherHeaders, withOtherHeadersDifferentOrder);
         Assert.assertTrue(withOtherHeadersDifferentOrder.equals(withOtherHeaders));
         Assert.assertTrue(withOtherHeaders.equals(withOtherHeadersDifferentOrder));

--- a/event-sources/event-sources-core/pom.xml
+++ b/event-sources/event-sources-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Event Sources - Core API</name>

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventHeaderSink.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventHeaderSink.java
@@ -19,6 +19,7 @@ import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.sinks.AbstractTransformingSink;
 import io.telicent.smart.cache.projectors.sinks.builder.AbstractForwardingSinkBuilder;
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.TelicentHeaders;
 import lombok.ToString;
@@ -37,7 +38,7 @@ import java.util.stream.Stream;
 @ToString(callSuper = true)
 public class EventHeaderSink<TKey, TValue> extends AbstractTransformingSink<Event<TKey, TValue>, Event<TKey, TValue>> {
     @ToString.Exclude
-    private final List<Function<Event<TKey, TValue>, Header>> headerGenerators = new ArrayList<>();
+    private final List<Function<Event<TKey, TValue>, EventHeader>> headerGenerators = new ArrayList<>();
 
     /**
      * Creates a new sink
@@ -46,7 +47,7 @@ public class EventHeaderSink<TKey, TValue> extends AbstractTransformingSink<Even
      * @param headerGenerators Header generator functions
      */
     EventHeaderSink(Sink<Event<TKey, TValue>> destination,
-                    Collection<Function<Event<TKey, TValue>, Header>> headerGenerators) {
+                    Collection<Function<Event<TKey, TValue>, EventHeader>> headerGenerators) {
         super(destination);
         this.headerGenerators.addAll(Objects.requireNonNull(headerGenerators, "Header Generators cannot be null"));
         if (this.headerGenerators.isEmpty()) {
@@ -57,7 +58,7 @@ public class EventHeaderSink<TKey, TValue> extends AbstractTransformingSink<Even
     @Override
     protected Event<TKey, TValue> transform(Event<TKey, TValue> event) {
         //@formatter:off
-        List<Header> additionalHeaders =
+        List<EventHeader> additionalHeaders =
                 this.headerGenerators.stream()
                                      .map(g -> g.apply(event))
                                      .filter(Objects::nonNull)
@@ -91,7 +92,7 @@ public class EventHeaderSink<TKey, TValue> extends AbstractTransformingSink<Even
     public static class Builder<TKey, TValue> extends
             AbstractForwardingSinkBuilder<Event<TKey, TValue>, Event<TKey, TValue>, EventHeaderSink<TKey, TValue>, Builder<TKey, TValue>> {
 
-        private final List<Function<Event<TKey, TValue>, Header>> headerGenerators = new ArrayList<>();
+        private final List<Function<Event<TKey, TValue>, EventHeader>> headerGenerators = new ArrayList<>();
 
         /**
          * Sets a header generator function that generates a header, may be called multiple times to have the sink add
@@ -125,7 +126,7 @@ public class EventHeaderSink<TKey, TValue> extends AbstractTransformingSink<Even
          *                        will be added
          * @return Builder
          */
-        public Builder<TKey, TValue> headerGenerator(Function<Event<TKey, TValue>, Header> headerGenerator) {
+        public Builder<TKey, TValue> headerGenerator(Function<Event<TKey, TValue>, EventHeader> headerGenerator) {
             if (headerGenerator != null) {
                 this.headerGenerators.add(headerGenerator);
             }

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/Event.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/Event.java
@@ -34,7 +34,7 @@ public interface Event<TKey, TValue> {
      *
      * @return Stream of headers
      */
-    Stream<Header> headers();
+    Stream<EventHeader> headers();
 
     /**
      * Provides a stream of header values for a specific header key
@@ -101,7 +101,7 @@ public interface Event<TKey, TValue> {
      * @param headers New headers
      * @return New event
      */
-    Event<TKey, TValue> replaceHeaders(Stream<Header> headers);
+    Event<TKey, TValue> replaceHeaders(Stream<EventHeader> headers);
 
     /**
      * Creates a new event appending the given headers to the existing headers
@@ -109,7 +109,7 @@ public interface Event<TKey, TValue> {
      * @param headers Additional headers
      * @return New event
      */
-    Event<TKey, TValue> addHeaders(Stream<Header> headers);
+    Event<TKey, TValue> addHeaders(Stream<EventHeader> headers);
 
     /**
      * Provides a reference back to the {@link EventSource} that produced this event instance

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/EventHeader.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/EventHeader.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * Interface for Event Headers which are Key Value pairs
+ */
+public interface EventHeader {
+
+    /**
+     * Header Key (aka Name)
+     *
+     * @return Key
+     */
+    String key();
+
+    /**
+     * Header value as a string
+     *
+     * @return String value
+     */
+    String value();
+
+    /**
+     * Header value as a raw byte sequence
+     *
+     * @return Raw byte value
+     */
+    @JsonIgnore
+    byte[] rawValue();
+}

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/RawHeader.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/RawHeader.java
@@ -17,31 +17,35 @@ package io.telicent.smart.cache.sources;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Objects;
 
 /**
- * Default implementation of an {@link EventHeader}
+ * Basic implementation of a Header that has a raw byte sequence value
+ *
+ * @param key      Key
+ * @param rawValue Raw value
  */
-public record Header(String key, String value) implements EventHeader {
-
+public record RawHeader(String key, byte[] rawValue) implements EventHeader {
     @Override
-    public String toString() {
-        return String.format("%s: %s", this.key, this.value);
+    public String value() {
+        return this.rawValue != null ? new String(this.rawValue, StandardCharsets.UTF_8) : null;
     }
 
     @Override
-    public byte[] rawValue() {
-        return this.value != null ? this.value.getBytes(StandardCharsets.UTF_8) : null;
+    public String toString() {
+        return String.format("%s: %,d bytes (%s)", this.key, this.rawValue != null ? this.rawValue.length : 0,
+                             this.rawValue != null ? Base64.getEncoder().encodeToString(this.rawValue) : null);
     }
 
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof EventHeader header)) return false;
-        return Objects.equals(key, header.key()) && Objects.deepEquals(this.rawValue(), header.rawValue());
+        return Objects.equals(key, header.key()) && Objects.deepEquals(rawValue, header.rawValue());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(key, Arrays.hashCode(this.rawValue()));
+        return Objects.hash(key, Arrays.hashCode(rawValue));
     }
 }

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/memory/SimpleEvent.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/memory/SimpleEvent.java
@@ -16,6 +16,7 @@
 package io.telicent.smart.cache.sources.memory;
 
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.EventSource;
 import io.telicent.smart.cache.sources.Header;
 import org.apache.commons.collections4.CollectionUtils;
@@ -33,7 +34,7 @@ import java.util.stream.Stream;
  */
 public class SimpleEvent<TKey, TValue> implements Event<TKey, TValue> {
 
-    private final List<Header> headers;
+    private final List<EventHeader> headers;
     private final TKey key;
     private final TValue value;
     private final EventSource source;
@@ -45,7 +46,7 @@ public class SimpleEvent<TKey, TValue> implements Event<TKey, TValue> {
      * @param key     Key
      * @param value   Value
      */
-    public SimpleEvent(Collection<Header> headers, TKey key, TValue value) {
+    public SimpleEvent(Collection<EventHeader> headers, TKey key, TValue value) {
         this(headers, key, value, null);
     }
 
@@ -57,7 +58,7 @@ public class SimpleEvent<TKey, TValue> implements Event<TKey, TValue> {
      * @param value   Value
      * @param source  Event source that originated this event
      */
-    public SimpleEvent(Collection<Header> headers, TKey key, TValue value, EventSource source) {
+    public SimpleEvent(Collection<EventHeader> headers, TKey key, TValue value, EventSource source) {
         this.headers = CollectionUtils.isNotEmpty(headers) ? new ArrayList<>(headers) : Collections.emptyList();
 
         // Note that an Event may have either a null key or value, however an event with both null is considered invalid
@@ -71,13 +72,13 @@ public class SimpleEvent<TKey, TValue> implements Event<TKey, TValue> {
     }
 
     @Override
-    public Stream<Header> headers() {
+    public Stream<EventHeader> headers() {
         return this.headers.stream();
     }
 
     @Override
     public Stream<String> headers(String key) {
-        return this.headers.stream().filter(h -> Objects.equals(h.key(), key)).map(Header::value);
+        return this.headers.stream().filter(h -> Objects.equals(h.key(), key)).map(EventHeader::value);
     }
 
     @Override
@@ -112,13 +113,13 @@ public class SimpleEvent<TKey, TValue> implements Event<TKey, TValue> {
     }
 
     @Override
-    public Event<TKey, TValue> replaceHeaders(Stream<Header> headers) {
+    public Event<TKey, TValue> replaceHeaders(Stream<EventHeader> headers) {
         return new SimpleEvent<>(headers.toList(), this.key, this.value, this.source);
     }
 
     @Override
-    public Event<TKey, TValue> addHeaders(Stream<Header> headers) {
-        List<Header> newHeaders = new ArrayList<>(this.headers);
+    public Event<TKey, TValue> addHeaders(Stream<EventHeader> headers) {
+        List<EventHeader> newHeaders = new ArrayList<>(this.headers);
         headers.forEach(newHeaders::add);
         return new SimpleEvent<>(newHeaders, this.key, this.value, this.source);
     }

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/AbstractEventSinkTests.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/AbstractEventSinkTests.java
@@ -17,6 +17,7 @@ package io.telicent.smart.cache.projectors.sinks.events;
 
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.EventSource;
 import io.telicent.smart.cache.sources.Header;
 import io.telicent.smart.cache.sources.memory.SimpleEvent;
@@ -48,7 +49,7 @@ public class AbstractEventSinkTests {
      * @param sourceSupplier  Source supplier
      */
     protected static void sendTestEvents(Sink<Event<String, String>> sink,
-                                         Function<String, Collection<Header>> headerGenerator,
+                                         Function<String, Collection<EventHeader>> headerGenerator,
                                          Supplier<EventSource<String, String>> sourceSupplier) {
         KEYS.forEach(k -> sink.send(
                 new SimpleEvent<>(headerGenerator.apply(k), k, StringUtils.repeat(k, 5), sourceSupplier.get())));

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/TestEventHeaderSink.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/projectors/sinks/events/TestEventHeaderSink.java
@@ -17,6 +17,7 @@ package io.telicent.smart.cache.projectors.sinks.events;
 
 import io.telicent.smart.cache.projectors.sinks.CollectorSink;
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.Header;
 import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
@@ -409,7 +410,7 @@ public class TestEventHeaderSink extends AbstractEventSinkTests {
             String name,
             String type) {
         // Given
-        List<Header> existing = new ArrayList<>();
+        List<EventHeader> existing = new ArrayList<>();
         if (StringUtils.isNotBlank(name)) {
             existing.add(new Header(DATA_SOURCE_NAME, name));
         }

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/memory/TestSimpleEvent.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/memory/TestSimpleEvent.java
@@ -16,6 +16,7 @@
 package io.telicent.smart.cache.sources.memory;
 
 import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
 import io.telicent.smart.cache.sources.EventSource;
 import io.telicent.smart.cache.sources.Header;
 import org.testng.Assert;
@@ -106,7 +107,7 @@ public class TestSimpleEvent {
 
     @Test
     public void event_headers_01() {
-        Collection<Header> headers = new ArrayList<>();
+        Collection<EventHeader> headers = new ArrayList<>();
         headers.add(new Header("Content-Type", "text/plain"));
         headers.add(new Header("Generator", this.getClass().getCanonicalName()));
         headers.add(new Header("Generator", TEST_VALUE));
@@ -127,7 +128,7 @@ public class TestSimpleEvent {
 
     @Test
     public void event_headers_02() {
-        Collection<Header> headers = new ArrayList<>();
+        Collection<EventHeader> headers = new ArrayList<>();
         headers.add(new Header("Generator", this.getClass().getCanonicalName()));
         headers.add(new Header("Generator", TEST_VALUE));
         SimpleEvent<String, String> event = new SimpleEvent<>(headers, TEST_KEY, TEST_VALUE);

--- a/event-sources/pom.xml
+++ b/event-sources/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-sources</artifactId>

--- a/jaxrs-base-server/pom.xml
+++ b/jaxrs-base-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jaxrs-base-server</artifactId>

--- a/jwt-auth-common/pom.xml
+++ b/jwt-auth-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <artifactId>jwt-auth-common</artifactId>
     <name>Telicent Smart Caches - JWT Authentication</name>

--- a/live-reporter/pom.xml
+++ b/live-reporter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <artifactId>live-reporter</artifactId>
     <name>Telicent Smart Caches - Live Reporter</name>

--- a/observability-core/pom.xml
+++ b/observability-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>observability-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.telicent.smart-caches</groupId>
     <artifactId>parent</artifactId>
-    <version>0.28.3-SNAPSHOT</version>
+    <version>0.29.0-SNAPSHOT</version>
     <modules>
         <module>projectors-core</module>
         <module>projector-driver</module>

--- a/projector-driver/pom.xml
+++ b/projector-driver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Projectors - Driver</name>

--- a/projectors-core/pom.xml
+++ b/projectors-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.28.3-SNAPSHOT</version>
+        <version>0.29.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Projectors - Core API</name>


### PR DESCRIPTION
This provides for the ability to access the raw `byte[]` value of a header, and also a new `RawHeader` implementation for event sources like Kafka that don't want to convert header values to `String` unnecessarily.

Various APIs are updated to use the `EventHeader` interface in preference to the existing `Header` implementation class.