### PR TITLE
Fix commit after long delay for Kafka (CORE-861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+# 0.29.2
+
+- Kafka Event Source improvements:
+    - Fixed a bug where the `KafkaEventSource` could throw an error if trying to commit after being removed from a
+      consumer group due to rebalance/timeout.  In this scenario a warning is now logged and consumption resumes from
+      the most recently committed offset upon the next `poll()` call.
+
 # 0.29.1
 
 - Projectors Core improvements:

--- a/docs/event-sources/kafka.md
+++ b/docs/event-sources/kafka.md
@@ -95,6 +95,13 @@ Alternatively, auto-commit may be disabled, in which case offsets are only commi
 when the Kafka source is connected to a data processing pipeline and wants to only update offsets when it has finished
 processing events, rather than merely having read them as with the default auto-commit behaviour.
 
+Whichever behaviour is used bear in mind if an application does not call `poll()` on a regular basis then it may be
+automatically removed from the Consumer Group due to inactivity and its partitions reassigned, either to itself or
+another application in the group at a later point in time.  When this happens any attempt to commit offsets may fail and
+event consumption for the affected partitions (once reassinged) resumes from the previously committed offsets.
+Therefore applications **SHOULD** be implemented such that event processing is idempotent to cope with this possibility
+that some events **MAY** be received more than once.
+
 ## Parameters
 
 The primary parameters are the bootstrap servers for connecting to Kafka, the topic to read and the Consumer Group ID.

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.consumer.InvalidOffsetException;
 import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.*;
 import org.slf4j.Logger;
@@ -250,7 +251,7 @@ public class KafkaEventSource<TKey, TValue>
                         // If there's no buffered events we've consumed everything from our last poll() so can use
                         // Kafka's no argument commitSync() method to just commit offsets based on our last poll()
                         // results
-                        this.consumer.commitSync();
+                        this.tryAutoCommit();
                     } else {
                         // Since we have some events buffered we cannot do a simple commitSync() since that would commit
                         // as if we had processed all the buffered events, which we have not!
@@ -413,7 +414,16 @@ public class KafkaEventSource<TKey, TValue>
         // If we are no longer assigned a given partition we aren't permitted to commit an offset for it
         commitOffsets.entrySet().removeIf(e -> !this.consumer.assignment().contains(e.getKey()));
         if (!commitOffsets.isEmpty()) {
-            this.consumer.commitSync(commitOffsets);
+            try {
+                this.consumer.commitSync(commitOffsets);
+            } catch (KafkaException e) {
+                // If we've been removed from the consumer group then it's an acceptable failure, otherwise throw
+                if (isAcceptableCommitFailure(e)) {
+                    logAcceptableCommitFailure();
+                } else {
+                    throw e;
+                }
+            }
         } else {
             noOffsetsToCommit();
         }
@@ -499,13 +509,7 @@ public class KafkaEventSource<TKey, TValue>
             // Don't do this on the first run since we won't have called KafkaConsumer.poll() yet so there's nothing to
             // commit
             if (this.autoCommit) {
-                try {
-                    this.consumer.commitSync();
-                } catch (WakeupException e) {
-                    // Ignore, this is recoverable, likely caused by a previous KafkaConsumer.wakeUp() call
-                    // We can try again immediately
-                    this.consumer.commitSync();
-                }
+                tryAutoCommit();
             }
         } else {
             // This is the point where the consumer is actually connected to Kafka.  It is intentionally delayed to the
@@ -528,6 +532,64 @@ public class KafkaEventSource<TKey, TValue>
             Runtime.getRuntime().addShutdownHook(new Thread(new Interrupter(this.consumer)));
         }
         this.firstRun = false;
+    }
+
+    /**
+     * Tries to automatically commit offsets
+     */
+    protected void tryAutoCommit() {
+        try {
+            this.consumer.commitSync();
+        } catch (WakeupException e) {
+            // Ignore, this is recoverable, likely caused by a previous KafkaConsumer.wakeUp() call
+            // We can try again immediately
+            try {
+                this.consumer.commitSync();
+            } catch (KafkaException e1) {
+                if (isAcceptableCommitFailure(e1)) {
+                    // Acceptable, just issue a warning
+                    logAcceptableCommitFailure();
+                } else {
+                    throw e;
+                }
+            }
+        } catch (KafkaException e) {
+            if (isAcceptableCommitFailure(e)) {
+                // Acceptable, just issue a warning
+                logAcceptableCommitFailure();
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Logs that a commit failure was considered acceptable
+     */
+    protected static void logAcceptableCommitFailure() {
+        LOGGER.warn(
+                "Failed to commit offsets, not currently part of an active group due to partition reassignment.  Some events may be reprocessed as a result.");
+    }
+
+    /**
+     * Checks whether the commit failure is acceptable
+     *
+     * @param e Commit failure
+     * @return True if acceptable, false otherwise
+     */
+    protected static boolean isAcceptableCommitFailure(KafkaException e) {
+        if (e instanceof CommitFailedException cfEx) {
+            // If the consumer got removed from the group, for whatever reason, then this could fail
+            // We detect this case by looking at the error message, and if so just issue a warning and continue,
+            // since we're likely to be reassigned partitions at a future date
+            return StringUtils.containsIgnoreCase(cfEx.getMessage(), "not part of an active group");
+        } else if (e instanceof RebalanceInProgressException) {
+            // If a rebalance is in progress we're not permitted to commit offsets either, again this is recoverable
+            // once rebalance completes in a future poll() call
+            return true;
+        }
+        // Any other error is not considered acceptable
+        return false;
     }
 
     private static Duration updateTimeout(long start, Duration timeout) {

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/automatic/AbstractAutoReadPolicy.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/automatic/AbstractAutoReadPolicy.java
@@ -115,7 +115,7 @@ public abstract class AbstractAutoReadPolicy<TKey, TValue> extends AbstractReadP
     @Override
     public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
         Set<String> affectedTopics = getAffectedTopics(partitions);
-        LOGGER.info("Assigned {} partitions for Kafka topic {}", partitions.size(),
+        LOGGER.info("Assigned {} partitions for Kafka topic(s) {}", partitions.size(),
                     StringUtils.join(affectedTopics, ", "));
         seek(partitions);
         logPartitionPositions(partitions, LOGGER);

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaPollingTimeout.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaPollingTimeout.java
@@ -1,0 +1,275 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka;
+
+import com.github.valfirst.slf4jtest.LoggingEvent;
+import com.github.valfirst.slf4jtest.TestLogger;
+import com.github.valfirst.slf4jtest.TestLoggerFactory;
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.kafka.policies.automatic.AbstractAutoReadPolicy;
+import io.telicent.smart.cache.sources.kafka.sinks.KafkaSink;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.internals.ConsumerCoordinator;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.event.Level;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+public class DockerTestKafkaPollingTimeout {
+
+    private static final AtomicInteger GROUP_ID = new AtomicInteger();
+
+    private BasicKafkaTestCluster kafka;
+    private final TestLogger eventSourceLogger = TestLoggerFactory.getTestLogger(KafkaEventSource.class);
+    private final TestLogger readPolicyLogger = TestLoggerFactory.getTestLogger(AbstractAutoReadPolicy.class);
+    private final TestLogger consumerCoordinatorLogger = TestLoggerFactory.getTestLogger(ConsumerCoordinator.class);
+
+    @BeforeClass
+    public void setup() {
+        Utils.logTestClassStarted(this.getClass());
+        this.kafka = new BasicKafkaTestCluster();
+        this.kafka.setup();
+    }
+
+    @AfterClass
+    public void teardown() {
+        this.kafka.teardown();
+        Utils.logTestClassFinished(this.getClass());
+    }
+
+    @AfterMethod
+    public void testCleanup() throws InterruptedException {
+        this.kafka.resetTestTopic();
+        this.consumerCoordinatorLogger.clearAll();
+        this.eventSourceLogger.clearAll();
+        this.readPolicyLogger.clearAll();
+    }
+
+    public void verifyLogging(TestLogger logger, Level level, String... searchTerms) {
+        List<LoggingEvent> logs =
+                logger.getAllLoggingEvents().stream().filter(event -> event.getLevel() == level).toList();
+        Assert.assertNotEquals(logs.size(), 0, "Expected at least one logging event at level " + level);
+        for (String searchTerm : searchTerms) {
+            Assert.assertTrue(logs.stream().anyMatch(event -> event.getFormattedMessage().contains(searchTerm)),
+                              "Logs were missing expected message '" + searchTerm + "'");
+        }
+    }
+
+    @Test
+    public void givenKafkaSource_whenLongDelayBetweenPoll_thenReceivesSubsequentEvents_andLoggingAsExpected() throws
+            InterruptedException {
+        // Given
+        KafkaEventSource<Integer, String> source = createSource();
+        try {
+            // When
+            Event<Integer, String> event = source.poll(Duration.ofSeconds(3));
+            Assert.assertNull(event);
+            Thread.sleep(7500);
+            sendTestEvent();
+
+            // Then
+            event = source.poll(Duration.ofSeconds(3));
+            verifyTestEvent(event);
+
+            // And
+            verifyLogging(consumerCoordinatorLogger, Level.WARN, "consumer poll timeout has expired");
+            verifyLogging(eventSourceLogger, Level.WARN, "Failed to commit offsets");
+            verifyLogging(readPolicyLogger, Level.INFO, "Assigned 1 partitions for Kafka topic(s) tests",
+                          "Revoked 1 partitions for Kafka topic(s) tests");
+        } finally {
+            source.close();
+        }
+    }
+
+    private void sendTestEvent() {
+        try (KafkaSink<Integer, String> sink = createSink()) {
+            sink.send(new SimpleEvent<>(Collections.emptyList(), 1, "test"));
+        }
+    }
+
+    private KafkaEventSource<Integer, String> createSource() {
+        return createSource(x -> x);
+    }
+
+    private KafkaEventSource<Integer, String> createSource(
+            Function<KafkaEventSource.Builder<Integer, String>, KafkaEventSource.Builder<Integer, String>> customiser) {
+        return customiser.apply(KafkaEventSource.<Integer, String>create()
+                                                .bootstrapServers(this.kafka.getBootstrapServers())
+                                                .topic(KafkaTestCluster.DEFAULT_TOPIC)
+                                                .consumerConfig(this.kafka.getClientProperties())
+                                                .consumerConfig(
+                                                        ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG,
+                                                        "5000")
+                                                .consumerConfig(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "10000")
+                                                .consumerGroup(
+                                                        "long-poll-delay" + GROUP_ID.incrementAndGet())
+                                                .keyDeserializer(IntegerDeserializer.class)
+                                                .valueDeserializer(StringDeserializer.class))
+                         .build();
+    }
+
+    @Test
+    public void givenKafkaSource_whenLongDelayBetweenPollExceedsSessionTimeout_thenReceivesSubsequentEvents_andLoggingAsExpected() throws
+            InterruptedException {
+        // Given
+        KafkaEventSource<Integer, String> source = createSource();
+        try {
+            // When
+            Event<Integer, String> event = source.poll(Duration.ofSeconds(3));
+            Assert.assertNull(event);
+            Thread.sleep(12500);
+            sendTestEvent();
+
+            // Then
+            event = source.poll(Duration.ofSeconds(3));
+            verifyTestEvent(event);
+
+            // And
+            verifyLogging(consumerCoordinatorLogger, Level.WARN, "consumer poll timeout has expired");
+            verifyLogging(eventSourceLogger, Level.WARN, "Failed to commit offsets");
+        } finally {
+            source.close();
+        }
+    }
+
+    private static void verifyTestEvent(Event<Integer, String> event) {
+        Assert.assertNotNull(event);
+        Assert.assertEquals(event.key(), 1);
+        Assert.assertEquals(event.value(), "test");
+    }
+
+    private @NotNull KafkaSink<Integer, String> createSink() {
+        return KafkaSink.<Integer, String>create()
+                        .bootstrapServers(this.kafka.getBootstrapServers())
+                        .topic(KafkaTestCluster.DEFAULT_TOPIC)
+                        .producerConfig(this.kafka.getClientProperties())
+                        .keySerializer(IntegerSerializer.class)
+                        .valueSerializer(StringSerializer.class)
+                        .noLinger()
+                        .noAsync()
+                        .build();
+    }
+
+    @Test
+    public void givenKafkaSource_whenLongDelayBetweenPollAndCommit_thenRereadsEvent_andLoggingAsExpected() throws
+            InterruptedException {
+        // Given
+        KafkaEventSource<Integer, String> source = createSource(AbstractKafkaEventSourceBuilder::commitOnProcessed);
+        sendTestEvent();
+        try {
+            // When
+            Event<Integer, String> event = source.poll(Duration.ofSeconds(3));
+            verifyTestEvent(event);
+            Thread.sleep(7500);
+            source.processed(List.of(event));
+
+            // Then
+            // NB - In this scenario we failed to commit and when we rejoined the group we have no committed offsets so
+            //      we re-read from our previous starting point
+            event = source.poll(Duration.ofSeconds(3));
+            verifyTestEvent(event);
+
+            // And
+            verifyLogging(consumerCoordinatorLogger, Level.WARN, "consumer poll timeout has expired");
+            verifyLogging(eventSourceLogger, Level.WARN, "Failed to commit offsets");
+            verifyLogging(readPolicyLogger, Level.INFO, "Assigned 1 partitions for Kafka topic(s) tests",
+                          "Revoked 1 partitions for Kafka topic(s) tests");
+        } finally {
+            source.close();
+        }
+    }
+
+    @Test
+    public void givenKafkaSource_whenDecreasingDelayBetweenPollAndCommit_thenRereadsEventUntilDelayShortEnough_andLoggingAsExpected() throws
+            InterruptedException {
+        // Given
+        KafkaEventSource<Integer, String> source = createSource(AbstractKafkaEventSourceBuilder::commitOnProcessed);
+        sendTestEvent();
+        try {
+            // When
+            Event<Integer, String> event = source.poll(Duration.ofSeconds(3));
+            verifyTestEvent(event);
+            for (long delay = 7500; delay > 0; delay -= 2500) {
+                Thread.sleep(delay + 50);
+                source.processed(List.of(event));
+
+                // Then
+                // NB - In this scenario if the delay was too long we would have failed to commit, then on rejoin
+                //      re-read the event again.  If the delay was short enough commit would be successful and we'd
+                //      reach the end of the topic
+                event = source.poll(Duration.ofSeconds(3));
+                if (delay >= 5000) {
+                    verifyTestEvent(event);
+                } else {
+                    // Once delay is short enough should no longer read event as commit will be successful
+                    Assert.assertNull(event);
+                    break;
+                }
+            }
+
+            // And
+            verifyLogging(consumerCoordinatorLogger, Level.WARN, "consumer poll timeout has expired");
+            verifyLogging(eventSourceLogger, Level.WARN, "Failed to commit offsets");
+            verifyLogging(readPolicyLogger, Level.INFO, "Assigned 1 partitions for Kafka topic(s) tests",
+                          "Revoked 1 partitions for Kafka topic(s) tests");
+        } finally {
+            source.close();
+        }
+    }
+
+    @Test
+    public void givenKafkaSource_whenLongDelayAfterCommit_thenNoFurtherEvents_andLoggingAsExpected() throws
+            InterruptedException {
+        // Given
+        KafkaEventSource<Integer, String> source = createSource(AbstractKafkaEventSourceBuilder::commitOnProcessed);
+        sendTestEvent();
+        try {
+            // When
+            Event<Integer, String> event = source.poll(Duration.ofSeconds(3));
+            verifyTestEvent(event);
+            source.processed(List.of(event));
+            Thread.sleep(7500);
+
+            // Then
+            // NB - In this scenario we would have committed our offsets but then been booted from the group due to our
+            //      delay before calling poll() again, however since our offsets were committed we won't re-read the
+            //      event again
+            event = source.poll(Duration.ofSeconds(3));
+            Assert.assertNull(event);
+
+            // And
+            verifyLogging(consumerCoordinatorLogger, Level.WARN, "consumer poll timeout has expired");
+            verifyLogging(readPolicyLogger, Level.INFO, "Assigned 1 partitions for Kafka topic(s) tests",
+                          "Revoked 1 partitions for Kafka topic(s) tests");
+        } finally {
+            source.close();
+        }
+    }
+}


### PR DESCRIPTION
If attempting to commit after a long delay from the preceding `poll()` call the consumer may have been kicked from the group due to inactivity/timeout.  In this case a commit failure is acceptable and should only produce a warning.  Then on subsequent `poll()` calls the consumer will rejoin the group if needed, potentially reprocessing some events.

Adds new integration tests to verify various scenarios around this.

# Related Issues and PRs

- This is the root cause for behaviour seen testing telicent-oss/smart-cache-graph#247, due to compaction holding an exclusive lock on the dataset Fuseki Kafka (which uses these libraries) has a long delay between `poll()` and `commit()` with the failed commit causing projection to abort