### PR TITLE
Assorted minor Kafka improvements (CORE-880)

### DIFF
--- a/action-tracker/src/main/java/io/telicent/smart/cache/actions/tracker/SimpleActionTracker.java
+++ b/action-tracker/src/main/java/io/telicent/smart/cache/actions/tracker/SimpleActionTracker.java
@@ -121,6 +121,7 @@ public class SimpleActionTracker implements ActionTracker {
             }
             this.action = action;
             attemptTransition(ActionState.PROCESSING);
+            LOGGER.info("Started action '{}'", action);
         }
     }
 
@@ -136,6 +137,7 @@ public class SimpleActionTracker implements ActionTracker {
                                       this.action));
             }
             attemptTransition(ActionState.READY);
+            LOGGER.info("Finished action '{}'", action);
             this.action = null;
         }
     }

--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/commands/projection/AbstractKafkaProjectorCommand.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/commands/projection/AbstractKafkaProjectorCommand.java
@@ -168,7 +168,7 @@ public abstract class AbstractKafkaProjectorCommand<TKey, TValue, TOutput>
         return KafkaEventSource.<TKey, TValue>create()
                                .bootstrapServers(this.kafka.bootstrapServers)
                                .topics(this.kafka.topics)
-                               .consumerGroup(this.kafka.getConsumerGroup())
+                               .consumerGroup(this.kafka.getConsumerGroup(null))
                                .keyDeserializer(keyDeserializerClass())
                                .valueDeserializer(valueDeserializerClass())
                                .maxPollRecords(this.kafka.getMaxPollRecords())

--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/commands/projection/AbstractKafkaRdfProjectionCommand.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/commands/projection/AbstractKafkaRdfProjectionCommand.java
@@ -44,7 +44,7 @@ public abstract class AbstractKafkaRdfProjectionCommand<TOutput>
         return KafkaRdfPayloadSource.<Bytes>createRdfPayload()
                                     .bootstrapServers(this.kafka.bootstrapServers)
                                     .topics(this.kafka.topics)
-                                    .consumerGroup(this.kafka.getConsumerGroup())
+                                    .consumerGroup(this.kafka.getConsumerGroup(null))
                                     .consumerConfig(this.kafka.getAdditionalProperties())
                                     .keyDeserializer(BytesDeserializer.class)
                                     .maxPollRecords(this.kafka.getMaxPollRecords())

--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/KafkaOptions.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/KafkaOptions.java
@@ -27,6 +27,7 @@ import io.telicent.smart.cache.configuration.Configurator;
 import io.telicent.smart.cache.sources.kafka.config.KafkaConfiguration;
 import io.telicent.smart.cache.sources.kafka.policies.KafkaReadPolicies;
 import io.telicent.smart.cache.sources.kafka.policies.KafkaReadPolicy;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,8 +54,7 @@ public class KafkaOptions extends KafkaConfigurationOptions {
      * Kafka bootstrap servers
      */
     @Option(name = {
-            "--bootstrap-server",
-            "--bootstrap-servers"
+            "--bootstrap-server", "--bootstrap-servers"
     }, title = "BootstrapServers", description = "Provides a comma separated list of bootstrap servers to use for creating the initial connection to Kafka.")
     @SourceRequired(name = "Kafka", unlessEnvironment = KafkaConfiguration.BOOTSTRAP_SERVERS)
     public String bootstrapServers = Configurator.get(KafkaConfiguration.BOOTSTRAP_SERVERS);
@@ -63,22 +63,30 @@ public class KafkaOptions extends KafkaConfigurationOptions {
      * Kafka input topic
      */
     @Option(name = {
-            "-t",
-            "--topic"
+            "-t", "--topic"
     }, title = "KafkaTopic", description = "Provides the name of the Kafka topic(s) to read events from.  May be specified multiple times to supply multiple topics, when multiple topics are specified then they must all contain events that can be deserialized by this command otherwise errors will occur!")
-    @RequiredForSource(sourceName = "Kafka", unlessEnvironment = { KafkaConfiguration.TOPIC, KafkaConfiguration.INPUT_TOPIC })
-    public Set<String> topics = Configurator.get(new String[] { KafkaConfiguration.TOPIC, KafkaConfiguration.INPUT_TOPIC }, t -> {
-        Set<String> ts = new LinkedHashSet<>();
-        ts.add(t);
-        return ts;
-    }, new LinkedHashSet<>());
+    @RequiredForSource(sourceName = "Kafka", unlessEnvironment = {
+            KafkaConfiguration.TOPIC, KafkaConfiguration.INPUT_TOPIC
+    })
+    public Set<String> topics =
+            Configurator.get(new String[] { KafkaConfiguration.TOPIC, KafkaConfiguration.INPUT_TOPIC }, t -> {
+                Set<String> ts = new LinkedHashSet<>();
+                if (t.contains(",")) {
+                    // Multiple topics in the configuration value
+                    ts.addAll(Arrays.asList(t.split(",")));
+                    ts.removeIf(StringUtils::isBlank);
+                } else {
+                    // Single topic in the configuration value
+                    ts.add(t);
+                }
+                return ts;
+            }, new LinkedHashSet<>());
 
     /**
      * Kafka DLQ Topic
      */
     @Option(name = {
-            "-dlq",
-            "--dlq-topic"
+            "-dlq", "--dlq-topic"
     }, title = "KafkaDlqTopic", description = "Provides the name of a Kafka dead letter topic, where events with processing errors will be written.")
     public String dlqTopic = Configurator.get(KafkaConfiguration.DLQ_TOPIC);
 
@@ -86,8 +94,7 @@ public class KafkaOptions extends KafkaConfigurationOptions {
      * Kafka consumer group
      */
     @Option(name = {
-            "-g",
-            "--group"
+            "-g", "--group"
     }, title = "KafkaConsumerGroup", description = "Provides the name of the Kafka Consumer Group to use.  If not set defaults to the name of the command being invoked, or smart-cache if that is unknown.")
     private String group = Configurator.get(KafkaConfiguration.CONSUMER_GROUP);
 
@@ -115,27 +122,46 @@ public class KafkaOptions extends KafkaConfigurationOptions {
      * Gets the consumer group to use to take advantage of Kafka's Consumer Group features.
      * <p>
      * This may be provided explicitly by the user, either via the command line {@code -g/--group} option or the
-     * {@value KafkaConfiguration#CONSUMER_GROUP} environment variable.  If not provided explicitly then a suitable default will be
-     * automatically selected.  This default will be the name of the command being invoked, or if not used in the
-     * context of a command then defaults to {@value #DEFAULT_CONSUMER_GROUP}.
+     * {@value KafkaConfiguration#CONSUMER_GROUP} environment variable.  If not provided explicitly then a suitable
+     * default will be automatically selected.  This default will be the name of the command being invoked, or if not
+     * used in the context of a command then defaults to {@value #DEFAULT_CONSUMER_GROUP}.
+     * </p>
+     *
+     * @return Consumer Group to use
+     * @deprecated Use {@link #getConsumerGroup(String)} that allows the application to control the default value
+     * explicitly
+     */
+    @Deprecated(since = "0.29.3")
+    public String getConsumerGroup() {
+        return getConsumerGroup(null);
+    }
+
+    /**
+     * Gets the consumer group to use to take advantage of Kafka's Consumer Group features.
+     * <p>
+     * This may be provided explicitly by the user, either via the command line {@code -g/--group} option or the
+     * {@value KafkaConfiguration#CONSUMER_GROUP} environment variable.  If not provided explicitly then the provided
+     * default is used (the {@code defaultConsumerGroup} parameter) if present.  If that is not provided then a suitable
+     * default will be automatically selected, this auto-selected default will be the name of the command being invoked.
+     * Finally, if not used in the context of a command then defaults to {@value #DEFAULT_CONSUMER_GROUP}.
      * </p>
      *
      * @return Consumer Group to use
      */
-    public String getConsumerGroup() {
-        if (this.group != null) {
+    public String getConsumerGroup(String defaultConsumerGroup) {
+        // Use explicitly configured group if present, otherwise use the application provided default if present
+        if (StringUtils.isNotBlank(this.group)) {
             return this.group;
+        } else if (StringUtils.isNotBlank(defaultConsumerGroup)) {
+            return defaultConsumerGroup;
         }
 
-        String envValue = Configurator.get(new String[] { KafkaConfiguration.CONSUMER_GROUP }, null);
-        if (envValue != null) {
-            return envValue;
-        }
-
+        // If used in the context of a CLI Command find the name of that command and use that as the consumer group
         if (this.command != null) {
             return this.command.getName();
         }
 
+        // Finally fallback to the generic default value
         return DEFAULT_CONSUMER_GROUP;
     }
 
@@ -171,8 +197,7 @@ public class KafkaOptions extends KafkaConfigurationOptions {
         /**
          * Read from external source
          */
-        EXTERNAL
-        ;
+        EXTERNAL;
 
         /**
          * Converts into a Kafka Read Policy

--- a/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/options/TestKafkaOptions.java
+++ b/cli/cli-core/src/test/java/io/telicent/smart/cache/cli/commands/options/TestKafkaOptions.java
@@ -19,9 +19,13 @@ import io.telicent.smart.cache.cli.commands.AbstractCommandTests;
 import io.telicent.smart.cache.cli.commands.SmartCacheCommand;
 import io.telicent.smart.cache.cli.commands.SmartCacheCommandTester;
 import io.telicent.smart.cache.cli.options.KafkaOptions;
+import io.telicent.smart.cache.configuration.Configurator;
+import io.telicent.smart.cache.configuration.sources.PropertiesSource;
 import io.telicent.smart.cache.sources.kafka.KafkaTestCluster;
+import io.telicent.smart.cache.sources.kafka.config.KafkaConfiguration;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -29,6 +33,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Properties;
+import java.util.Set;
 
 public class TestKafkaOptions extends AbstractCommandTests {
 
@@ -43,6 +48,67 @@ public class TestKafkaOptions extends AbstractCommandTests {
         Assert.assertEquals(properties.get(key), bar);
     }
 
+    @AfterMethod
+    @Override
+    public void testCleanup() throws InterruptedException {
+        super.testCleanup();
+        Configurator.reset();
+    }
+
+    @Test
+    public void givenSingleTopicInConfig_whenParsing_thenSingleTopic() {
+        // Given
+        Properties properties = new Properties();
+        properties.put(KafkaConfiguration.TOPIC, KafkaTestCluster.DEFAULT_TOPIC);
+        Configurator.setSingleSource(new PropertiesSource(properties));
+
+        // When
+        String[] args = new String[] {
+                "--bootstrap-server", TEST_BOOTSTRAP_SERVERS
+        };
+        SmartCacheCommand.runAsSingleCommand(KafkaOptionsCommand.class, args);
+
+        // Then
+        Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 0);
+        Assert.assertEquals(getParsedKafkaOptions().topics, Set.of(KafkaTestCluster.DEFAULT_TOPIC));
+    }
+
+    @Test
+    public void givenMultipleTopicsInConfig_whenParsing_thenMultipleTopics() {
+        // Given
+        Properties properties = new Properties();
+        properties.put(KafkaConfiguration.TOPIC, KafkaTestCluster.DEFAULT_TOPIC + ",other,,another");
+        Configurator.setSingleSource(new PropertiesSource(properties));
+
+        // When
+        String[] args = new String[] {
+                "--bootstrap-server", TEST_BOOTSTRAP_SERVERS
+        };
+        SmartCacheCommand.runAsSingleCommand(KafkaOptionsCommand.class, args);
+
+        // Then
+        Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 0);
+        Assert.assertEquals(getParsedKafkaOptions().topics, Set.of(KafkaTestCluster.DEFAULT_TOPIC, "other", "another"));
+    }
+
+    @Test
+    public void givenTopicsInOptionsAndConfig_whenParsing_thenMultipleTopics() {
+        // Given
+        Properties properties = new Properties();
+        properties.put(KafkaConfiguration.TOPIC, KafkaTestCluster.DEFAULT_TOPIC);
+        Configurator.setSingleSource(new PropertiesSource(properties));
+        String[] args = new String[] {
+                "--bootstrap-servers", TEST_BOOTSTRAP_SERVERS, "--topic", "other"
+        };
+
+        // When
+        SmartCacheCommand.runAsSingleCommand(KafkaOptionsCommand.class, args);
+
+        // Then
+        Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 0);
+        Assert.assertEquals(getParsedKafkaOptions().topics, Set.of(KafkaTestCluster.DEFAULT_TOPIC, "other"));
+    }
+
     @Test
     public void givenMinimalKafkaArguments_whenParsing_thenNoAdditionalProperties() {
         // Given
@@ -55,13 +121,19 @@ public class TestKafkaOptions extends AbstractCommandTests {
 
         // Then
         Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 0);
-        Properties properties = getKafkaProperties();
+        Properties properties = getParsedKafkaProperties();
         Assert.assertTrue(properties.isEmpty());
     }
 
-    private static Properties getKafkaProperties() {
-        return ((KafkaOptionsCommand) SmartCacheCommandTester.getLastParseResult()
-                                                             .getCommand()).kafkaOptions.getAdditionalProperties();
+    private static Properties getParsedKafkaProperties() {
+        return getParsedKafkaOptions().getAdditionalProperties();
+    }
+
+    private static KafkaOptions getParsedKafkaOptions() {
+        Assert.assertNotNull(SmartCacheCommandTester.getLastParseResult(), "Should have successfully parsed options");
+        Assert.assertNotNull(SmartCacheCommandTester.getLastParseResult().getCommand(),
+                             "Should have successfully parsed options and created a command");
+        return ((KafkaOptionsCommand) SmartCacheCommandTester.getLastParseResult().getCommand()).kafkaOptions;
     }
 
     @Test
@@ -83,7 +155,7 @@ public class TestKafkaOptions extends AbstractCommandTests {
 
         // Then
         Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 0);
-        Properties properties = getKafkaProperties();
+        Properties properties = getParsedKafkaProperties();
         Assert.assertFalse(properties.isEmpty());
         verifyPropertyExists(properties, SaslConfigs.SASL_JAAS_CONFIG);
     }
@@ -109,7 +181,7 @@ public class TestKafkaOptions extends AbstractCommandTests {
 
         // Then
         Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 0);
-        Properties properties = getKafkaProperties();
+        Properties properties = getParsedKafkaProperties();
         Assert.assertFalse(properties.isEmpty());
         verifyPropertyExists(properties, SaslConfigs.SASL_JAAS_CONFIG);
         Assert.assertEquals(properties.getProperty(SaslConfigs.SASL_MECHANISM), "SCRAM-SHA-256");
@@ -133,7 +205,7 @@ public class TestKafkaOptions extends AbstractCommandTests {
 
         // Then
         Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 0);
-        Properties properties = getKafkaProperties();
+        Properties properties = getParsedKafkaProperties();
         Assert.assertFalse(properties.isEmpty());
         verifyPropertyValue(properties, "foo", "bar");
     }
@@ -161,7 +233,7 @@ public class TestKafkaOptions extends AbstractCommandTests {
 
         // Then
         Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 0);
-        Properties properties = getKafkaProperties();
+        Properties properties = getParsedKafkaProperties();
         Assert.assertFalse(properties.isEmpty());
         verifyPropertyValue(properties, "foo", "bar");
         verifyPropertyValue(properties, "key", "value");
@@ -186,7 +258,8 @@ public class TestKafkaOptions extends AbstractCommandTests {
                     TEST_BOOTSTRAP_SERVERS,
                     "--topic",
                     KafkaTestCluster.DEFAULT_TOPIC,
-                    "--kafka-properties", temp.getAbsolutePath()
+                    "--kafka-properties",
+                    temp.getAbsolutePath()
             };
 
             // When
@@ -194,7 +267,7 @@ public class TestKafkaOptions extends AbstractCommandTests {
 
             // Then
             Assert.assertEquals(SmartCacheCommandTester.getLastExitStatus(), 0);
-            Properties properties = getKafkaProperties();
+            Properties properties = getParsedKafkaProperties();
             Assert.assertFalse(properties.isEmpty());
             verifyPropertyValue(properties, "foo", "bar");
             verifyPropertyValue(properties, "key", "value");

--- a/cli/cli-debug/src/main/java/io/telicent/smart/cache/cli/commands/projection/debug/Capture.java
+++ b/cli/cli-debug/src/main/java/io/telicent/smart/cache/cli/commands/projection/debug/Capture.java
@@ -80,7 +80,7 @@ public class Capture extends AbstractKafkaProjectorCommand<Bytes, Bytes, Event<B
                 .valueDeserializer(BytesDeserializer.class)
                 .bootstrapServers(this.kafka.bootstrapServers)
                 .topics(this.kafka.topics)
-                .consumerGroup(this.kafka.getConsumerGroup())
+                .consumerGroup(this.kafka.getConsumerGroup("smart-cache-debug-capture"))
                 .consumerConfig(this.kafka.getAdditionalProperties())
                 .maxPollRecords(this.kafka.getMaxPollRecords())
                 .readPolicy(this.kafka.readPolicy.toReadPolicy())
@@ -88,8 +88,8 @@ public class Capture extends AbstractKafkaProjectorCommand<Bytes, Bytes, Event<B
     }
 
     @Override
-    protected Projector getProjector() {
-        return new NoOpProjector();
+    protected Projector<Event<Bytes, Bytes>, Event<Bytes, Bytes>> getProjector() {
+        return new NoOpProjector<>();
     }
 
     @Override

--- a/cli/cli-debug/src/main/java/io/telicent/smart/cache/cli/commands/projection/debug/Dump.java
+++ b/cli/cli-debug/src/main/java/io/telicent/smart/cache/cli/commands/projection/debug/Dump.java
@@ -82,7 +82,7 @@ public class Dump extends AbstractKafkaProjectorCommand<Bytes, String, Event<Str
                 .valueDeserializer(StringDeserializer.class)
                 .bootstrapServers(this.kafka.bootstrapServers)
                 .topics(this.kafka.topics)
-                .consumerGroup(this.kafka.getConsumerGroup())
+                .consumerGroup(this.kafka.getConsumerGroup("smart-cache-debug-dump"))
                 .consumerConfig(this.kafka.getAdditionalProperties())
                 .maxPollRecords(this.kafka.getMaxPollRecords())
                 .readPolicy(this.kafka.readPolicy.toReadPolicy())
@@ -93,8 +93,8 @@ public class Dump extends AbstractKafkaProjectorCommand<Bytes, String, Event<Str
     }
 
     @Override
-    protected Projector getProjector() {
-        return new NoOpProjector();
+    protected Projector<Event<Bytes, String>, Event<String, String>> getProjector() {
+        return (e, s) -> s.send(e.replaceKey(null));
     }
 
     @Override

--- a/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliDumpCommand.java
+++ b/cli/cli-debug/src/test/java/io/telicent/smart/cache/cli/commands/debug/DockerTestDebugCliDumpCommand.java
@@ -186,7 +186,7 @@ public class DockerTestDebugCliDumpCommand extends AbstractDockerDebugCliTests {
         verifyDumpCommandUsed();
         YamlOffsetStore store = new YamlOffsetStore(offsetsFile);
         Assert.assertEquals(store.<Long>loadOffset(
-                KafkaEventSource.externalOffsetStoreKey(KafkaTestCluster.DEFAULT_TOPIC, 0, "dump")), 10L);
+                KafkaEventSource.externalOffsetStoreKey(KafkaTestCluster.DEFAULT_TOPIC, 0, "smart-cache-debug-dump")), 10L);
         String stdErr = SmartCacheCommandTester.getLastStdErr();
         Assert.assertTrue(CS.contains(stdErr, "no persistent offsets"));
     }

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/AbstractReadPolicy.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/policies/AbstractReadPolicy.java
@@ -52,14 +52,20 @@ public abstract class AbstractReadPolicy<TKey, TValue> implements KafkaReadPolic
 
     /**
      * We create a basic cache to control the amount of repeated status messages logged that add no value.
+     * <p>
+     * Note that we could be configured to subscribe to multiple topics in which case the cache needs to allow for a few
+     * different values otherwise as soon as we're configured with multiple topics it does nothing to actually suppress
+     * duplicate messages.
+     * </p>
      */
+    //@formatter:off
     protected static final Cache<String, Boolean> LOGGING_CACHE =
             Caffeine.newBuilder()
                     .expireAfterWrite(Duration.ofMinutes(5))
-                    .initialCapacity(1)
-                    .maximumSize(1)
+                    .initialCapacity(10)
+                    .maximumSize(10)
                     .build();
-
+    //@formatter:on
 
     @Override
     public void prepareConsumerConfiguration(Properties props) {
@@ -128,10 +134,13 @@ public abstract class AbstractReadPolicy<TKey, TValue> implements KafkaReadPolic
             long position = this.consumer.position(p);
             OptionalLong currentLag = this.consumer.currentLag(p);
             String knownLag = currentLag.isPresent() ? String.format("%,d", currentLag.getAsLong()) : "unknown";
+            String consumerGroup =
+                    this.consumer.groupMetadata() != null ? this.consumer.groupMetadata().groupId() : "unknown";
             String key = String.format("%s-%d-%s", p, position, knownLag);
             if (LOGGING_CACHE.getIfPresent(key) == null) {
-                FmtLog.info(logger, "Kafka Partition %s is at position %,d with a current lag of %s", p,
-                            position, knownLag);
+                FmtLog.info(logger,
+                            "Kafka Partition %s (Consumer Group '%s') is at position %,d with a current lag of %s",
+                            p, consumerGroup, position, knownLag);
                 LOGGING_CACHE.put(key, Boolean.TRUE);
             }
         });


### PR DESCRIPTION
- Include consumer group in logged read position
- Increase size of read positions cache so when multiple consumers are in use we actually suppress duplicate messages
- Improved `-t`/`--topic` option support for external configuration so that the env vars can be specified with a comma separated list of topics
- Improved `getConsumerGroup()` method so that application can now supply a more meaningful default value when not explicitly configured by user