### PR TITLE
[Minor] Addressing build warnings

### DIFF
--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/commands/projection/AbstractProjectorCommand.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/commands/projection/AbstractProjectorCommand.java
@@ -97,7 +97,7 @@ public abstract class AbstractProjectorCommand<TKey, TValue, TOutput> extends Sm
      * Provides file source options
      */
     @AirlineModule
-    protected FileSourceOptions<TKey, TValue> fileSourceOptions = new FileSourceOptions();
+    protected FileSourceOptions<TKey, TValue> fileSourceOptions = new FileSourceOptions<>();
 
     /**
      * Provides health probe server options

--- a/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/TestHelpCommand.java
+++ b/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/TestHelpCommand.java
@@ -20,6 +20,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class TestHelpCommand extends AbstractCommandTests {
 
     @Test
@@ -33,7 +35,7 @@ public class TestHelpCommand extends AbstractCommandTests {
         Assert.assertTrue(StringUtils.isBlank(SmartCacheCommandTester.getLastStdOut()));
         String lastStdErr = SmartCacheCommandTester.getLastStdErr();
         Assert.assertFalse(StringUtils.isBlank(lastStdErr));
-        Assert.assertTrue(StringUtils.contains(lastStdErr.trim(), HelpCommand.UNABLE_TO_SHOW_HELP));
+        Assert.assertTrue(CS.contains(lastStdErr.trim(), HelpCommand.UNABLE_TO_SHOW_HELP));
     }
 
     @Test
@@ -47,6 +49,6 @@ public class TestHelpCommand extends AbstractCommandTests {
         Assert.assertTrue(StringUtils.isBlank(SmartCacheCommandTester.getLastStdOut()));
         String lastStdErr = SmartCacheCommandTester.getLastStdErr();
         Assert.assertFalse(StringUtils.isBlank(lastStdErr));
-        Assert.assertTrue(StringUtils.contains(lastStdErr.trim(), HelpCommand.UNABLE_TO_SHOW_HELP));
+        Assert.assertTrue(CS.contains(lastStdErr.trim(), HelpCommand.UNABLE_TO_SHOW_HELP));
     }
 }

--- a/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/backup/DockerTestActionTracker.java
+++ b/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/backup/DockerTestActionTracker.java
@@ -31,7 +31,12 @@ import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.apache.commons.lang3.Strings.CS;
 
 public class DockerTestActionTracker extends AbstractCommandTests {
 
@@ -100,7 +105,7 @@ public class DockerTestActionTracker extends AbstractCommandTests {
             hasLine(secondaryLines, "Paused");
             hasLine(secondaryLines, "state READY");
             hasLine(secondaryLines, "state PROCESSING");
-            Assert.assertTrue(StringUtils.contains(secondaryLines.get(secondaryLines.size() - 2), "Working"));
+            Assert.assertTrue(CS.contains(secondaryLines.get(secondaryLines.size() - 2), "Working"));
         } finally {
             executor.shutdownNow();
         }
@@ -155,6 +160,6 @@ public class DockerTestActionTracker extends AbstractCommandTests {
     }
 
     private static void hasLine(List<String> lines, String expected) {
-        Assert.assertTrue(lines.stream().anyMatch(line -> StringUtils.contains(line, expected)));
+        Assert.assertTrue(lines.stream().anyMatch(line -> CS.contains(line, expected)));
     }
 }

--- a/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/projection/DockerTestDeadLetterQueue.java
+++ b/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/projection/DockerTestDeadLetterQueue.java
@@ -44,6 +44,8 @@ import java.nio.file.Files;
 import java.time.Duration;
 import java.util.*;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class DockerTestDeadLetterQueue extends AbstractCommandTests {
 
     public static final String DEAD_LETTER_TOPIC = "dead-letters";
@@ -212,7 +214,7 @@ public class DockerTestDeadLetterQueue extends AbstractCommandTests {
         // Then
         Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 1);
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "ClassCastException"));
+        Assert.assertTrue(CS.contains(stdErr, "ClassCastException"));
     }
 
     @Test

--- a/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/projection/TransformingProjectorCommand.java
+++ b/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/projection/TransformingProjectorCommand.java
@@ -34,7 +34,7 @@ public class TransformingProjectorCommand
         extends AbstractKafkaProjectorCommand<String, String, Event<Integer, String>> {
 
     @AirlineModule
-    public DeadLetterTestingOptions<Integer, String> deadLetterTestingOptions = new DeadLetterTestingOptions();
+    public DeadLetterTestingOptions<Integer, String> deadLetterTestingOptions = new DeadLetterTestingOptions<>();
 
     public static void main(String[] args) {
         SmartCacheCommand.runAsSingleCommand(TransformingProjectorCommand.class, args);
@@ -88,20 +88,5 @@ public class TransformingProjectorCommand
         return new PeriodicDeadLetterSink<>(this.deadLetterTestingOptions.successful,
                                             this.deadLetterTestingOptions.deadLetterFrequency,
                                             deadLetters);
-    }
-
-    @Override
-    protected <K, V> Sink<Event<K, V>> prepareDeadLetterSink(String dlqTopic, Class<?> keySerializer,
-                                                             Class<?> valueSerializer) {
-        if (StringUtils.isBlank(dlqTopic)) return null;
-
-        return KafkaSink.<K, V>create()
-                        .bootstrapServers(this.kafka.bootstrapServers)
-                        .topic(dlqTopic)
-                        .keySerializer(keySerializer)
-                        .valueSerializer(valueSerializer)
-                        .producerConfig(this.kafka.getAdditionalProperties())
-                        .lingerMs(5)
-                        .build();
     }
 }

--- a/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/options/TestLoggerCommand.java
+++ b/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/options/TestLoggerCommand.java
@@ -18,6 +18,7 @@ package io.telicent.smart.cache.cli.options;
 import io.telicent.smart.cache.cli.commands.AbstractCommandTests;
 
 import static io.telicent.smart.cache.cli.options.LoggingCommand.*;
+import static org.apache.commons.lang3.Strings.CS;
 
 import io.telicent.smart.cache.cli.commands.SmartCacheCommandTester;
 import org.apache.commons.lang3.StringUtils;
@@ -38,12 +39,12 @@ public class TestLoggerCommand extends AbstractCommandTests {
         String stdErr = SmartCacheCommandTester.getLastStdErr();
 
         for (String message : expected) {
-            Assert.assertTrue(StringUtils.contains(stdErr, message),
+            Assert.assertTrue(CS.contains(stdErr, message),
                               "Standard error missing expected message " + message);
         }
 
         for (String message : unexpected) {
-            Assert.assertFalse(StringUtils.contains(stdErr, message),
+            Assert.assertFalse(CS.contains(stdErr, message),
                                "Standard error contains unexpected message " + message);
         }
     }

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractDockerDebugCliTests.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/AbstractDockerDebugCliTests.java
@@ -42,7 +42,6 @@ import io.telicent.smart.cache.sources.kafka.policies.KafkaReadPolicies;
 import io.telicent.smart.cache.sources.kafka.sinks.KafkaSink;
 import io.telicent.smart.cache.sources.memory.SimpleEvent;
 import io.telicent.smart.cache.sources.offsets.file.AbstractJacksonOffsetStore;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.sys.JenaSystem;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -60,6 +59,7 @@ import java.util.Collections;
 import java.util.Objects;
 
 import static io.telicent.smart.cache.cli.commands.debug.TestLogUtil.enableSpecificLogging;
+import static org.apache.commons.lang3.Strings.CS;
 
 public class AbstractDockerDebugCliTests extends AbstractCommandTests {
 
@@ -72,7 +72,7 @@ public class AbstractDockerDebugCliTests extends AbstractCommandTests {
     public static void verifyEvents(String format) {
         String stdOut = SmartCacheCommandTester.getLastStdOut();
         for (int i = 1; i <= 1_000; i++) {
-            boolean eventFound = StringUtils.contains(stdOut, String.format(format, i));
+            boolean eventFound = CS.contains(stdOut, String.format(format, i));
             if (!eventFound) {
                 SmartCacheCommandTester.printToOriginalStdOut(
                         "Missing expected event, command standard error is displayed below:");
@@ -98,7 +98,7 @@ public class AbstractDockerDebugCliTests extends AbstractCommandTests {
             for (int i = 1; i <= 1_000; i++) {
                 Event<String, String> event = source.poll(Duration.ofSeconds(3));
                 Assert.assertNotNull(event, "Missing event " + i);
-                Assert.assertTrue(StringUtils.contains(event.value(), String.format(format, i)),
+                Assert.assertTrue(CS.contains(event.value(), String.format(format, i)),
                                   "Wrong value for event " + i);
             }
         } finally {

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliCaptureCommand.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliCaptureCommand.java
@@ -21,13 +21,14 @@ import io.telicent.smart.cache.sources.file.text.PlainTextFormat;
 import io.telicent.smart.cache.sources.file.yaml.YamlFormat;
 import io.telicent.smart.cache.sources.kafka.FlakyKafkaTest;
 import io.telicent.smart.cache.sources.kafka.KafkaTestCluster;
-import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+
+import static org.apache.commons.lang3.Strings.CS;
 
 public class DockerTestDebugCliCaptureCommand extends AbstractDockerDebugCliTests {
 
@@ -59,11 +60,11 @@ public class DockerTestDebugCliCaptureCommand extends AbstractDockerDebugCliTest
         verifyCaptureCommandUsed();
         String stdErr = SmartCacheCommandTester.getLastStdErr();
         // Expecting a DEBUG statement from KafkaEventSource
-        Assert.assertTrue(StringUtils.contains(stdErr, "Currently no new events available"));
+        Assert.assertTrue(CS.contains(stdErr, "Currently no new events available"));
         // Expecting NOT to receive a WARN statement from LiveReporterOptions
-        Assert.assertFalse(StringUtils.contains(stdErr, "live heartbeats are not being reported anywhere"));
+        Assert.assertFalse(CS.contains(stdErr, "live heartbeats are not being reported anywhere"));
         // Expecting an INFO statement from LiveReporter
-        Assert.assertTrue(StringUtils.contains(stdErr, "Background Live Reporter thread started"));
+        Assert.assertTrue(CS.contains(stdErr, "Background Live Reporter thread started"));
         // Expect no captured events
         File[] files = captureDir.listFiles();
         Assert.assertNotNull(files);
@@ -98,11 +99,11 @@ public class DockerTestDebugCliCaptureCommand extends AbstractDockerDebugCliTest
         verifyCaptureCommandUsed();
         String stdErr = SmartCacheCommandTester.getLastStdErr();
         // Expecting a DEBUG statement from KafkaEventSource
-        Assert.assertTrue(StringUtils.contains(stdErr, "Currently no new events available"));
+        Assert.assertTrue(CS.contains(stdErr, "Currently no new events available"));
         // Expecting NOT to receive a WARN statement from LiveReporterOptions
-        Assert.assertFalse(StringUtils.contains(stdErr, "live heartbeats are not being reported anywhere"));
+        Assert.assertFalse(CS.contains(stdErr, "live heartbeats are not being reported anywhere"));
         // Expecting an INFO statement from LiveReporter
-        Assert.assertTrue(StringUtils.contains(stdErr, "Background Live Reporter thread started"));
+        Assert.assertTrue(CS.contains(stdErr, "Background Live Reporter thread started"));
         // Verify capture
         verifyCapturedEvents(captureDir, YamlFormat.NAME, "Event %,d");
     }
@@ -138,11 +139,11 @@ public class DockerTestDebugCliCaptureCommand extends AbstractDockerDebugCliTest
         verifyCaptureCommandUsed();
         String stdErr = SmartCacheCommandTester.getLastStdErr();
         // Expecting a DEBUG statement from KafkaEventSource
-        Assert.assertTrue(StringUtils.contains(stdErr, "Currently no new events available"));
+        Assert.assertTrue(CS.contains(stdErr, "Currently no new events available"));
         // Expecting NOT to receive a WARN statement from LiveReporterOptions
-        Assert.assertFalse(StringUtils.contains(stdErr, "live heartbeats are not being reported anywhere"));
+        Assert.assertFalse(CS.contains(stdErr, "live heartbeats are not being reported anywhere"));
         // Expecting an INFO statement from LiveReporter
-        Assert.assertTrue(StringUtils.contains(stdErr, "Background Live Reporter thread started"));
+        Assert.assertTrue(CS.contains(stdErr, "Background Live Reporter thread started"));
         // Verify capture
         verifyCapturedEvents(captureDir, PlainTextFormat.NAME, "Event %,d");
     }
@@ -177,11 +178,11 @@ public class DockerTestDebugCliCaptureCommand extends AbstractDockerDebugCliTest
         verifyCaptureCommandUsed();
         String stdErr = SmartCacheCommandTester.getLastStdErr();
         // Expecting a DEBUG statement from KafkaEventSource
-        Assert.assertTrue(StringUtils.contains(stdErr, "Currently no new events available"));
+        Assert.assertTrue(CS.contains(stdErr, "Currently no new events available"));
         // Expecting NOT to receive a WARN statement from LiveReporterOptions
-        Assert.assertFalse(StringUtils.contains(stdErr, "live heartbeats are not being reported anywhere"));
+        Assert.assertFalse(CS.contains(stdErr, "live heartbeats are not being reported anywhere"));
         // Expecting an INFO statement from LiveReporter
-        Assert.assertTrue(StringUtils.contains(stdErr, "Background Live Reporter thread started"));
+        Assert.assertTrue(CS.contains(stdErr, "Background Live Reporter thread started"));
         // Verify capture
         verifyCapturedEvents(captureDir, RdfFormat.NAME, "<http://subject> <http://predicate> \"%d\" .");
     }

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliDumpCommand.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliDumpCommand.java
@@ -28,6 +28,8 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class DockerTestDebugCliDumpCommand extends AbstractDockerDebugCliTests {
 
     @Test(retryAnalyzer = FlakyKafkaTest.class)
@@ -54,9 +56,9 @@ public class DockerTestDebugCliDumpCommand extends AbstractDockerDebugCliTests {
         // Then
         verifyDumpCommandUsed();
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "Currently no new events available"));
-        Assert.assertFalse(StringUtils.contains(stdErr, "live heartbeats are not being reported anywhere"));
-        Assert.assertTrue(StringUtils.contains(stdErr, "Background Live Reporter thread started"));
+        Assert.assertTrue(CS.contains(stdErr, "Currently no new events available"));
+        Assert.assertFalse(CS.contains(stdErr, "live heartbeats are not being reported anywhere"));
+        Assert.assertTrue(CS.contains(stdErr, "Background Live Reporter thread started"));
     }
 
     @Test(retryAnalyzer = FlakyKafkaTest.class)
@@ -84,9 +86,9 @@ public class DockerTestDebugCliDumpCommand extends AbstractDockerDebugCliTests {
         verifyDumpCommandUsed();
         verifyEvents("Event %,d");
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "Currently no new events available"));
-        Assert.assertFalse(StringUtils.contains(stdErr, "live heartbeats are not being reported anywhere"));
-        Assert.assertTrue(StringUtils.contains(stdErr, "Background Live Reporter thread started"));
+        Assert.assertTrue(CS.contains(stdErr, "Currently no new events available"));
+        Assert.assertFalse(CS.contains(stdErr, "live heartbeats are not being reported anywhere"));
+        Assert.assertTrue(CS.contains(stdErr, "Background Live Reporter thread started"));
     }
 
     @Test(retryAnalyzer = FlakyKafkaTest.class)
@@ -111,11 +113,11 @@ public class DockerTestDebugCliDumpCommand extends AbstractDockerDebugCliTests {
         // Then
         verifyDumpCommandUsed();
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "all events have been exhausted"));
+        Assert.assertTrue(CS.contains(stdErr, "all events have been exhausted"));
 
         // And
-        Assert.assertTrue(StringUtils.contains(stdErr, "live heartbeats are not being reported anywhere"));
-        Assert.assertTrue(StringUtils.contains(stdErr, "Background Live Reporter thread started"));
+        Assert.assertTrue(CS.contains(stdErr, "live heartbeats are not being reported anywhere"));
+        Assert.assertTrue(CS.contains(stdErr, "Background Live Reporter thread started"));
         verifyHeartbeats(false);
     }
 
@@ -143,11 +145,11 @@ public class DockerTestDebugCliDumpCommand extends AbstractDockerDebugCliTests {
         // Then
         verifyDumpCommandUsed();
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "all events have been exhausted"));
+        Assert.assertTrue(CS.contains(stdErr, "all events have been exhausted"));
 
         // And
-        Assert.assertFalse(StringUtils.contains(stdErr, "live heartbeats are not being reported anywhere"));
-        Assert.assertTrue(StringUtils.contains(stdErr, "Background Live Reporter thread started"));
+        Assert.assertFalse(CS.contains(stdErr, "live heartbeats are not being reported anywhere"));
+        Assert.assertTrue(CS.contains(stdErr, "Background Live Reporter thread started"));
         verifyHeartbeats(true);
     }
 
@@ -186,7 +188,7 @@ public class DockerTestDebugCliDumpCommand extends AbstractDockerDebugCliTests {
         Assert.assertEquals(store.<Long>loadOffset(
                 KafkaEventSource.externalOffsetStoreKey(KafkaTestCluster.DEFAULT_TOPIC, 0, "dump")), 10L);
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "no persistent offsets"));
+        Assert.assertTrue(CS.contains(stdErr, "no persistent offsets"));
     }
 
     @Test(expectedExceptions = IllegalStateException.class)
@@ -225,6 +227,6 @@ public class DockerTestDebugCliDumpCommand extends AbstractDockerDebugCliTests {
         Assert.assertNull(
                 store.loadOffset(KafkaEventSource.externalOffsetStoreKey(KafkaTestCluster.DEFAULT_TOPIC, 0, "dump")));
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "failed to store offsets"));
+        Assert.assertTrue(CS.contains(stdErr, "failed to store offsets"));
     }
 }

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliFakeReporterCommand.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliFakeReporterCommand.java
@@ -38,6 +38,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.apache.commons.lang3.Strings.CI;
+
 public class DockerTestDebugCliFakeReporterCommand extends AbstractDockerDebugCliTests {
 
     private final Client client = ClientBuilder.newClient();
@@ -153,7 +155,7 @@ public class DockerTestDebugCliFakeReporterCommand extends AbstractDockerDebugCl
         Assert.assertEquals(response.getStatus(), Response.Status.SERVICE_UNAVAILABLE.getStatusCode());
         HealthStatus status = response.readEntity(HealthStatus.class);
         Assert.assertFalse(status.isHealthy());
-        Assert.assertTrue(status.reasons().stream().anyMatch(r -> StringUtils.containsIgnoreCase(r, "Unhealthy")));
+        Assert.assertTrue(status.reasons().stream().anyMatch(r -> CI.contains(r, "Unhealthy")));
 
         // And
         verifyFakeReporter(task);

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliMutualTlsKafka.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliMutualTlsKafka.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.util.*;
 
 import static io.telicent.smart.cache.cli.commands.debug.TestLogUtil.enableSpecificLogging;
+import static org.apache.commons.lang3.Strings.CS;
 
 public class DockerTestDebugCliMutualTlsKafka extends AbstractCommandTests {
 
@@ -45,7 +46,7 @@ public class DockerTestDebugCliMutualTlsKafka extends AbstractCommandTests {
     @BeforeClass
     @Override
     public void setup() {
-        if (StringUtils.contains(System.getProperty("os.name"), "Windows")) {
+        if (CS.contains(System.getProperty("os.name"), "Windows")) {
             throw new SkipException(
                     "These tests cannot run on Windows because the SSL certificates generator script assumes a Posix compatible OS");
         }
@@ -136,7 +137,7 @@ public class DockerTestDebugCliMutualTlsKafka extends AbstractCommandTests {
         // Then
         AbstractDockerDebugCliTests.verifyDumpCommandUsed();
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "Currently no new events available"));
+        Assert.assertTrue(CS.contains(stdErr, "Currently no new events available"));
     }
 
     @Test(retryAnalyzer = FlakyKafkaTest.class)
@@ -151,7 +152,7 @@ public class DockerTestDebugCliMutualTlsKafka extends AbstractCommandTests {
         AbstractDockerDebugCliTests.verifyDumpCommandUsed();
         AbstractDockerDebugCliTests.verifyEvents("Event %,d");
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "Currently no new events available"));
+        Assert.assertTrue(CS.contains(stdErr, "Currently no new events available"));
     }
 
     @Test(retryAnalyzer = FlakyKafkaTest.class)
@@ -181,6 +182,6 @@ public class DockerTestDebugCliMutualTlsKafka extends AbstractCommandTests {
 
         // And
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "LiveReporter"));
+        Assert.assertTrue(CS.contains(stdErr, "LiveReporter"));
     }
 }

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliReplayCommand.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliReplayCommand.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class DockerTestDebugCliReplayCommand extends AbstractDockerDebugCliTests {
 
     @Test(retryAnalyzer = FlakyKafkaTest.class)
@@ -55,7 +57,7 @@ public class DockerTestDebugCliReplayCommand extends AbstractDockerDebugCliTests
         // Then
         verifyReplayCommandUsed();
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "all events have been exhausted"));
+        Assert.assertTrue(CS.contains(stdErr, "all events have been exhausted"));
     }
 
     @Test(retryAnalyzer = FlakyKafkaTest.class)

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliSecureKafka.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliSecureKafka.java
@@ -40,6 +40,7 @@ import org.testng.annotations.Test;
 import java.util.*;
 
 import static io.telicent.smart.cache.cli.commands.debug.TestLogUtil.enableSpecificLogging;
+import static org.apache.commons.lang3.Strings.CS;
 
 public class DockerTestDebugCliSecureKafka extends AbstractCommandTests {
 
@@ -136,7 +137,7 @@ public class DockerTestDebugCliSecureKafka extends AbstractCommandTests {
         AbstractDockerDebugCliTests.verifyDumpCommandUsed();
 
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "Currently no new events available"));
+        Assert.assertTrue(CS.contains(stdErr, "Currently no new events available"));
     }
 
     @Test(retryAnalyzer = FlakyKafkaTest.class)
@@ -150,7 +151,7 @@ public class DockerTestDebugCliSecureKafka extends AbstractCommandTests {
 
         AbstractDockerDebugCliTests.verifyEvents("Event %,d");
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "Currently no new events available"));
+        Assert.assertTrue(CS.contains(stdErr, "Currently no new events available"));
     }
 
     @Test(retryAnalyzer = FlakyKafkaTest.class)
@@ -204,6 +205,6 @@ public class DockerTestDebugCliSecureKafka extends AbstractCommandTests {
 
         // And
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "LiveReporter"));
+        Assert.assertTrue(CS.contains(stdErr, "LiveReporter"));
     }
 }

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugRdfDumpCommand.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugRdfDumpCommand.java
@@ -31,6 +31,8 @@ import org.testng.annotations.Test;
 import java.time.Duration;
 import java.util.List;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class DockerTestDebugRdfDumpCommand extends AbstractDockerDebugCliTests {
 
     @Test(retryAnalyzer = FlakyKafkaTest.class)
@@ -142,7 +144,7 @@ public class DockerTestDebugRdfDumpCommand extends AbstractDockerDebugCliTests {
         // Then
         verifyRdfDumpCommandUsed();
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "Ignored malformed RDF event"));
+        Assert.assertTrue(CS.contains(stdErr, "Ignored malformed RDF event"));
         Assert.assertEquals(StringUtils.countMatches(stdErr, "Ignored malformed RDF event"), 1_000);
 
         // And

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/TestDebugCli.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/TestDebugCli.java
@@ -49,7 +49,12 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import static org.apache.commons.lang3.Strings.CS;
 
 public class TestDebugCli extends AbstractCommandTests {
 
@@ -67,7 +72,7 @@ public class TestDebugCli extends AbstractCommandTests {
         Assert.assertTrue(command instanceof HelpCommand);
         String stdOut = SmartCacheCommandTester.getLastStdOut();
         Assert.assertFalse(StringUtils.isBlank(stdOut));
-        Assert.assertTrue(StringUtils.contains(stdOut, "Commands are:"));
+        Assert.assertTrue(CS.contains(stdOut, "Commands are:"));
     }
 
     @Test
@@ -87,7 +92,7 @@ public class TestDebugCli extends AbstractCommandTests {
         List<ParseException> errors = new ArrayList<>(result.getErrors());
         Assert.assertFalse(errors.isEmpty());
         Assert.assertTrue(errors.stream()
-                                .anyMatch(e -> StringUtils.contains(e.getMessage(),
+                                .anyMatch(e -> CS.contains(e.getMessage(),
                                                                     "not in the list of allowed values")));
     }
 
@@ -116,7 +121,7 @@ public class TestDebugCli extends AbstractCommandTests {
         List<ParseException> errors = new ArrayList<>(result.getErrors());
         Assert.assertFalse(errors.isEmpty());
         Assert.assertTrue(errors.stream()
-                                .anyMatch(e -> StringUtils.contains(e.getMessage(),
+                                .anyMatch(e -> CS.contains(e.getMessage(),
                                                                     "not in the list of allowed values")));
     }
 
@@ -139,7 +144,7 @@ public class TestDebugCli extends AbstractCommandTests {
         // Then
         verifyFailedCommand(false);
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "Cannot specify the same"));
+        Assert.assertTrue(CS.contains(stdErr, "Cannot specify the same"));
     }
 
     private static ParseResult<SmartCacheCommand> verifyFailedCommand(boolean isParseError) {
@@ -161,7 +166,7 @@ public class TestDebugCli extends AbstractCommandTests {
         // Then
         verifyFailedCommand(false);
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "Failed to specify sufficient options"));
+        Assert.assertTrue(CS.contains(stdErr, "Failed to specify sufficient options"));
     }
 
 
@@ -232,7 +237,7 @@ public class TestDebugCli extends AbstractCommandTests {
         // Then
         AbstractDockerDebugCliTests.verifyDumpCommandUsed();
         String stdOut = SmartCacheCommandTester.getLastStdOut();
-        Assert.assertTrue(StringUtils.contains(stdOut, "Event 1"));
+        Assert.assertTrue(CS.contains(stdOut, "Event 1"));
     }
 
     @Test
@@ -284,7 +289,7 @@ public class TestDebugCli extends AbstractCommandTests {
         // Then
         AbstractDockerDebugCliTests.verifyRdfDumpCommandUsed();
         String stdOut = SmartCacheCommandTester.getLastStdOut();
-        Assert.assertTrue(StringUtils.contains(stdOut, "\"1\""));
+        Assert.assertTrue(CS.contains(stdOut, "\"1\""));
     }
 
     @Test
@@ -352,7 +357,7 @@ public class TestDebugCli extends AbstractCommandTests {
     public void givenSingleRdfFile_whenCapturingRdfToInvalidPath_thenFails() throws IOException {
         // Given
         String os = System.getProperty("os.name");
-        if (StringUtils.contains(os, "Windows")) {
+        if (CS.contains(os, "Windows")) {
             throw new SkipException("Test not suitable for Windows");
         }
 
@@ -382,7 +387,7 @@ public class TestDebugCli extends AbstractCommandTests {
         // Then
         verifyFailedCommand(false);
         String stdErr = SmartCacheCommandTester.getLastStdErr();
-        Assert.assertTrue(StringUtils.contains(stdErr, "Failed to create"));
+        Assert.assertTrue(CS.contains(stdErr, "Failed to create"));
     }
 
     private static void verifyCapturedRdfEvent(File captureDir, String captureFormat) {
@@ -449,7 +454,7 @@ public class TestDebugCli extends AbstractCommandTests {
     public static void verifyEventsDumped(String format) {
         String stdOut = SmartCacheCommandTester.getLastStdOut();
         for (int i = 1; i < 1_000; i++) {
-            Assert.assertTrue(StringUtils.contains(stdOut, String.format(format, i)));
+            Assert.assertTrue(CS.contains(stdOut, String.format(format, i)));
         }
     }
 

--- a/cli/cli-probe-server/src/test/java/io/telicent/smart/cache/cli/probes/TestHealthProbeServer.java
+++ b/cli/cli-probe-server/src/test/java/io/telicent/smart/cache/cli/probes/TestHealthProbeServer.java
@@ -44,6 +44,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.commons.lang3.Strings.CI;
+
 public class TestHealthProbeServer {
 
     private final static RandomPortProvider TEST_PORT = new RandomPortProvider(1234);
@@ -101,7 +103,7 @@ public class TestHealthProbeServer {
         Assert.assertTrue(readinessLogger.getAllLoggingEvents()
                                          .stream()
                                          .filter(m -> m.getLevel() == Level.WARN)
-                                         .anyMatch(m -> StringUtils.containsIgnoreCase(m.getFormattedMessage(),
+                                         .anyMatch(m -> CI.contains(m.getFormattedMessage(),
                                                                                        "unhealthy")));
     }
 

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/projectors/sinks/events/file/EventCapturingSink.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/projectors/sinks/events/file/EventCapturingSink.java
@@ -35,6 +35,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 /**
  * A sink that captures events to files so that they can be replayed using a
  * {@link io.telicent.smart.cache.sources.file.FileEventSource} in the future while also forwarding them onto another
@@ -83,7 +85,7 @@ public class EventCapturingSink<TKey, TValue>
         this.prefix = prefix;
         this.padding = padding;
         this.extension = StringUtils.isBlank(extension) ? extension :
-                         (StringUtils.startsWith(extension, ".") ? extension : "." + extension);
+                         (CS.startsWith(extension, ".") ? extension : "." + extension);
         this.additionalHeaders =
                 additionalHeaders != null ? new ArrayList<>(additionalHeaders) : Collections.emptyList();
         this.additionalHeaderGenerators =

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/NumericFilenameComparator.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/NumericFilenameComparator.java
@@ -22,6 +22,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 /**
  * A comparator for filenames which extracts the numeric portion of the filename, parses it to a long integer and
  * compares based on that resulting in sorting files into numeric order
@@ -59,7 +61,7 @@ public class NumericFilenameComparator implements Comparator<File> {
      */
     private static Long fileToNumber(File f) {
         String name = f.getName();
-        if (StringUtils.contains(name, ".")) {
+        if (CS.contains(name, ".")) {
             name = name.substring(0, name.indexOf("."));
         }
         name = StringUtils.getDigits(name);

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/NumericallyNamedWithExtensionFilter.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/NumericallyNamedWithExtensionFilter.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.FileFilter;
 import java.util.Objects;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 /**
  * A filter that selects only files with a specific extension and a numeric portion within their filename
  */
@@ -36,7 +38,7 @@ public class NumericallyNamedWithExtensionFilter implements FileFilter {
         if (StringUtils.isBlank(extension)) {
             throw new IllegalArgumentException("File extension cannot be null/blank");
         }
-        if (!StringUtils.startsWith(extension, ".")) {
+        if (!CS.startsWith(extension, ".")) {
             throw new IllegalArgumentException("File extension must start with a . character");
         }
         this.extension = extension;

--- a/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/projectors/sinks/events/file/TestEventCapturingSink.java
+++ b/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/projectors/sinks/events/file/TestEventCapturingSink.java
@@ -44,6 +44,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class TestEventCapturingSink {
 
     @DataProvider(name = "captureSettings")
@@ -51,7 +53,7 @@ public class TestEventCapturingSink {
         return new Object[][] {
                 { "test-", ".yaml", 4, YamlFileEventSource.YAML_FILTER },
                 { null, "yaml", 3, YamlFileEventSource.YAML_FILTER },
-                { "foo-", ".bar", 10, (FileFilter) pathname -> StringUtils.endsWith(pathname.getName(), ".bar") },
+                { "foo-", ".bar", 10, (FileFilter) pathname -> CS.endsWith(pathname.getName(), ".bar") },
                 { null, null, 0, (FileFilter) pathname -> true }
         };
     }
@@ -137,15 +139,15 @@ public class TestEventCapturingSink {
                 Assert.assertFalse(StringUtils.getDigits(f.getName()).isEmpty());
             }
             if (StringUtils.isNotBlank(prefix)) {
-                Assert.assertTrue(StringUtils.startsWith(f.getName(), prefix));
+                Assert.assertTrue(CS.startsWith(f.getName(), prefix));
             } else {
                 Assert.assertTrue(Character.isDigit(f.getName().charAt(0)));
             }
             if (StringUtils.isNotBlank(extension)) {
-                Assert.assertTrue(StringUtils.contains(f.getName(), "."));
-                Assert.assertTrue(StringUtils.endsWith(f.getName(), extension));
+                Assert.assertTrue(CS.contains(f.getName(), "."));
+                Assert.assertTrue(CS.endsWith(f.getName(), extension));
             } else {
-                Assert.assertFalse(StringUtils.contains(f.getName(), "."));
+                Assert.assertFalse(CS.contains(f.getName(), "."));
             }
         }
         Assert.assertEquals(created.size(), expectedFiles);

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
@@ -46,6 +46,8 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
+import static org.apache.commons.lang3.Strings.CI;
+
 /**
  * An event source backed by Kafka
  *
@@ -582,7 +584,7 @@ public class KafkaEventSource<TKey, TValue>
             // If the consumer got removed from the group, for whatever reason, then this could fail
             // We detect this case by looking at the error message, and if so just issue a warning and continue,
             // since we're likely to be reassigned partitions at a future date
-            return StringUtils.containsIgnoreCase(cfEx.getMessage(), "not part of an active group");
+            return CI.contains(cfEx.getMessage(), "not part of an active group");
         } else if (e instanceof RebalanceInProgressException) {
             // If a rebalance is in progress we're not permitted to commit offsets either, again this is recoverable
             // once rebalance completes in a future poll() call

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/RdfPayloadDeserializer.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/RdfPayloadDeserializer.java
@@ -26,6 +26,8 @@ import org.apache.kafka.common.serialization.Deserializer;
 import java.io.ByteArrayInputStream;
 import java.util.Map;
 
+import static org.apache.commons.lang3.Strings.CI;
+
 /**
  * An RDF Payload deserialiser that can cope with both RDF Dataset and RDF Patch format events.  Which format is used is
  * dependent on the {@code Content-Type} header of the event.  If no such header is present then an RDF Dataset is
@@ -78,9 +80,9 @@ public class RdfPayloadDeserializer extends AbstractRdfSerdes implements Deseria
             return RdfPayload.of(this.dsgDeserializer.deserialize(topic, headers, data));
         }
 
-        if (StringUtils.equalsIgnoreCase(contentType, WebContent.ctPatch.getContentTypeStr())) {
+        if (CI.equals(contentType, WebContent.ctPatch.getContentTypeStr())) {
             return RdfPayload.of(RDFPatchOps.read(new ByteArrayInputStream(data)));
-        } else if (StringUtils.equalsIgnoreCase(contentType, WebContent.ctPatchThrift.getContentTypeStr())) {
+        } else if (CI.equals(contentType, WebContent.ctPatchThrift.getContentTypeStr())) {
             return RdfPayload.of(RDFPatchOps.readBinary(new ByteArrayInputStream(data)));
         } else {
             // Assume an RDF Dataset
@@ -91,7 +93,7 @@ public class RdfPayloadDeserializer extends AbstractRdfSerdes implements Deseria
     @Override
     public void configure(Map<String, ?> configs, boolean isKey) {
         try {
-            this.eagerParsing = StringUtils.equalsIgnoreCase((String) configs.get(EAGER_PARSING_CONFIG_KEY),
+            this.eagerParsing = CI.equals((String) configs.get(EAGER_PARSING_CONFIG_KEY),
                                                              Boolean.TRUE.toString());
         } catch (ClassCastException e) {
             this.eagerParsing = false;

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/RdfPayloadSerializer.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/RdfPayloadSerializer.java
@@ -28,6 +28,8 @@ import org.apache.kafka.common.serialization.Serializer;
 
 import java.io.ByteArrayOutputStream;
 
+import static org.apache.commons.lang3.Strings.CI;
+
 /**
  * A Kafka serializer that serializes RDF Payloads
  */
@@ -82,10 +84,10 @@ public class RdfPayloadSerializer extends AbstractRdfSerdes implements Serialize
             ByteArrayOutputStream output = new ByteArrayOutputStream();
             RDFPatch patch = payload.getPatch();
             try {
-                if (StringUtils.equalsIgnoreCase(contentType, WebContent.ctPatch.getContentTypeStr())) {
+                if (CI.equals(contentType, WebContent.ctPatch.getContentTypeStr())) {
                     RDFPatchOps.write(output, patch);
                     return output.toByteArray();
-                } else if (StringUtils.equalsIgnoreCase(contentType, WebContent.ctPatchThrift.getContentTypeStr())) {
+                } else if (CI.equals(contentType, WebContent.ctPatchThrift.getContentTypeStr())) {
                     RDFPatchOps.writeBinary(output, patch);
                     return output.toByteArray();
                 }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaEventSource.java
@@ -51,6 +51,8 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.*;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class DockerTestKafkaEventSource {
 
     private BasicKafkaTestCluster kafka;
@@ -489,7 +491,7 @@ public class DockerTestKafkaEventSource {
         Assert.assertTrue(testLogger.getAllLoggingEvents()
                                     .stream()
                                     .map(LoggingEvent::getFormattedMessage)
-                                    .anyMatch(m -> StringUtils.contains(m, "Kafka reported error deserializing")));
+                                    .anyMatch(m -> CS.contains(m, "Kafka reported error deserializing")));
     }
 
     @Test

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaTopicExistence.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaTopicExistence.java
@@ -40,6 +40,7 @@ import java.util.concurrent.*;
 import static io.telicent.smart.cache.sources.kafka.Utils.waitAWhileFor;
 import static io.telicent.smart.cache.sources.kafka.Utils.waitAWhileOrFailFor;
 import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.Strings.CS;
 
 /**
  * Topic existence checks run with a fresh Kafka cluster per-test because otherwise we've observed the tests interfering
@@ -480,7 +481,7 @@ public class DockerTestKafkaTopicExistence {
                 () -> logger.getAllLoggingEvents()
                             .stream()
                             .map(LoggingEvent::getFormattedMessage)
-                            .filter(m -> StringUtils.contains(m, expectedMessage))
+                            .filter(m -> CS.contains(m, expectedMessage))
                             .anyMatch(x -> true)
         );
     }
@@ -490,7 +491,7 @@ public class DockerTestKafkaTopicExistence {
                 () -> logger.getAllLoggingEvents()
                         .stream()
                         .map(LoggingEvent::getFormattedMessage)
-                        .filter(m -> StringUtils.contains(m, expectedMessage))
+                        .filter(m -> CS.contains(m, expectedMessage))
                         .count() == expectedMessageCount
         );
     }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestMutualTlsKafkaCluster.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestMutualTlsKafkaCluster.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static io.telicent.smart.cache.sources.kafka.DockerTestSecureKafkaCluster.RECORD_ERROR_TOTAL;
+import static org.apache.commons.lang3.Strings.CS;
 
 public class DockerTestMutualTlsKafkaCluster {
 
@@ -57,7 +58,7 @@ public class DockerTestMutualTlsKafkaCluster {
 
     @BeforeClass
     public void setup() {
-        if (StringUtils.contains(System.getProperty("os.name"), "Windows")) {
+        if (CS.contains(System.getProperty("os.name"), "Windows")) {
             throw new SkipException(
                     "These tests cannot run on Windows because the SSL certificates generator script assumes a Posix compatible OS");
         }
@@ -121,7 +122,7 @@ public class DockerTestMutualTlsKafkaCluster {
             event = goodSource.poll(Duration.ofSeconds(5));
         } catch (EventSourceException e) {
             if (!expectSuccess) {
-                Assert.assertTrue(StringUtils.contains(e.getMessage(), "Security"));
+                Assert.assertTrue(CS.contains(e.getMessage(), "Security"));
             } else {
                 Assert.fail("Event Source threw an error when credentials were expected to be valid");
             }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestSecureKafkaCluster.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestSecureKafkaCluster.java
@@ -50,6 +50,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class DockerTestSecureKafkaCluster {
 
     public static final String RECORD_ERROR_TOTAL = "record-error-total";
@@ -293,7 +295,7 @@ public class DockerTestSecureKafkaCluster {
             event = goodSource.poll(Duration.ofSeconds(3));
         } catch (EventSourceException e) {
             if (!areCredentialsValid) {
-                Assert.assertTrue(StringUtils.contains(e.getMessage(), "Security"));
+                Assert.assertTrue(CS.contains(e.getMessage(), "Security"));
             } else {
                 Assert.fail("Event Source threw an error when credentials were expected to be valid");
             }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaSinkErrorHandling.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaSinkErrorHandling.java
@@ -85,6 +85,8 @@ public class TestKafkaSinkErrorHandling {
         try (KafkaSink<Integer, String> sink = getBuilder().noAsync().build()) {
             // When and Then
             sink.send(EVENT);
+        } catch (Exception e) {
+            throw e;
         }
     }
 

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/payloads/RdfPayload.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/payloads/RdfPayload.java
@@ -30,6 +30,8 @@ import org.apache.jena.sparql.core.DatasetGraphFactory;
 import java.io.ByteArrayInputStream;
 import java.util.Objects;
 
+import static org.apache.commons.lang3.Strings.CI;
+
 /**
  * Represents an RDF Payload, this may either be a purely additive {@link DatasetGraph} or a mutative {@link RDFPatch}
  * containing an ordered sequence of additions and deletions.
@@ -243,7 +245,7 @@ public class RdfPayload {
     }
 
     private boolean isRdfPatchContentType() {
-        return StringUtils.equalsAnyIgnoreCase(contentType, RDF_PATCH_CONTENT_TYPES);
+        return CI.equalsAny(contentType, RDF_PATCH_CONTENT_TYPES);
     }
 
     /**
@@ -266,9 +268,9 @@ public class RdfPayload {
             // Otherwise try to deserialise now
             try {
                 RDFPatch patch = null;
-                if (StringUtils.equalsIgnoreCase(contentType, WebContent.contentTypePatch)) {
+                if (CI.equals(contentType, WebContent.contentTypePatch)) {
                     patch = RDFPatchOps.read(new ByteArrayInputStream(this.rawData));
-                } else if (StringUtils.equalsIgnoreCase(contentType, WebContent.contentTypePatchThrift)) {
+                } else if (CI.equals(contentType, WebContent.contentTypePatchThrift)) {
                     patch = RDFPatchOps.readBinary(new ByteArrayInputStream(this.rawData));
                 }
 

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/offsets/AbstractOffsetStore.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/offsets/AbstractOffsetStore.java
@@ -63,6 +63,7 @@ public abstract class AbstractOffsetStore implements OffsetStore {
      */
     protected abstract <T> void saveOffsetInternal(String key, T offset);
 
+    @SuppressWarnings("unchecked")
     @Override
     public final <T> T loadOffset(String key) {
         ensureNotClosed();

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/TestCapturingEventSource.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/TestCapturingEventSource.java
@@ -40,8 +40,8 @@ public class TestCapturingEventSource extends AbstractEventSourceTests<Integer, 
         AtomicInteger counter = new AtomicInteger(0);
         return createSampleStrings(size).stream()
                                         .map(s -> new SimpleEvent<>(Collections.emptyList(), counter.incrementAndGet(),
-                                                                    s, new CapturingEventSource(
-                                                new InMemoryEventSource(Collections.emptyList()), NullSink.of())))
+                                                                    s, new CapturingEventSource<>(
+                                                new InMemoryEventSource<String, String>(Collections.emptyList()), NullSink.of())))
                                         .collect(Collectors.toList());
     }
 

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/ServerBuilder.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/applications/ServerBuilder.java
@@ -45,6 +45,8 @@ import java.net.URISyntaxException;
 import java.util.*;
 import java.util.function.Function;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 /**
  * Builder for creating server instances, use {@link #create()} as the entrypoint for building a new server e.g.
  * <pre>
@@ -192,9 +194,9 @@ public class ServerBuilder {
         if (Objects.equals(path, ROOT_CONTEXT)) {
             // A lone / is always a valid context path and indicates that the root context is used
             // This branch of the if is needed to avoid the checks in the subsequent branches rejecting this case
-        } else if (!StringUtils.startsWith(path, ROOT_CONTEXT)) {
+        } else if (!CS.startsWith(path, ROOT_CONTEXT)) {
             throw new IllegalArgumentException("Context path must start with a forward slash e.g. / or /app NOT app");
-        } else if (StringUtils.endsWith(path, ROOT_CONTEXT)) {
+        } else if (CS.endsWith(path, ROOT_CONTEXT)) {
             throw new IllegalArgumentException("Context path must not end with a forward slash e.g. /app NOT /app/");
         }
         this.contextPath = path;

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/filters/CrossOriginFilter.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/filters/CrossOriginFilter.java
@@ -34,6 +34,8 @@ import java.io.IOException;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 /**
  * Implementation of the
  * <a href="http://www.w3.org/TR/cors/">cross-origin resource sharing</a>.
@@ -395,8 +397,8 @@ public class CrossOriginFilter implements Filter {
     }
 
     private String parseAllowedWildcardOriginToRegex(String allowedOrigin) {
-        String regex = StringUtils.replace(allowedOrigin, ".", "\\.");
-        return StringUtils.replace(regex, "*",
+        String regex = CS.replace(allowedOrigin, ".", "\\.");
+        return CS.replace(regex, "*",
                                    ".*"); // we want to be greedy here to match multiple subdomains, thus we use .*
     }
 

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/init/InitPriorityComparator.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/init/InitPriorityComparator.java
@@ -15,9 +15,9 @@
  */
 package io.telicent.smart.cache.server.jaxrs.init;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.Comparator;
+
+import static org.apache.commons.lang3.Strings.CS;
 
 /**
  * A comparator that compares our {@link ServerConfigInit} implementations based upon their declared
@@ -48,7 +48,7 @@ public class InitPriorityComparator implements Comparator<ServerConfigInit> {
         // first
         int c = -1 * Integer.compare(a.priority(), b.priority());
         if (c == 0) {
-            c = StringUtils.compare(a.getName(), b.getName());
+            c = CS.compare(a.getName(), b.getName());
         }
         return c;
     }

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServer.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServer.java
@@ -44,6 +44,8 @@ import java.net.ConnectException;
 import java.util.concurrent.*;
 import java.util.function.Function;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class TestServer extends AbstractAppEntrypoint {
 
     private static final RandomPortProvider PORT = new RandomPortProvider(1366);
@@ -548,7 +550,7 @@ public class TestServer extends AbstractAppEntrypoint {
             Assert.assertNotNull(problem);
 
             // And
-            Assert.assertTrue(StringUtils.contains(problem.getDetail(), "'query'"));
+            Assert.assertTrue(CS.contains(problem.getDetail(), "'query'"));
         }
     }
 
@@ -788,9 +790,9 @@ public class TestServer extends AbstractAppEntrypoint {
                 Assert.assertEquals(response.getHeaderString(HttpNames.hContentType), MediaType.TEXT_PLAIN);
                 String body = response.readEntity(String.class);
 
-                Assert.assertTrue(StringUtils.contains(body, "400"));
-                Assert.assertTrue(StringUtils.contains(body, "Test Error"));
-                Assert.assertTrue(StringUtils.contains(body, "Something went wrong"));
+                Assert.assertTrue(CS.contains(body, "400"));
+                Assert.assertTrue(CS.contains(body, "Test Error"));
+                Assert.assertTrue(CS.contains(body, "Something went wrong"));
             }
         }
     }
@@ -831,7 +833,7 @@ public class TestServer extends AbstractAppEntrypoint {
                 Problem problem =
                         verifyProblemResponse(response, Response.Status.NOT_FOUND.getStatusCode(),
                                               MediaType.APPLICATION_JSON);
-                Assert.assertTrue(StringUtils.contains(problem.getDetail(), "not a valid URL"));
+                Assert.assertTrue(CS.contains(problem.getDetail(), "not a valid URL"));
             }
         }
     }
@@ -852,7 +854,7 @@ public class TestServer extends AbstractAppEntrypoint {
                 Problem problem =
                         verifyProblemResponse(response, Response.Status.NOT_FOUND.getStatusCode(),
                                               Problem.MEDIA_TYPE);
-                Assert.assertTrue(StringUtils.contains(problem.getDetail(), "not a valid URL"));
+                Assert.assertTrue(CS.contains(problem.getDetail(), "not a valid URL"));
             }
         }
     }
@@ -876,7 +878,7 @@ public class TestServer extends AbstractAppEntrypoint {
                 // NB - JAX-RS treats null Content-Type as application/octet-stream so can't deserialize this as a
                 //      Problem as no suitable MessageBodyReader is registered, just read as String instead
                 String problem = response.readEntity(String.class);
-                Assert.assertTrue(StringUtils.contains(problem, "not a valid URL"));
+                Assert.assertTrue(CS.contains(problem, "not a valid URL"));
             }
         }
     }

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServerBuilder.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServerBuilder.java
@@ -27,6 +27,8 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class TestServerBuilder {
 
     private final Client client = ClientBuilder.newClient();
@@ -93,7 +95,7 @@ public class TestServerBuilder {
     private void verifyHealthy(Server server) throws IOException {
         server.start();
         WebTarget target = this.client.target(server.getBaseUri()).path("/healthz");
-        Assert.assertTrue(StringUtils.startsWith(target.getUri().toString(), server.getBaseUri()));
+        Assert.assertTrue(CS.startsWith(target.getUri().toString(), server.getBaseUri()));
         try (Response response = target.request(MediaType.APPLICATION_JSON_TYPE).get()) {
             Assert.assertEquals(response.getStatus(), Response.Status.NO_CONTENT.getStatusCode());
         } finally {

--- a/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServerLimits.java
+++ b/jaxrs-base-server/src/test/java/io/telicent/smart/cache/server/jaxrs/applications/TestServerLimits.java
@@ -32,6 +32,8 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class TestServerLimits {
     private static final RandomPortProvider PORT = new RandomPortProvider(21212);
 
@@ -177,7 +179,7 @@ public class TestServerLimits {
                 Assert.fail("Expected Grizzly to abort the response in this test");
             } catch (ProcessingException e) {
                 // Then
-                Assert.assertTrue(StringUtils.contains(e.getMessage(), "Unexpected end of file"));
+                Assert.assertTrue(CS.contains(e.getMessage(), "Unexpected end of file"));
             }
         } finally {
             server.stop();

--- a/jwt-auth-common/src/main/java/io/telicent/smart/caches/configuration/auth/TelicentConfigurationAdaptor.java
+++ b/jwt-auth-common/src/main/java/io/telicent/smart/caches/configuration/auth/TelicentConfigurationAdaptor.java
@@ -17,12 +17,12 @@ package io.telicent.smart.caches.configuration.auth;
 
 import io.telicent.servlet.auth.jwt.configuration.RuntimeConfigurationAdaptor;
 import io.telicent.smart.cache.configuration.Configurator;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.function.Function;
 
 import static io.telicent.servlet.auth.jwt.configuration.ConfigurationParameters.*;
 import static io.telicent.servlet.auth.jwt.verifier.aws.AwsVerificationProvider.PARAM_AWS_REGION;
+import static org.apache.commons.lang3.Strings.CS;
 
 /**
  * An adaptor from our environment variable driven configuration approach to the JWT Servlet Auth libraries runtime
@@ -36,7 +36,7 @@ public abstract class TelicentConfigurationAdaptor implements RuntimeConfigurati
      */
     public TelicentConfigurationAdaptor() {
         this.usingAws =
-                StringUtils.startsWith(Configurator.get(AuthConstants.ENV_JWKS_URL), AuthConstants.AUTH_PREFIX_AWS);
+                CS.startsWith(Configurator.get(AuthConstants.ENV_JWKS_URL), AuthConstants.AUTH_PREFIX_AWS);
     }
 
     @Override

--- a/observability-core/src/main/java/io/telicent/smart/cache/observability/events/EventUtil.java
+++ b/observability-core/src/main/java/io/telicent/smart/cache/observability/events/EventUtil.java
@@ -30,6 +30,7 @@ public class EventUtil {
      * @param events the event(s) to be dispatched.
      * @param <E> the type of the event to be dispatched.
      */
+    @SafeVarargs
     public static <E extends ComponentEvent> void emit(final EventDispatcher<E> dispatcher, E ... events) {
         emit(dispatcher, asList(events));
     }

--- a/observability-core/src/test/java/io/telicent/smart/cache/observability/TestRuntimeInfo.java
+++ b/observability-core/src/test/java/io/telicent/smart/cache/observability/TestRuntimeInfo.java
@@ -18,13 +18,17 @@ package io.telicent.smart.cache.observability;
 import com.github.valfirst.slf4jtest.LoggingEvent;
 import com.github.valfirst.slf4jtest.TestLogger;
 import com.github.valfirst.slf4jtest.TestLoggerFactory;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
+
+import org.apache.commons.lang3.Strings;
+
+import static org.apache.commons.lang3.Strings.CI;
+import static org.apache.commons.lang3.Strings.CS;
 
 public class TestRuntimeInfo {
 
@@ -80,7 +84,7 @@ public class TestRuntimeInfo {
     }
 
     private static void verifyMatchingLogMessage(List<String> messages, String searchSeq) {
-        Assert.assertTrue(messages.stream().anyMatch(m -> StringUtils.contains(m, searchSeq)));
+        Assert.assertTrue(messages.stream().anyMatch(m -> CS.contains(m, searchSeq)));
     }
 
     @Test
@@ -106,8 +110,8 @@ public class TestRuntimeInfo {
             List<String> messages = logger.getAllLoggingEvents().stream().map(LoggingEvent::getFormattedMessage).toList();
             Assert.assertFalse(messages.isEmpty());
             Assert.assertTrue(messages.stream()
-                                      .anyMatch(m -> StringUtils.contains(m,
-                                                                          TestLibraryVersion.OBSERVABILITY_CORE) && StringUtils.contains(
+                                      .anyMatch(m -> CS.contains(m,
+                                                                          TestLibraryVersion.OBSERVABILITY_CORE) && CS.contains(
                                               m, LibraryVersion.get(TestLibraryVersion.OBSERVABILITY_CORE))));
         } finally {
             logger.clearAll();

--- a/observability-core/src/test/java/io/telicent/smart/cache/observability/events/EventSourceSupportTest.java
+++ b/observability-core/src/test/java/io/telicent/smart/cache/observability/events/EventSourceSupportTest.java
@@ -15,18 +15,30 @@
  */
 package io.telicent.smart.cache.observability.events;
 
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static io.telicent.smart.cache.observability.events.CounterEvent.counterEvent;
 import static org.mockito.Mockito.*;
 
 public class EventSourceSupportTest {
+
+    @Mock
+    EventListener<ComponentEvent> listener;
+
+    @BeforeMethod
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
     @Test
     public void whenAListenerIsRegisteredWithTheEventSource_thenTheListenerIsNotifiedOfEventsEmitted() {
         // Given an event source support delegate
         final EventSourceSupport<ComponentEvent> eventSourceSupport = new EventSourceSupport<>();
-        final EventListener<ComponentEvent> listener = mock(EventListener.class);
+
         final ComponentEvent event = counterEvent("someEvent");
         final ComponentEvent otherEvent = counterEvent("someOtherEvent");
 
@@ -55,7 +67,6 @@ public class EventSourceSupportTest {
         // Given an event source support delegate
         final EventSourceSupport<ComponentEvent> eventSourceSupport = new EventSourceSupport<>();
         final ComponentEvent event = counterEvent("someEvent");
-        final EventListener<ComponentEvent> listener = mock(EventListener.class);
         Mockito.doThrow(new RuntimeException("The listener error")).when(listener).on(any());
 
         // When the listener is registered with the event source

--- a/observability-core/src/test/java/io/telicent/smart/cache/observability/events/EventUtilTest.java
+++ b/observability-core/src/test/java/io/telicent/smart/cache/observability/events/EventUtilTest.java
@@ -15,6 +15,9 @@
  */
 package io.telicent.smart.cache.observability.events;
 
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static io.telicent.smart.cache.observability.events.CounterEvent.counterEvent;
@@ -22,10 +25,14 @@ import static io.telicent.smart.cache.observability.events.DurationEvent.duratio
 import static org.mockito.Mockito.*;
 
 public class EventUtilTest {
+
+    @Mock
+    EventDispatcher<ComponentEvent> dispatcher;
+
     @Test
     public void whenEmitIsCalledWithDispatcherAndSomeEvents_thenTheDispatcherIsCalledToDispatchEachEvent() {
         // Given a dispatcher and some events to be dispatched
-        EventDispatcher<ComponentEvent> dispatcher = mock(EventDispatcher.class);
+        MockitoAnnotations.openMocks(this);
         ComponentEvent event1 = counterEvent("event1");
         ComponentEvent event2 = durationEvent("event2", 1000, 2000);
 

--- a/projector-driver/src/main/java/io/telicent/smart/cache/projectors/driver/ProjectorDriver.java
+++ b/projector-driver/src/main/java/io/telicent/smart/cache/projectors/driver/ProjectorDriver.java
@@ -29,7 +29,6 @@ import io.telicent.smart.cache.projectors.utils.ThroughputTracker;
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.EventSource;
 import lombok.Getter;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +37,8 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Supplier;
+
+import static org.apache.commons.lang3.Strings.CS;
 
 /**
  * A projector driver connects an event source up to a projector and an output sink.
@@ -261,7 +262,7 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
             }
         } catch (Throwable e) {
             // Log only if not some form of interrupt
-            if (!StringUtils.contains(e.getClass().getCanonicalName(), "Interrupt")) {
+            if (!CS.contains(e.getClass().getCanonicalName(), "Interrupt")) {
                 LOGGER.warn("Projector Driver aborting due to error: {}", e.getMessage());
                 throw e;
             }

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestCircuitBreakerSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestCircuitBreakerSink.java
@@ -17,25 +17,30 @@ package io.telicent.smart.cache.projectors.sinks;
 
 import io.telicent.smart.cache.projectors.Sink;
 import io.telicent.smart.cache.projectors.SinkException;
-import org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class TestCircuitBreakerSink {
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".*at least 1")
     public void givenBadQueueSize_whenCreatingCircuitBreakerSink_thenIllegalArgument() {
         // Given, When and Then
-        CircuitBreakerSink.create().queueSize(-10).build();
+        try(CircuitBreakerSink<Object> ignored = CircuitBreakerSink.create().queueSize(-10).build()) {
+            // to avoid compiler warning
+        }
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void givenNullInitialState_whenCreatingCircuitBreakerSink_thenNPE() {
         // Given, When and Then
-        new CircuitBreakerSink<>(null, null, 10, true);
+        try(CircuitBreakerSink<Object> ignored = new CircuitBreakerSink<>(null, null, 10, true)) {
+            // to avoid compiler warning
+        }
     }
 
     private void sendItems(Sink<Integer> sink, int count) {
@@ -194,7 +199,7 @@ public class TestCircuitBreakerSink {
             InterruptedException {
         // Given
         try (CollectorSink<Integer> collector = CollectorSink.of()) {
-            try (DelaySink<Integer> delay = new DelaySink(collector, 10)) {
+            try (DelaySink<Integer> delay = new DelaySink<>(collector, 10)) {
                 try (CircuitBreakerSink<Integer> sink = CircuitBreakerSink.<Integer>create()
                                                                           .queueSize(100)
                                                                           .opened()
@@ -236,7 +241,7 @@ public class TestCircuitBreakerSink {
             InterruptedException {
         // Given
         try (CollectorSink<Integer> collector = CollectorSink.of()) {
-            try (DelaySink<Integer> delay = new DelaySink(collector, 10)) {
+            try (DelaySink<Integer> delay = new DelaySink<>(collector, 10)) {
                 try (CircuitBreakerSink<Integer> sink = CircuitBreakerSink.<Integer>create()
                                                                           .queueSize(100)
                                                                           .opened()
@@ -268,7 +273,7 @@ public class TestCircuitBreakerSink {
                         sink.close();
                     } catch (SinkException e) {
                         // Expected, sink was closed while the queue was non-empty, ignore
-                        Assert.assertTrue(StringUtils.contains(e.getMessage(), "queued items"));
+                        Assert.assertTrue(CS.contains(e.getMessage(), "queued items"));
                     }
                     semaphore.release();
 

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestDuplicationSuppressionSinks.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestDuplicationSuppressionSinks.java
@@ -36,6 +36,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static io.telicent.smart.cache.projectors.sinks.TestJacksonJsonSink.verifyCollectedValues;
+import static org.apache.commons.lang3.Strings.CS;
 
 public class TestDuplicationSuppressionSinks {
 
@@ -183,7 +184,7 @@ public class TestDuplicationSuppressionSinks {
             verifyCollectedValues(collector, values);
         }
         Assert.assertTrue(TestLoggerUtils.formattedLogMessages(suppressDuplicatesLogger)
-                                   .anyMatch(m -> StringUtils.contains(m, "Invalidated duplicate suppression cache")),
+                                   .anyMatch(m -> CS.contains(m, "Invalidated duplicate suppression cache")),
                           "Expected sink to log that it was invalidated");
     }
 
@@ -202,7 +203,7 @@ public class TestDuplicationSuppressionSinks {
             verifyCollectedValues(collector, Arrays.asList("a", "b"));
         }
         Assert.assertTrue(TestLoggerUtils.formattedLogMessages(suppressDuplicatesLogger)
-                                   .noneMatch(m -> StringUtils.contains(m, "Invalidated duplicate suppression cache")),
+                                   .noneMatch(m -> CS.contains(m, "Invalidated duplicate suppression cache")),
                           "Expected sink to NOT log that it was invalidated");
     }
 
@@ -330,6 +331,7 @@ public class TestDuplicationSuppressionSinks {
     };
 
     @Test
+    @SuppressWarnings("unchecked")
     public void suppress_unmodified_01() {
         List<Map<String, Object>> values = new ArrayList<>();
         Map<String, Object> a = A;
@@ -444,7 +446,7 @@ public class TestDuplicationSuppressionSinks {
 
         Assert.assertEquals(suppressUnmodifiedLogger.getLoggingEvents().size(), 8);
         Assert.assertTrue(TestLoggerUtils.formattedLogMessages(suppressUnmodifiedLogger)
-                                   .allMatch(m -> StringUtils.contains(m, "Invalidated unmodified suppression cache")));
+                                   .allMatch(m -> CS.contains(m, "Invalidated unmodified suppression cache")));
     }
 
     @Test
@@ -474,7 +476,7 @@ public class TestDuplicationSuppressionSinks {
 
         Assert.assertEquals(suppressUnmodifiedLogger.getLoggingEvents().size(), 7);
         Assert.assertTrue(TestLoggerUtils.formattedLogMessages(suppressUnmodifiedLogger)
-                                   .allMatch(m -> StringUtils.contains(m, "Invalidated unmodified suppression cache")));
+                                   .allMatch(m -> CS.contains(m, "Invalidated unmodified suppression cache")));
     }
 
     @Test

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestFilterSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestFilterSink.java
@@ -26,8 +26,12 @@ import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Predicate;
+
+import static org.apache.commons.lang3.Strings.CS;
 
 public class TestFilterSink extends AbstractSinkTests {
 
@@ -65,7 +69,7 @@ public class TestFilterSink extends AbstractSinkTests {
     public void givenActualPredicate_whenFilteringItems_thenSomeItemsAreFiltered() {
         // Given
         List<String> values = Arrays.asList("foo", "bar", "faz");
-        Predicate<String> filter = x -> StringUtils.startsWith(x, "f");
+        Predicate<String> filter = x -> CS.startsWith(x, "f");
 
         // When and Then
         verifyFilter(values, filter, Arrays.asList("foo", "faz"));
@@ -75,7 +79,7 @@ public class TestFilterSink extends AbstractSinkTests {
     public void givenActualPredicate_whenFilteringItems_thenSomeItemsAreFiltered_andMetricsAreCorrect() {
         // Given
         List<String> values = Arrays.asList("foo", "bar", "faz");
-        Predicate<String> filter = x -> StringUtils.startsWith(x, "f");
+        Predicate<String> filter = x -> CS.startsWith(x, "f");
 
         // When, Then, And
         verifyFilter(values, filter, "filter_03", Arrays.asList("foo", "faz"));

--- a/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestRejectSink.java
+++ b/projectors-core/src/test/java/io/telicent/smart/cache/projectors/sinks/TestRejectSink.java
@@ -32,6 +32,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
+import static org.apache.commons.lang3.Strings.CS;
+
 public class TestRejectSink extends AbstractSinkTests {
 
     @Test
@@ -68,7 +70,7 @@ public class TestRejectSink extends AbstractSinkTests {
     public void givenActualPredicate_whenRejectingItems_thenSomeItemsAreRejected() {
         // Given
         List<String> values = Arrays.asList("foo", "bar", "faz");
-        Predicate<String> filter = x -> StringUtils.startsWith(x, "f");
+        Predicate<String> filter = x -> CS.startsWith(x, "f");
 
         // When and Then
         verifyReject(values, filter, Arrays.asList("foo", "faz"));
@@ -78,7 +80,7 @@ public class TestRejectSink extends AbstractSinkTests {
     public void givenActualPredicate_whenRejectingItems_thenSomeItemsAreRejected_andMetricsAreCorrect() {
         // Given
         List<String> values = Arrays.asList("foo", "bar", "faz");
-        Predicate<String> filter = x -> StringUtils.startsWith(x, "f");
+        Predicate<String> filter = x -> CS.startsWith(x, "f");
 
         // When, Then, And
         verifyReject(values, filter, "reject_03", Arrays.asList("foo", "faz"));


### PR DESCRIPTION
Updating deprecated code usage:
- String Util calls in Apache Common Lang 3 
- Predicate use from Apache Common Collection Utils 4

Fixing unchecked warnings:
- by adding a suppression
- or <> to infer the generic type 

Plus, I removed some overridden code that was identical to the super class. 

We might want to consider bumping the JDK version from 17 to 21 as Jena (which I believe was the reason we were on 17) is now up to 21+. 