### PR TITLE
Allow ProjectorDriver logging to be labelled (CORE-905)

### DIFF
--- a/projector-driver/src/main/java/io/telicent/smart/cache/projectors/driver/ProjectorDriver.java
+++ b/projector-driver/src/main/java/io/telicent/smart/cache/projectors/driver/ProjectorDriver.java
@@ -190,7 +190,7 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
                 }
 
                 if (this.limit >= 0 && this.tracker.processedCount() >= this.limit) {
-                    FmtLog.info(LOGGER, "%sReached configured event limit of %,d events", this.logLabel, this.limit);
+                    FmtLog.info(LOGGER, "%s Reached configured event limit of %,d events", this.logLabel, this.limit);
                     this.shouldRun = false;
                     break;
                 }
@@ -199,7 +199,7 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
                 boolean expectToBlock = !this.source.availableImmediately();
 
                 if (this.source.isExhausted()) {
-                    LOGGER.info("{}Event Source indicates all events have been exhausted, ending projection",
+                    LOGGER.info("{} Event Source indicates all events have been exhausted, ending projection",
                                 this.logLabel);
                     this.shouldRun = false;
                     break;
@@ -210,14 +210,14 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
                 if (event == null) {
                     // Log timeout, whether we choose to abort depends on whether we were expecting to block or not i.e.
                     // whether the source reliably reported the availability of further events
-                    LOGGER.debug("{}Timed out waiting for Event Source to return more events, waited {}", this.logLabel,
+                    LOGGER.debug("{} Timed out waiting for Event Source to return more events, waited {}", this.logLabel,
                                  this.pollTimeout);
                     this.stalls.add(1, this.metricAttributes);
                     this.consecutiveStallsCount++;
 
                     if (!expectToBlock) {
                         LOGGER.warn(
-                                "{}Event Source incorrectly indicated that events were available but failed to return them, aborting projection",
+                                "{} Event Source incorrectly indicated that events were available but failed to return them, aborting projection",
                                 this.logLabel);
                         this.shouldRun = false;
                         break;
@@ -225,7 +225,7 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
 
                     if (this.maxStalls > 0 && this.consecutiveStallsCount >= this.maxStalls) {
                         LOGGER.info(
-                                "{}Event Source is stalled, no new events have been received on the last {} polls, aborting projection",
+                                "{} Event Source is stalled, no new events have been received on the last {} polls, aborting projection",
                                 this.logLabel, this.maxStalls);
                         this.shouldRun = false;
                         break;
@@ -246,10 +246,10 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
                             // and actually make it harder to debug any real problems that occur
                             if (remaining == 0L) {
                                 LOGGER.info(
-                                        "{}Event Source reports it currently has 0 events remaining i.e. all events have been processed",
+                                        "{} Event Source reports it currently has 0 events remaining i.e. all events have been processed",
                                         this.logLabel);
                             } else {
-                                FmtLog.info(LOGGER, "%sEvent Source reports it only has %,d events remaining",
+                                FmtLog.info(LOGGER, "%s Event Source reports it only has %,d events remaining",
                                             this.logLabel, remaining);
                             }
 
@@ -258,7 +258,7 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
                             double overallRate = this.tracker.getOverallRate();
                             if (overallRate > remaining && this.processingSpeedWarnings) {
                                 FmtLog.warn(LOGGER,
-                                            "%sOverall processing rate (%.3f events/seconds) is greater than remaining events (%,d).  Application performance is being reduced by a slower upstream producer writing to %s",
+                                            "%s Overall processing rate (%.3f events/seconds) is greater than remaining events (%,d).  Application performance is being reduced by a slower upstream producer writing to %s",
                                             this.logLabel, overallRate, remaining, this.source.toString());
                             }
                         }
@@ -273,7 +273,7 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
         } catch (Throwable e) {
             // Log only if not some form of interrupt
             if (!CS.contains(e.getClass().getCanonicalName(), "Interrupt")) {
-                LOGGER.warn("{}Projector Driver aborting due to error: {}", this.logLabel, e.getMessage());
+                LOGGER.warn("{} Projector Driver aborting due to error: {}", this.logLabel, e.getMessage());
                 throw e;
             }
         } finally {

--- a/projector-driver/src/main/java/io/telicent/smart/cache/projectors/driver/ProjectorDriver.java
+++ b/projector-driver/src/main/java/io/telicent/smart/cache/projectors/driver/ProjectorDriver.java
@@ -29,6 +29,7 @@ import io.telicent.smart.cache.projectors.utils.ThroughputTracker;
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.EventSource;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.jena.atlas.logging.FmtLog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,6 +86,8 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
     @Getter
     private final long limit, maxStalls;
     private long consecutiveStallsCount;
+    @Getter
+    private final String logLabel;
     private final ThroughputTracker tracker;
     private final boolean processingSpeedWarnings;
     private volatile boolean shouldRun = true;
@@ -112,7 +115,8 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
     @SuppressWarnings("resource")
     ProjectorDriver(EventSource<TKey, TValue> source, Duration pollTimeout,
                     Projector<Event<TKey, TValue>, TOutput> projector, Supplier<Sink<TOutput>> outputSinkSupplier,
-                    long limit, long maxStalls, long reportBatchSize, boolean processingSpeedWarnings) {
+                    long limit, long maxStalls, long reportBatchSize, String logLabel,
+                    boolean processingSpeedWarnings) {
         Objects.requireNonNull(source, "Event Source cannot be null");
         Objects.requireNonNull(projector, "Projector cannot be null");
         Objects.requireNonNull(outputSinkSupplier, "Sink Supplier cannot be null");
@@ -124,6 +128,7 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
         this.sinkSupplier = outputSinkSupplier;
         this.limit = limit;
         this.maxStalls = maxStalls;
+        this.logLabel = StringUtils.isNotBlank(logLabel) ? logLabel : "";
         this.processingSpeedWarnings = processingSpeedWarnings;
 
         if (this.projector instanceof StallAwareProjector<Event<TKey, TValue>, TOutput> stallAwareProjector) {
@@ -179,12 +184,13 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
 
             while (this.shouldRun) {
                 if (this.source.isClosed()) {
-                    LOGGER.warn("Event Source has been closed outside of our control, aborting projection");
+                    LOGGER.warn("{}Event Source has been closed outside of our control, aborting projection",
+                                this.logLabel);
                     throw new IllegalStateException("Event Source closed externally");
                 }
 
                 if (this.limit >= 0 && this.tracker.processedCount() >= this.limit) {
-                    FmtLog.info(LOGGER, "Reached configured event limit of %,d events", this.limit);
+                    FmtLog.info(LOGGER, "%sReached configured event limit of %,d events", this.logLabel, this.limit);
                     this.shouldRun = false;
                     break;
                 }
@@ -193,7 +199,8 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
                 boolean expectToBlock = !this.source.availableImmediately();
 
                 if (this.source.isExhausted()) {
-                    LOGGER.info("Event Source indicates all events have been exhausted, ending projection");
+                    LOGGER.info("{}Event Source indicates all events have been exhausted, ending projection",
+                                this.logLabel);
                     this.shouldRun = false;
                     break;
                 }
@@ -203,22 +210,23 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
                 if (event == null) {
                     // Log timeout, whether we choose to abort depends on whether we were expecting to block or not i.e.
                     // whether the source reliably reported the availability of further events
-                    LOGGER.debug("Timed out waiting for Event Source to return more events, waited {}",
+                    LOGGER.debug("{}Timed out waiting for Event Source to return more events, waited {}", this.logLabel,
                                  this.pollTimeout);
                     this.stalls.add(1, this.metricAttributes);
                     this.consecutiveStallsCount++;
 
                     if (!expectToBlock) {
                         LOGGER.warn(
-                                "Event Source incorrectly indicated that events were available but failed to return them, aborting projection");
+                                "{}Event Source incorrectly indicated that events were available but failed to return them, aborting projection",
+                                this.logLabel);
                         this.shouldRun = false;
                         break;
                     }
 
                     if (this.maxStalls > 0 && this.consecutiveStallsCount >= this.maxStalls) {
                         LOGGER.info(
-                                "Event Source is stalled, no new events have been received on the last {} polls, aborting projection",
-                                this.maxStalls);
+                                "{}Event Source is stalled, no new events have been received on the last {} polls, aborting projection",
+                                this.logLabel, this.maxStalls);
                         this.shouldRun = false;
                         break;
                     }
@@ -238,9 +246,11 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
                             // and actually make it harder to debug any real problems that occur
                             if (remaining == 0L) {
                                 LOGGER.info(
-                                        "Event Source reports it currently has 0 events remaining i.e. all events have been processed");
+                                        "{}Event Source reports it currently has 0 events remaining i.e. all events have been processed",
+                                        this.logLabel);
                             } else {
-                                FmtLog.info(LOGGER, "Event Source reports it only has %,d events remaining", remaining);
+                                FmtLog.info(LOGGER, "%sEvent Source reports it only has %,d events remaining",
+                                            this.logLabel, remaining);
                             }
 
                             // Also if our current throughput is higher than the remaining events then we are being blocked
@@ -248,8 +258,8 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
                             double overallRate = this.tracker.getOverallRate();
                             if (overallRate > remaining && this.processingSpeedWarnings) {
                                 FmtLog.warn(LOGGER,
-                                            "Overall processing rate (%.3f events/seconds) is greater than remaining events (%,d).  Application performance is being reduced by a slower upstream producer writing to %s",
-                                            overallRate, remaining, this.source.toString());
+                                            "%sOverall processing rate (%.3f events/seconds) is greater than remaining events (%,d).  Application performance is being reduced by a slower upstream producer writing to %s",
+                                            this.logLabel, overallRate, remaining, this.source.toString());
                             }
                         }
                     }
@@ -263,7 +273,7 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
         } catch (Throwable e) {
             // Log only if not some form of interrupt
             if (!CS.contains(e.getClass().getCanonicalName(), "Interrupt")) {
-                LOGGER.warn("Projector Driver aborting due to error: {}", e.getMessage());
+                LOGGER.warn("{}Projector Driver aborting due to error: {}", this.logLabel, e.getMessage());
                 throw e;
             }
         } finally {

--- a/projector-driver/src/main/java/io/telicent/smart/cache/projectors/driver/ProjectorDriverBuilder.java
+++ b/projector-driver/src/main/java/io/telicent/smart/cache/projectors/driver/ProjectorDriverBuilder.java
@@ -39,6 +39,7 @@ public class ProjectorDriverBuilder<TKey, TValue, TOutput> {
     private Projector<Event<TKey, TValue>, TOutput> projector;
     private Supplier<Sink<TOutput>> sinkSupplier;
     private long limit = -1, maxStalls = 0, reportBatchSize = 10_000L;
+    private String logLabel;
     private boolean processingSpeedWarnings = true;
 
     /**
@@ -205,6 +206,7 @@ public class ProjectorDriverBuilder<TKey, TValue, TOutput> {
      * <p>
      * See {@link #processingSpeedWarnings(boolean)} for details.
      * </p>
+     *
      * @return Builder
      */
     public ProjectorDriverBuilder<TKey, TValue, TOutput> enableProcessingSpeedWarnings() {
@@ -216,10 +218,26 @@ public class ProjectorDriverBuilder<TKey, TValue, TOutput> {
      * <p>
      * See {@link #processingSpeedWarnings(boolean)} for details.
      * </p>
+     *
      * @return Builder
      */
     public ProjectorDriverBuilder<TKey, TValue, TOutput> disabledProcessingSpeedWarnings() {
         return processingSpeedWarnings(false);
+    }
+
+    /**
+     * Specifies a label that will be used at the start of log messages
+     * <p>
+     * This is useful for applications that run multiple {@link ProjectorDriver} instances to help make log output
+     * clearer.
+     * </p>
+     *
+     * @param logLabel Log label
+     * @return Builder
+     */
+    public ProjectorDriverBuilder<TKey, TValue, TOutput> logLabel(String logLabel) {
+        this.logLabel = logLabel;
+        return this;
     }
 
     /**
@@ -228,7 +246,7 @@ public class ProjectorDriverBuilder<TKey, TValue, TOutput> {
      * @return Projector Driver
      */
     public ProjectorDriver<TKey, TValue, TOutput> build() {
-        return new ProjectorDriver<>(source, pollTimeout, projector, sinkSupplier, limit, maxStalls,
-                                     reportBatchSize, processingSpeedWarnings);
+        return new ProjectorDriver<>(source, pollTimeout, projector, sinkSupplier, limit, maxStalls, reportBatchSize,
+                                     logLabel, processingSpeedWarnings);
     }
 }

--- a/projector-driver/src/test/java/io/smart/cache/projectors/driver/TestProjectorDriver.java
+++ b/projector-driver/src/test/java/io/smart/cache/projectors/driver/TestProjectorDriver.java
@@ -262,6 +262,7 @@ public class TestProjectorDriver {
                                .projector(new NoOpProjector<>())
                                .destination(sink)
                                .unlimited()
+                               .logLabel("[test] ")
                                .build();
 
         // When
@@ -270,6 +271,7 @@ public class TestProjectorDriver {
 
         // Then
         Assert.assertTrue(source.isClosed());
+        verifyLogging(Level.INFO, "[test]");
     }
 
     @Test

--- a/projector-driver/src/test/java/io/smart/cache/projectors/driver/TestProjectorDriver.java
+++ b/projector-driver/src/test/java/io/smart/cache/projectors/driver/TestProjectorDriver.java
@@ -262,7 +262,7 @@ public class TestProjectorDriver {
                                .projector(new NoOpProjector<>())
                                .destination(sink)
                                .unlimited()
-                               .logLabel("[test] ")
+                               .logLabel("[test]")
                                .build();
 
         // When


### PR DESCRIPTION
When multiple `ProjectorDriver`'s are running in an application there logging is interleaved which can make it hard to parse/debug.  This commit adds the ability to specify a log label on a driver which is then inserted at the start of all logging from the `ProjectorDriver` to make the logs easier to read.