### PR TITLE
CORE-859: fixing bug in CORS filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 # 0.29.4
 
 - Updating Telicent HEADERS:
-  - adding Distribution ID & Data Source Reference. 
+  - adding Distribution ID & Data Source Reference.
+  - fixed a bug in CORS filtering that prevented allowed methods being recognised
 
 # 0.29.3
 

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/filters/CrossOriginFilter.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/filters/CrossOriginFilter.java
@@ -477,7 +477,7 @@ public class CrossOriginFilter implements Filter {
         }
 
         List<String> requestedHeaders = new ArrayList<>();
-        String[] headers = StringUtils.split(accessControlRequestHeaders, ",");
+        String[] headers = StringUtils.split(accessControlRequestHeaders, DefaultCorsConfiguration.CORS_DELIMITER);
         for (String header : headers) {
             String h = header.trim();
             if (!h.isEmpty()) {

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/filters/DefaultCorsConfiguration.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/filters/DefaultCorsConfiguration.java
@@ -30,7 +30,7 @@ public class DefaultCorsConfiguration {
     /**
      * The delimiter used in CORS headers to separate the items in a list
      */
-    public static final String CORS_DELIMITER = ", ";
+    public static final String CORS_DELIMITER = ",";
 
     /**
      * The HTTP Headers that may be accessed by scripts in response to a pre-flight request


### PR DESCRIPTION
Decided to fix this issue as it was preventing me from testing [CORE-912](https://github.com/telicent-oss/smart-caches-core/compare/CORE-912) with the Swagger UI.

I have tested a snapshot build of this locally with smart-cache-documents and can confirm it resolves the problem I originally reported in [CORE-859](https://github.com/telicent-oss/smart-caches-core/compare/CORE-859).

[CORE-912]: https://telicent.atlassian.net/browse/CORE-912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-859]: https://telicent.atlassian.net/browse/CORE-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ