### PR TITLE
Fix for ThroughputTracker with arbitrary increments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+# 0.29.1
+
+- Projectors Core improvements:
+    - Fixed a bug where calling `ThroughputTracker.itemsProcessed(int)` with irregular increments could cause reporting
+      to not trigger as intended
+- Build and test improvements:
+    - Upgraded Apache Kafka to 3.9.1
+    - Upgraded OpenTelemetry SDK to 1.50.0
+    - Upgraded various build and test dependencies to latest available
+
 # 0.29.0
 
 - Event Source Improvements:

--- a/docs/sinks/index.md
+++ b/docs/sinks/index.md
@@ -149,6 +149,37 @@ You can inspect the state of the tracker via various methods e.g. `receivedCount
 seen, `firstTime()` and `lastTime()` for when the tracker was started/received its first item and when it processed the
 last item, and `getOverallRate()` to get the overall processing rate for the lifetime of the tracker.
 
+If you process things in batches then you can use a `ThroughputTracker` to track that as well e.g.
+
+```java
+ThroughputTracker tracker 
+  = ThroughputTracker.create()
+                     .logger(someLogger)
+                     .reportInteval(100_000)
+                     .inSeconds()
+                     .action("Processed")
+                     .itemsName("Items")
+                     .build();
+tracker.start();
+while (someCondition) {
+    // Get items from somewhere...
+    List<Item> batch = new ArrayList();
+    for (Item item : someApiCall()) {
+      tracker.itemReceived();
+      batch.add(item);
+    }
+    // Do something with the batch of items...
+    processBatch(batch);
+
+    // Tell the tracker we processed the whole batch
+    tracker.itemProcessed(batch.size());
+}
+
+// Report throughput and reset when done
+tracker.reportThroughput();
+tracker.reset();
+```
+
 ## `PeriodicAction`
 
 Additionally, we have a `PeriodicAction` class which is a leaky bucket rate limiter using the "as a meter" semantics.

--- a/docs/sinks/throughput.md
+++ b/docs/sinks/throughput.md
@@ -6,8 +6,7 @@ encompasses the destination sink processing time thus represents the full proces
 pipeline that the sink wraps.
 
 Throughput metrics are reported based on a reporting batch size i.e. metrics are only reported when sufficient inputs
-have been seen.  Currently, these metrics are only reporting by logging them, future iterations of this API may expand
-this capability, however there is some control over how the metrics are presented in the log output.
+have been seen.  Metrics are reported by logging, and as OpenTelemetry [metrics](#metrics).
 
 Note that the actual tracking and reporting is actually provided via a separate class `ThroughputTracker` that can also
 be reused anywhere else you want throughput tracking independently of the `Sink` API itself.
@@ -66,7 +65,7 @@ Discarded 1,000,000 strings in 158 minutes at 6,329.114 strings/minutes
 
 Note that as shown in the above example output a `ThroughputSink` only reports throughput after inputs have been
 forwarded onto the destination sink for processing.  Therefore, the outermost sink in a pipeline (which in the above
-example is the sink from the innermost try with resources block) will be the one that reports metrics last.
+example is the first sink in the fluent builder definition) will be the one that reports metrics last.
 
 # Metrics
 


### PR DESCRIPTION
While debugging other issues it was noticed that if the `ThroughputTracker` increments the `itemsProcessed()` in arbitrary increments that don't perfectly align with the reporting batch size then reporting could be unintentionally suppressed.

This commit fixes the logic so that we always trigger a throughput report when we reach/exceed the reporting batch boundary