### PR TITLE
[CORE-903] Moving Document pipeline headers to core

### DIFF
--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/TelicentHeaders.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/TelicentHeaders.java
@@ -64,6 +64,7 @@ public class TelicentHeaders {
 
     /**
      * Event header used to identify the type of the data source/pipeline that an event originated from
+     * @deprecated Replaced by {@link #DISTRIBUTION_ID}
      */
     @Deprecated
     public static final String DATA_SOURCE_TYPE = "Data-Source-Type";

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/TelicentHeaders.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/TelicentHeaders.java
@@ -68,7 +68,7 @@ public class TelicentHeaders {
     public static final String DATA_SOURCE_TYPE = "Data-Source-Type";
 
     /**
-     * Event header used to identify the type of the data source/pipeline that an event originated from.
+     * Event header used to identify the source reference for a specific event
      * Replaces deprecated DATA_SOURCE_NAME and DATA_SOURCE_TYPE
      */
     public static final String DATA_SOURCE_REFERENCE = "Data-Source-Reference";

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/TelicentHeaders.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/TelicentHeaders.java
@@ -57,6 +57,7 @@ public class TelicentHeaders {
 
     /**
      * Event header used to identify the name of the data source/pipeline that an event originated from
+     * @deprecated Replaced by {@link #DISTRIBUTION_ID}
      */
     @Deprecated
     public static final String DATA_SOURCE_NAME = "Data-Source-Name";

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/TelicentHeaders.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/TelicentHeaders.java
@@ -76,7 +76,7 @@ public class TelicentHeaders {
     /**
      * Distribution ID header for the distribution of data being ingested.
      */
-    public static final String DISTRIBUTION_ID_HEADER = "Distribution-Id";
+    public static final String DISTRIBUTION_ID = "Distribution-Id";
 
     /**
      * EDH/IDH policy information header for the data being ingested.

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/TelicentHeaders.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/TelicentHeaders.java
@@ -58,10 +58,28 @@ public class TelicentHeaders {
     /**
      * Event header used to identify the name of the data source/pipeline that an event originated from
      */
+    @Deprecated
     public static final String DATA_SOURCE_NAME = "Data-Source-Name";
 
     /**
      * Event header used to identify the type of the data source/pipeline that an event originated from
      */
+    @Deprecated
     public static final String DATA_SOURCE_TYPE = "Data-Source-Type";
+
+    /**
+     * Event header used to identify the type of the data source/pipeline that an event originated from.
+     * Replaces deprecated DATA_SOURCE_NAME and DATA_SOURCE_TYPE
+     */
+    public static final String DATA_SOURCE_REFERENCE = "Data-Source-Reference";
+
+    /**
+     * Distribution ID header for the distribution of data being ingested.
+     */
+    public static final String DISTRIBUTION_ID_HEADER = "Distribution-Id";
+
+    /**
+     * EDH/IDH policy information header for the data being ingested.
+     */
+    public static final String POLICY_INFORMATION_HEADER = "Policy-Information";
 }


### PR DESCRIPTION
Where they are more suitably placed. 
Also deprecating older headers ahead of eventual removal.