### PR TITLE
Ensure CycloneDX SBOMs are produced (CORE-852)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -668,6 +668,7 @@
                 </executions>
                 <configuration>
                     <outputName>${project.artifactId}-${project.version}-bom</outputName>
+                    <skipNotDeployed>false</skipNotDeployed>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Workaround a buggy interaction between Maven Central and CycloneDX plugins that causes SBOMs to not be produced