### PR TITLE
Ignore Kafka tombstones by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+# 0.37.0
+
+- Kafka improvements:
+    - `KafkaEventSource` implementations will now ignore tombstone events by default (those with `null` values),
+      applications that wish to continue to receive these can now specify `ignoreTombstones(false)` when building their
+      source
+    - Fixed some edge cases with various Kafka `Serializer`/`Deserializer` implementations around handling of `null`
+      values
+
 # 0.36.3
 
 - Build improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
     - `KafkaEventSource` implementations will now ignore tombstone events by default (those with `null` values),
       applications that wish to continue to receive these can now specify `ignoreTombstones(false)` when building their
       source
+        - Note that applications that configure their source for manual commits, i.e. `commitOnProcessed()`, should
+          consider whether they actually want to ignore tombstones or not.  In this configuration a large sequence of
+          trailing tombstones could force a large amount of tombstone reprocessing should the application be restarted.
+        - Please see Javadoc on the `ignoreTombstones()` builder method for more details
     - Fixed some edge cases with various Kafka `Serializer`/`Deserializer` implementations around handling of `null`
       values
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 # 0.37.0
 
+- Event Source improvements:
+    - **BREAKING** `Event.source()` now uses a wildcard type reference rather than a raw type to reduce compiler
+      warnings
+    - **BREAKING** `EventSource.processed()` now uses a wildcard type reference rather than a raw type to reduce
+      compiler warnings
 - Kafka improvements:
     - `KafkaEventSource` implementations will now ignore tombstone events by default (those with `null` values),
       applications that wish to continue to receive these can now specify `ignoreTombstones(false)` when building their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # 0.37.0
 
 - Event Source improvements:
+    - `AbstractBufferedEventSource` pulled up into `event-sources-core` module
+    - **BREAKING** `AbstractBufferedEventSource` now has `boolean` return value from `tryFillBuffer()` and more 
+      intelligent `poll()` behaviour based on that return value
     - **BREAKING** `Event.source()` now uses a wildcard type reference rather than a raw type to reduce compiler
       warnings
     - **BREAKING** `EventSource.processed()` now uses a wildcard type reference rather than a raw type to reduce

--- a/action-tracker/pom.xml
+++ b/action-tracker/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <artifactId>action-tracker</artifactId>
     <name>Telicent Smart Caches - Action Tracker</name>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>benchmarks</artifactId>

--- a/cli/cli-core/pom.xml
+++ b/cli/cli-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli-core</artifactId>

--- a/cli/cli-debug/pom.xml
+++ b/cli/cli-debug/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>cli</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli-debug</artifactId>

--- a/cli/cli-probe-server/pom.xml
+++ b/cli/cli-probe-server/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>cli</artifactId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <artifactId>cli-probe-server</artifactId>
     <name>Telicent Smart Caches - CLI - Health Probe Server</name>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cli</artifactId>

--- a/configurator/pom.xml
+++ b/configurator/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <artifactId>configurator</artifactId>
     <name>Telicent Smart Caches - Configuration API</name>

--- a/event-sources/event-source-file/pom.xml
+++ b/event-sources/event-source-file/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-source-file</artifactId>

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/FileEventSource.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/FileEventSource.java
@@ -112,7 +112,7 @@ public class FileEventSource<TKey, TValue> implements EventSource<TKey, TValue> 
     }
 
     @Override
-    public void processed(Collection<Event> processedEvents) {
+    public void processed(Collection<Event<?,?>> processedEvents) {
         // No-op
         LOGGER.trace("Received {} processed events in processed() callback, this is ignored by the FileEventSource",
                      processedEvents.size());

--- a/event-sources/event-source-kafka/pom.xml
+++ b/event-sources/event-source-kafka/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-source-kafka</artifactId>

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractBufferedEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractBufferedEventSource.java
@@ -90,18 +90,40 @@ public abstract class AbstractBufferedEventSource<TIntermediate, TKey, TValue> i
             throw new IllegalStateException("Event source has been closed");
         }
 
-        // If we have some events buffered continue returning them
+        // If we have some events buffered continue returning them, no need to worry about timeout as this should be
+        // essentially immediate
         if (!events.isEmpty()) {
             return this.decodeEvent(events.poll());
         }
 
         // The buffer has now been exhausted, allow the derived implementation chance to do any state management it
         // needs and then ask it to refill the buffer
-        bufferExhausted();
-        tryFillBuffer(timeout);
+        // Depending on the derived implementation it's possible this might fail to fill the buffer BUT still have time
+        // remaining on its timeout, in which case we keep going round the loop and decreasing our timeout until it is
+        // fully exhausted
+        long start = System.currentTimeMillis();
+        Duration remainingTimeout = timeout;
+        while (events.isEmpty() && remainingTimeout != null) {
+            bufferExhausted();
+            tryFillBuffer(remainingTimeout);
+
+            if (events.isEmpty()) {
+                remainingTimeout = updateTimeout(start, timeout);
+            }
+        }
 
         // Return the next buffered event, or null if no events available
         return this.decodeEvent(events.poll());
+    }
+
+    public static Duration updateTimeout(long start, Duration timeout) {
+        long elapsed = System.currentTimeMillis() - start;
+        long remainingTime = timeout.toMillis() - elapsed;
+        if (remainingTime <= 0) {
+            return null;
+        } else {
+            return Duration.ofMillis(remainingTime);
+        }
     }
 
     /**

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractBufferedEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractBufferedEventSource.java
@@ -106,8 +106,8 @@ public abstract class AbstractBufferedEventSource<TIntermediate, TKey, TValue> i
         while (events.isEmpty() && remainingTimeout != null) {
             bufferExhausted();
             if (tryFillBuffer(remainingTimeout)) {
-                // If tryFillBuffer() indicates it was interrupted then return immediately regardless of whether we
-                // have remaining timeout
+                // If tryFillBuffer() indicates it was interrupted/genuinely empty then return immediately regardless of
+                // whether we have remaining timeout
                 return this.decodeEvent(events.poll());
             }
 
@@ -133,9 +133,16 @@ public abstract class AbstractBufferedEventSource<TIntermediate, TKey, TValue> i
     /**
      * Try to refill the buffer with the next available events.  If no new events are available within the timeout leave
      * the buffer unmodified.
+     * <p>
+     * The return value of this method controls whether the {@link #poll(Duration)} method may call this method again to
+     * retry refilling the buffer.  A {@code true} value indicates that the refill operation was interrupted,
+     * <strong>OR</strong> genuinely had no new available, in which case {@link #poll(Duration)} will return
+     * immediately.  Therefore, implementations should ensure that they return {@code true} or {@code false}
+     * appropriately.
+     * </p>
      *
      * @param timeout Timeout
-     * @return True if interrupted, false otherwise
+     * @return True if interrupted or genuinely no events currently available, false otherwise
      * @throws io.telicent.smart.cache.sources.EventSourceException Should be thrown if an unrecoverable error is
      *                                                              encountered
      */

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractBufferedEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractBufferedEventSource.java
@@ -105,7 +105,11 @@ public abstract class AbstractBufferedEventSource<TIntermediate, TKey, TValue> i
         Duration remainingTimeout = timeout;
         while (events.isEmpty() && remainingTimeout != null) {
             bufferExhausted();
-            tryFillBuffer(remainingTimeout);
+            if (tryFillBuffer(remainingTimeout)) {
+                // If tryFillBuffer() indicates it was interrupted then return immediately regardless of whether we
+                // have remaining timeout
+                return this.decodeEvent(events.poll());
+            }
 
             if (events.isEmpty()) {
                 remainingTimeout = updateTimeout(start, timeout);
@@ -131,8 +135,11 @@ public abstract class AbstractBufferedEventSource<TIntermediate, TKey, TValue> i
      * the buffer unmodified.
      *
      * @param timeout Timeout
+     * @return True if interrupted, false otherwise
+     * @throws io.telicent.smart.cache.sources.EventSourceException Should be thrown if an unrecoverable error is
+     *                                                              encountered
      */
-    protected abstract void tryFillBuffer(Duration timeout);
+    protected abstract boolean tryFillBuffer(Duration timeout);
 
     /**
      * Gives derived implementations a chance to carry out any state management they might need to track the fact that

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractKafkaEventSourceBuilder.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractKafkaEventSourceBuilder.java
@@ -293,6 +293,19 @@ public abstract class AbstractKafkaEventSourceBuilder<TKey, TValue, TSource exte
      * application code needs to be implemented such that the value of events can be {@code null} and it does not
      * blindly try and call {@code .value().someMethod()} on events retrieved from this source.
      * </p>
+     * <p>
+     * Note that if ignoring tombstones in combination with manually committing offsets, i.e.
+     * {@link #commitOnProcessed()}, then applications need to be careful.  If a topic contains a large trailing
+     * sequence of tombstones that application will only ever be able to commit offsets up to the last non-tombstone
+     * event.  Therefore, upon restart it will need to reprocess all the tombstone events before processing any new
+     * events after the tombstones.  While reprocessing tombstones should be relatively quick this could become a
+     * problem if very large deletes generating huge numbers of tombstones can happen on your Kafka topic.  Therefore,
+     * applications that use manual commits should consider whether it is better to not ignore tombstones and call
+     * {@link io.telicent.smart.cache.sources.EventSource#processed(Collection)} regularly even with the tombstone
+     * events.  Whether this is a problem in practise will primarily depend on how frequently the source topic(s) are
+     * updated with non-tombstone events.  Provided there is a steady flow of non-tombstone events an application that
+     * manually commits offsets should only ever be a little behind the actual offset for the end of the topic.
+     * </p>
      *
      * @return Builder
      */

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractKafkaEventSourceBuilder.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/AbstractKafkaEventSourceBuilder.java
@@ -47,6 +47,7 @@ public abstract class AbstractKafkaEventSourceBuilder<TKey, TValue, TSource exte
     Duration lagReportInterval = Duration.ofMinutes(1);
     KafkaReadPolicy<TKey, TValue> readPolicy = KafkaReadPolicies.fromEarliest();
     boolean autoCommit = true;
+    boolean ignoreTombstones = true;
     OffsetStore externalOffsetStore = null;
     Properties properties = new Properties();
 
@@ -78,7 +79,7 @@ public abstract class AbstractKafkaEventSourceBuilder<TKey, TValue, TSource exte
      * @return Builder
      */
     public TBuilder topic(String topic) {
-        if(!this.topics.isEmpty()){
+        if (!this.topics.isEmpty()) {
             LOGGER.info("Topics '{}' are being replaced by '{}'", topics.toString(), topic);
             this.topics.clear();
         }
@@ -280,6 +281,23 @@ public abstract class AbstractKafkaEventSourceBuilder<TKey, TValue, TSource exte
      */
     public TBuilder externalOffsetStore(OffsetStore store) {
         this.externalOffsetStore = store;
+        return (TBuilder) this;
+    }
+
+    /**
+     * Specifies whether any tombstone events (those with a {@code null} value) will be ignored and not returned by the
+     * {@link KafkaEventSource#poll(Duration)} calls.
+     * <p>
+     * From {@code 0.37.0} onwards this became the default behaviour so can be disabled by calling
+     * {@code ignoreTombstones(false)} if your application needs to process tombstones directly.  If you set this then
+     * application code needs to be implemented such that the value of events can be {@code null} and it does not
+     * blindly try and call {@code .value().someMethod()} on events retrieved from this source.
+     * </p>
+     *
+     * @return Builder
+     */
+    public TBuilder ignoreTombstones(boolean ignore) {
+        this.ignoreTombstones = ignore;
         return (TBuilder) this;
     }
 

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaDatasetGraphSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaDatasetGraphSource.java
@@ -67,10 +67,11 @@ public class KafkaDatasetGraphSource<TKey> extends KafkaEventSource<TKey, Datase
      */
     KafkaDatasetGraphSource(String bootstrapServers, Set<String> topics, String groupId, String keyDeserializerClass,
                             int maxPollRecords, KafkaReadPolicy<TKey, DatasetGraph> policy, boolean autoCommit,
-                            OffsetStore offsetStore, Duration lagReportInterval, Properties properties) {
+                            boolean ignoreTombstones, OffsetStore offsetStore, Duration lagReportInterval,
+                            Properties properties) {
         super(bootstrapServers, topics, groupId, keyDeserializerClass,
-              DatasetGraphDeserializer.class.getCanonicalName(), maxPollRecords, policy, autoCommit, offsetStore,
-              lagReportInterval, properties);
+              DatasetGraphDeserializer.class.getCanonicalName(), maxPollRecords, policy, autoCommit, ignoreTombstones,
+              offsetStore, lagReportInterval, properties);
     }
 
     /**
@@ -92,8 +93,8 @@ public class KafkaDatasetGraphSource<TKey> extends KafkaEventSource<TKey, Datase
         public KafkaDatasetGraphSource<TKey> build() {
             return new KafkaDatasetGraphSource<>(this.bootstrapServers, this.topics, this.groupId,
                                                  this.keyDeserializerClass, this.maxPollRecords, this.readPolicy,
-                                                 this.autoCommit, this.externalOffsetStore, this.lagReportInterval,
-                                                 this.properties);
+                                                 this.autoCommit, this.ignoreTombstones, this.externalOffsetStore,
+                                                 this.lagReportInterval, this.properties);
         }
     }
 }

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
@@ -646,6 +646,9 @@ public class KafkaEventSource<TKey, TValue>
             // We do this here rather than in decodeEvent() as this allows us to potentially discard the entire buffer
             // if we've hit a segment of the topic with a lot of tombstones, this causes tryFillBuffer() to get called
             // again and retrieve the next batch of events sooner
+            // Note whether we retrieved anything or not prior to this check as if we eliminate all events due to them
+            // all being tombstones we want poll() to call us again promptly
+            boolean genuinelyEmpty = events.isEmpty();
             if (this.ignoreTombstones) {
                 int size = events.size();
                 events.removeIf(r -> r.value() == null);
@@ -657,12 +660,19 @@ public class KafkaEventSource<TKey, TValue>
 
             this.positionLogger.run();
 
+            // Return true if, and only if, we retrieved zero new events from Kafka indicating nothing was currently
+            // available
+            return genuinelyEmpty;
         /*
         These errors are considered recoverable i.e. a subsequent call to this function could successfully fill the
         buffer
         */
         } catch (WakeupException | InterruptException e) {
             LOGGER.debug("[{}] Interrupted/woken while polling Kafka for events", this.topicNames);
+
+            // Returning true to indicate we were interrupted, this prevents poll() from immediately calling us again
+            // and ensures that interrupts propagate upwards promptly as it's likely higher level code will also detect
+            // the interrupt and stop poll()'ing
             return true;
         /*
         The following errors are considered unrecoverable and result in an EventSourceException being thrown
@@ -699,7 +709,6 @@ public class KafkaEventSource<TKey, TValue>
             LOGGER.error("[{}] Kafka Error: ", this.topicNames, e);
             throw new EventSourceException(e);
         }
-        return false;
     }
 
     /**

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
@@ -395,8 +395,7 @@ public class KafkaEventSource<TKey, TValue>
      * @see io.telicent.smart.cache.sources.EventSource#processed(Collection)
      */
     @Override
-    @SuppressWarnings("rawtypes")
-    public void processed(Collection<Event> processedEvents) {
+    public void processed(Collection<Event<?,?>> processedEvents) {
         // Compute the maximum processed offset for each topic partitions
         Map<TopicPartition, OffsetAndMetadata> commitOffsets = determineCommitOffsetsFromEvents(processedEvents);
 
@@ -470,7 +469,7 @@ public class KafkaEventSource<TKey, TValue>
      * @return Offsets to commit, may be empty if no Kafka events provided
      */
     @SuppressWarnings("rawtypes")
-    public static Map<TopicPartition, OffsetAndMetadata> determineCommitOffsetsFromEvents(Collection<Event> events) {
+    public static Map<TopicPartition, OffsetAndMetadata> determineCommitOffsetsFromEvents(Collection<Event<?, ?>> events) {
         if (CollectionUtils.isEmpty(events)) {
             return Collections.emptyMap();
         }

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
@@ -594,19 +594,19 @@ public class KafkaEventSource<TKey, TValue>
     }
 
     @Override
-    protected void tryFillBuffer(Duration timeout) {
+    protected boolean tryFillBuffer(Duration timeout) {
         // Buffer up some more events
         ConsumerRecords<TKey, TValue> records;
         try {
             // Don't do any work if none of the topic(s) exist on the Kafka cluster
             long start = System.currentTimeMillis();
-            if (!this.topicExistenceChecker.anyTopicExists(timeout)) return;
+            if (!this.topicExistenceChecker.anyTopicExists(timeout)) return true;
 
             // Reduce the timeout by the amount of time we spent waiting for the topic to exist as otherwise we
             // could wait twice our timeout and violate our API contract
             timeout = updateTimeout(start, timeout);
             if (timeout == null) {
-                return;
+                return false;
             }
 
             // If an offset reset is in progress this means we have delayed offset resets submitted by a thread other
@@ -628,7 +628,7 @@ public class KafkaEventSource<TKey, TValue>
                 // In this scenario the events we just returned are likely not for the correct offsets so don't
                 // add these to the buffer, this forces the caller to call EventSource.poll() again at which point we
                 // should resolve the offset reset on our next poll() call and return the expected events.
-                return;
+                return false;
             }
             for (ConsumerRecord<TKey, TValue> record : records) {
                 events.add(record);
@@ -663,6 +663,7 @@ public class KafkaEventSource<TKey, TValue>
         */
         } catch (WakeupException | InterruptException e) {
             LOGGER.debug("[{}] Interrupted/woken while polling Kafka for events", this.topicNames);
+            return true;
         /*
         The following errors are considered unrecoverable and result in an EventSourceException being thrown
 
@@ -698,6 +699,7 @@ public class KafkaEventSource<TKey, TValue>
             LOGGER.error("[{}] Kafka Error: ", this.topicNames, e);
             throw new EventSourceException(e);
         }
+        return false;
     }
 
     /**

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
@@ -593,16 +593,6 @@ public class KafkaEventSource<TKey, TValue>
         return false;
     }
 
-    private static Duration updateTimeout(long start, Duration timeout) {
-        long elapsed = System.currentTimeMillis() - start;
-        long remainingTime = timeout.toMillis() - elapsed;
-        if (remainingTime <= 0) {
-            return null;
-        } else {
-            return Duration.ofMillis(remainingTime);
-        }
-    }
-
     @Override
     protected void tryFillBuffer(Duration timeout) {
         // Buffer up some more events

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
@@ -25,6 +25,7 @@ import io.telicent.smart.cache.observability.TelicentMetrics;
 import io.telicent.smart.cache.projectors.utils.PeriodicAction;
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.EventSourceException;
+import io.telicent.smart.cache.sources.buffered.AbstractBufferedEventSource;
 import io.telicent.smart.cache.sources.kafka.policies.KafkaReadPolicy;
 import io.telicent.smart.cache.sources.offsets.OffsetStore;
 import org.apache.commons.collections4.CollectionUtils;

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaEventSource.java
@@ -86,7 +86,7 @@ public class KafkaEventSource<TKey, TValue>
     private final Set<String> topics;
     private boolean firstRun = true;
     private final TopicExistenceChecker topicExistenceChecker;
-    private final boolean autoCommit;
+    private final boolean autoCommit, ignoreTombstones;
     private final Map<TopicPartition, OffsetAndMetadata> autoCommitOffsets = new HashMap<>();
     private final Queue<Map<TopicPartition, OffsetAndMetadata>> delayedOffsetCommits = new ConcurrentLinkedDeque<>();
     private final Map<TopicPartition, Long> delayedOffsetResets = new ConcurrentHashMap<>();
@@ -114,6 +114,7 @@ public class KafkaEventSource<TKey, TValue>
      *                               {@link KafkaConsumer#poll(Duration)} request.
      * @param policy                 Kafka Read Policy to control what events to read from the configured topic
      * @param autoCommit             Whether the event source will automatically commit Kafka positions
+     * @param ignoreTombstones       Whether to ignore tombstone events and not return them from poll() calls
      * @param offsetStore            An external offset store to commit offsets to in addition to committing them to
      *                               Kafka
      * @param lagReportInterval      Lag reporting interval
@@ -123,7 +124,8 @@ public class KafkaEventSource<TKey, TValue>
     KafkaEventSource(final String bootstrapServers, final Set<String> topics, final String groupId,
                      final String keyDeserializerClass, final String valueDeserializerClass, final int maxPollRecords,
                      final KafkaReadPolicy<TKey, TValue> policy, final boolean autoCommit,
-                     final OffsetStore offsetStore, final Duration lagReportInterval, final Properties properties) {
+                     final boolean ignoreTombstones, final OffsetStore offsetStore, final Duration lagReportInterval,
+                     final Properties properties) {
         if (StringUtils.isBlank(bootstrapServers)) {
             throw new IllegalArgumentException("Kafka bootstrapServers cannot be null");
         }
@@ -170,6 +172,7 @@ public class KafkaEventSource<TKey, TValue>
         this.readPolicy = policy;
         this.readPolicy.setConsumer(this.consumer);
         this.autoCommit = autoCommit;
+        this.ignoreTombstones = ignoreTombstones;
         this.externalOffsetStore = offsetStore;
         this.topicExistenceChecker =
                 new TopicExistenceChecker(createAdminClient(props), this.server, this.topics, LOGGER);
@@ -650,6 +653,19 @@ public class KafkaEventSource<TKey, TValue>
                              topicNames);
             }
 
+            // Proactively prune tombstones
+            // We do this here rather than in decodeEvent() as this allows us to potentially discard the entire buffer
+            // if we've hit a segment of the topic with a lot of tombstones, this causes tryFillBuffer() to get called
+            // again and retrieve the next batch of events sooner
+            if (this.ignoreTombstones) {
+                int size = events.size();
+                events.removeIf(r -> r.value() == null);
+                if (events.size() < size) {
+                    LOGGER.debug("[{}] Pruned {} tombstone events retrieved from Kafka", topicNames,
+                                 size - events.size());
+                }
+            }
+
             this.positionLogger.run();
 
         /*
@@ -714,7 +730,8 @@ public class KafkaEventSource<TKey, TValue>
         boolean anyTopicsMatch = offsets.keySet().stream().anyMatch(t -> this.topics.contains(t.topic()));
         if (!anyTopicsMatch) {
             LOGGER.warn(
-                    "[{}] Reset offsets called without any topics that match this sources configured topics, nothing was reset!", this.topicNames);
+                    "[{}] Reset offsets called without any topics that match this sources configured topics, nothing was reset!",
+                    this.topicNames);
             return;
         }
 
@@ -729,7 +746,8 @@ public class KafkaEventSource<TKey, TValue>
         if (this.pollThread != Thread.currentThread()) {
             // Delay resets to later
             this.delayedOffsetResets.putAll(offsets);
-            LOGGER.info("[{}] Only the polling thread may reset offsets, delaying resets until next poll call", this.topicNames);
+            LOGGER.info("[{}] Only the polling thread may reset offsets, delaying resets until next poll call",
+                        this.topicNames);
 
             // Clear out internally buffered events, this forces the next poll() call to call tryFillBuffer() which is
             // where we process our delayed offset resets
@@ -805,8 +823,8 @@ public class KafkaEventSource<TKey, TValue>
         public KafkaEventSource<TKey, TValue> build() {
             return new KafkaEventSource<>(this.bootstrapServers, this.topics, this.groupId, this.keyDeserializerClass,
                                           this.valueDeserializerClass, this.maxPollRecords, this.readPolicy,
-                                          this.autoCommit, this.externalOffsetStore, this.lagReportInterval,
-                                          this.properties);
+                                          this.autoCommit, this.ignoreTombstones, this.externalOffsetStore,
+                                          this.lagReportInterval, this.properties);
         }
     }
 

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaRdfPayloadSource.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/KafkaRdfPayloadSource.java
@@ -71,9 +71,10 @@ public class KafkaRdfPayloadSource<TKey> extends KafkaEventSource<TKey, RdfPaylo
      */
     KafkaRdfPayloadSource(String bootstrapServers, Set<String> topics, String groupId, String keyDeserializerClass,
                           int maxPollRecords, KafkaReadPolicy<TKey, RdfPayload> policy, boolean autoCommit,
-                          OffsetStore offsetStore, Duration lagReportInterval, Properties properties) {
+                          boolean ignoreTombstones, OffsetStore offsetStore, Duration lagReportInterval,
+                          Properties properties) {
         super(bootstrapServers, topics, groupId, keyDeserializerClass, RdfPayloadDeserializer.class.getCanonicalName(),
-              maxPollRecords, policy, autoCommit, offsetStore, lagReportInterval, properties);
+              maxPollRecords, policy, autoCommit, ignoreTombstones, offsetStore, lagReportInterval, properties);
     }
 
     /**
@@ -95,8 +96,8 @@ public class KafkaRdfPayloadSource<TKey> extends KafkaEventSource<TKey, RdfPaylo
         public KafkaRdfPayloadSource<TKey> build() {
             return new KafkaRdfPayloadSource<>(this.bootstrapServers, this.topics, this.groupId,
                                                this.keyDeserializerClass, this.maxPollRecords, this.readPolicy,
-                                               this.autoCommit, this.externalOffsetStore, this.lagReportInterval,
-                                               this.properties);
+                                               this.autoCommit, this.ignoreTombstones, this.externalOffsetStore,
+                                               this.lagReportInterval, this.properties);
         }
     }
 }

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/AbstractJacksonDeserializer.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/AbstractJacksonDeserializer.java
@@ -58,6 +58,10 @@ public class AbstractJacksonDeserializer<T> extends AbstractJacksonSerdes implem
 
     @Override
     public T deserialize(String topic, Headers headers, byte[] data) {
+        if (data == null) {
+            return null;
+        }
+
         try {
             return this.deserialize(data, this.cls);
         } catch (IOException e) {

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/AbstractJacksonSerializer.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/AbstractJacksonSerializer.java
@@ -51,6 +51,10 @@ public class AbstractJacksonSerializer<T> extends AbstractJacksonSerdes implemen
 
     @Override
     public byte[] serialize(String topic, Headers headers, T data) {
+        if (data == null) {
+            return null;
+        }
+
         try {
             return this.serialize(data);
         } catch (JsonProcessingException e) {

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/GraphSerializer.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/GraphSerializer.java
@@ -58,7 +58,7 @@ public class GraphSerializer extends AbstractRdfSerdes implements Serializer<Gra
     @Override
     public byte[] serialize(String topic, Graph data) {
         if (data == null) {
-            return new byte[0];
+            return null;
         }
         return serializeInternal(data, null);
     }
@@ -66,7 +66,7 @@ public class GraphSerializer extends AbstractRdfSerdes implements Serializer<Gra
     @Override
     public byte[] serialize(String topic, Headers headers, Graph data) {
         if (data == null) {
-            return new byte[0];
+            return null;
         }
 
         String contentType = findContentType(headers);

--- a/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/RdfPayloadSerializer.java
+++ b/event-sources/event-source-kafka/src/main/java/io/telicent/smart/cache/sources/kafka/serializers/RdfPayloadSerializer.java
@@ -71,7 +71,7 @@ public class RdfPayloadSerializer extends AbstractRdfSerdes implements Serialize
     @Override
     public byte[] serialize(String topic, Headers headers, RdfPayload payload) {
         if (payload == null) {
-            return new byte[0];
+            return null;
         }
         try {
             if (payload.isDataset()) {

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaEventSource.java
@@ -659,7 +659,7 @@ public class DockerTestKafkaEventSource {
             Assert.assertFalse(source.isExhausted());
 
             // When
-            Collection<Event> events = new ArrayList<>(verifyTestEvents(500, source, start));
+            Collection<Event<?,?>> events = new ArrayList<>(verifyTestEvents(500, source, start));
             source.processed(events);
             verifyClosure(source);
 

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaEventSourceBehaviour.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/DockerTestKafkaEventSourceBehaviour.java
@@ -107,7 +107,6 @@ public class DockerTestKafkaEventSourceBehaviour extends AbstractEventSourceTest
         //      our base class uses take too long to bring up and tear down with Kafka
         return new Object[][] {
                 { 100 },
-                { 2_500 },
                 { 10_000 }
         };
     }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/KafkaTestCluster.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/KafkaTestCluster.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 public abstract class KafkaTestCluster {
 
     public static final String DEFAULT_TOPIC = "tests";
-    private static final int DEFAULT_TIMEOUT = 5;
+    private static final int DEFAULT_TIMEOUT = 15;
 
     protected GenericContainer kafka;
     protected AdminClient adminClient;

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/KafkaTestCluster.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/KafkaTestCluster.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 public abstract class KafkaTestCluster {
 
     public static final String DEFAULT_TOPIC = "tests";
-    private static final int DEFAULT_TIMEOUT = 3;
+    private static final int DEFAULT_TIMEOUT = 5;
 
     protected GenericContainer kafka;
     protected AdminClient adminClient;

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockKafkaDatasetGraphSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockKafkaDatasetGraphSource.java
@@ -48,7 +48,7 @@ public class MockKafkaDatasetGraphSource extends KafkaDatasetGraphSource<Integer
                                        KafkaReadPolicy<Integer, DatasetGraph> policy, boolean autoCommit,
                                        Collection<Event<Integer, DatasetGraph>> events) {
         super(bootstrapServers, topics, groupId, IntegerDeserializer.class.getCanonicalName(), maxPollRecords,
-              new MockReadPolicy<>(policy, events), autoCommit, null, Duration.ofMinutes(1), null);
+              new MockReadPolicy<>(policy, events), autoCommit, true, null, Duration.ofMinutes(1), null);
     }
 
     @Override

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockKafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockKafkaEventSource.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * @param <TValue>
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public class MockKafkaEventSource<TKey, TValue> extends KafkaEventSource<TKey, TValue> {
+public class MockKafkaEventSource<TKey, TValue> extends KafkaEventSource<TKey, TValue> implements AutoCloseable {
 
     private MockConsumer<TKey, TValue> mock;
 

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockKafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockKafkaEventSource.java
@@ -55,7 +55,7 @@ public class MockKafkaEventSource<TKey, TValue> extends KafkaEventSource<TKey, T
                                 String keyDeserializerClass, String valueDeserializerClass, int maxPollRecords,
                                 KafkaReadPolicy policy, boolean autoCommit, Collection<Event<TKey, TValue>> events) {
         super(bootstrapServers, topics, groupId, keyDeserializerClass, valueDeserializerClass, maxPollRecords,
-              new MockReadPolicy(policy, events), autoCommit, null, Duration.ofMinutes(1), null);
+              new MockReadPolicy(policy, events), autoCommit, true, null, Duration.ofMinutes(1), null);
     }
 
     @Override

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockKafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockKafkaEventSource.java
@@ -30,10 +30,11 @@ import java.util.Set;
 
 /**
  * An extended event source that injects Kafka's {@link MockConsumer} in place of a real consumer
+ *
  * @param <TKey>
  * @param <TValue>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
+@SuppressWarnings({ "rawtypes", "unchecked" })
 public class MockKafkaEventSource<TKey, TValue> extends KafkaEventSource<TKey, TValue> implements AutoCloseable {
 
     private MockConsumer<TKey, TValue> mock;
@@ -48,14 +49,16 @@ public class MockKafkaEventSource<TKey, TValue> extends KafkaEventSource<TKey, T
      * @param valueDeserializerClass Value deserializer class
      * @param maxPollRecords         Maximum events to retrieve and buffer in one Kafka
      *                               {@link KafkaConsumer#poll(Duration)} request.
-     * @param autoCommit             Whether the event source will automatically commit Kafka positions
      * @param policy                 Kafka Read Policy to control what events to read from the configured topic
+     * @param autoCommit             Whether the event source will automatically commit Kafka positions
+     * @param ignoreTombstones       Whether the event source will ignore tombstones
      */
     public MockKafkaEventSource(String bootstrapServers, Set<String> topics, String groupId,
                                 String keyDeserializerClass, String valueDeserializerClass, int maxPollRecords,
-                                KafkaReadPolicy policy, boolean autoCommit, Collection<Event<TKey, TValue>> events) {
+                                KafkaReadPolicy policy, boolean autoCommit, boolean ignoreTombstones,
+                                Collection<Event<TKey, TValue>> events) {
         super(bootstrapServers, topics, groupId, keyDeserializerClass, valueDeserializerClass, maxPollRecords,
-              new MockReadPolicy(policy, events), autoCommit, true, null, Duration.ofMinutes(1), null);
+              new MockReadPolicy(policy, events), autoCommit, ignoreTombstones, null, Duration.ofMinutes(1), null);
     }
 
     @Override

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockKafkaRdfPayloadSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockKafkaRdfPayloadSource.java
@@ -46,7 +46,7 @@ public class MockKafkaRdfPayloadSource extends KafkaRdfPayloadSource<Integer> {
                                      KafkaReadPolicy<Integer, RdfPayload> policy, boolean autoCommit,
                                      Collection<Event<Integer, RdfPayload>> events) {
         super(bootstrapServers, topics, groupId, IntegerDeserializer.class.getCanonicalName(), maxPollRecords,
-              new MockReadPolicy<>(policy, events), autoCommit, null, Duration.ofMinutes(1), null);
+              new MockReadPolicy<>(policy, events), autoCommit, true, null, Duration.ofMinutes(1), null);
     }
 
     @Override

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockitoKafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockitoKafkaEventSource.java
@@ -40,7 +40,7 @@ import java.util.Set;
  * @param <TValue>
  */
 @SuppressWarnings({ "rawtypes", "unchecked" })
-public class MockitoKafkaEventSource<TKey, TValue> extends KafkaEventSource<TKey, TValue> {
+public class MockitoKafkaEventSource<TKey, TValue> extends KafkaEventSource<TKey, TValue> implements AutoCloseable {
 
     private static final ThreadLocal<KafkaConsumer> MOCK_CONSUMER = new ThreadLocal<>();
     private static final ThreadLocal<AdminClient> MOCK_ADMIN_CLIENT = new ThreadLocal<>();

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockitoKafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MockitoKafkaEventSource.java
@@ -75,7 +75,7 @@ public class MockitoKafkaEventSource<TKey, TValue> extends KafkaEventSource<TKey
                                    String keyDeserializerClass, String valueDeserializerClass, int maxPollRecords,
                                    KafkaReadPolicy policy, boolean autoCommit) {
         super(bootstrapServers, topics, groupId, keyDeserializerClass, valueDeserializerClass, maxPollRecords,
-              policy, autoCommit, null, Duration.ofMinutes(1), null);
+              policy, autoCommit, true,null, Duration.ofMinutes(1), null);
     }
 
     @Override

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MutualTlsKafkaTestCluster.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/MutualTlsKafkaTestCluster.java
@@ -108,6 +108,6 @@ public class MutualTlsKafkaTestCluster extends KafkaTestCluster {
     @Override
     protected int getDefaultTimeout() {
         // NB - Takes slightly longer to connect to secure Kafka clusters
-        return 5;
+        return super.getDefaultTimeout() + 5;
     }
 }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/SecureKafkaTestCluster.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/SecureKafkaTestCluster.java
@@ -170,6 +170,6 @@ public class SecureKafkaTestCluster extends BasicKafkaTestCluster {
     @Override
     protected int getDefaultTimeout() {
         // NB - Takes slightly longer to connect to secure Kafka clusters
-        return 5;
+        return super.getDefaultTimeout() + 5;
     }
 }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestBufferedEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestBufferedEventSource.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka;
+
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventSource;
+import io.telicent.smart.cache.sources.EventSourceException;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.Collection;
+
+public class TestBufferedEventSource {
+
+    private static abstract class DummySource
+            extends AbstractBufferedEventSource<KafkaEvent<Integer, String>, Integer, String> {
+        @Override
+        protected Event<Integer, String> decodeEvent(KafkaEvent<Integer, String> internalEvent) {
+            return internalEvent;
+        }
+
+        @Override
+        public Long remaining() {
+            return 0L;
+        }
+
+        @Override
+        public void processed(Collection<Event<?, ?>> processedEvents) {
+
+        }
+    }
+
+    private static final class AlwaysEmpty
+            extends DummySource {
+
+        @Override
+        protected void tryFillBuffer(Duration timeout) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // Ignore
+            }
+        }
+    }
+
+    private static final class AlwaysErrors extends DummySource {
+
+        @Override
+        protected void tryFillBuffer(Duration timeout) {
+            throw new EventSourceException("Failed");
+        }
+    }
+
+    private static final class EventuallyNonEmpty
+            extends DummySource {
+
+        private int attemptCount = 0;
+        private final int yieldAfterAttempts;
+
+        private EventuallyNonEmpty(int yieldAfterAttempts) {
+            this.yieldAfterAttempts = yieldAfterAttempts;
+        }
+
+        @Override
+        protected void tryFillBuffer(Duration timeout) {
+            this.attemptCount++;
+            if (this.attemptCount > this.yieldAfterAttempts) {
+                this.events.add(new KafkaEvent<>(new ConsumerRecord<>("test", 0, 0, 1, "test"), null));
+            } else {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    // Ignore
+                }
+            }
+        }
+    }
+
+    @Test
+    public void givenAlwaysEmptySource_whenPolling_thenWaitsForTimeoutBeforeReturningNull() {
+        // Given
+        EventSource<Integer, String> source = new AlwaysEmpty();
+
+        // When
+        long start = System.currentTimeMillis();
+        Event<Integer, String> event = source.poll(Duration.ofSeconds(1));
+
+        // Then
+        Assert.assertNull(event);
+        verifyAtLeastTimeoutElapsed(start);
+    }
+
+    private static void verifyAtLeastTimeoutElapsed(long start) {
+        Assert.assertTrue(System.currentTimeMillis() - start > 1000,
+                          "Elapsed time (" + (System.currentTimeMillis() - start) + ") was less than timeout");
+    }
+
+    @Test
+    public void givenEventuallyNonEmptySource_whenBufferFillsWithinTimeout_thenFirstPollReturnsNonNull_andTimeoutNotElapsed() {
+        // Given
+        EventSource<Integer, String> source = new EventuallyNonEmpty(5);
+
+        // When
+        long start = System.currentTimeMillis();
+        Event<Integer, String> event = source.poll(Duration.ofSeconds(1));
+
+        // Then
+        Assert.assertNotNull(event);
+
+        // And
+        verifyLessThanTimeoutElapsed(start);
+    }
+
+    @Test
+    public void givenEventuallyNonEmptySource_whenBufferFillsAfterTimeout_thenFirstPollReturnsNull_andSubsequentPollIsNonNull() {
+        // Given
+        EventSource<Integer, String> source = new EventuallyNonEmpty(15);
+
+        // When
+        long start = System.currentTimeMillis();
+        Event<Integer, String> event = source.poll(Duration.ofSeconds(1));
+
+        // Then
+        Assert.assertNull(event);
+        verifyAtLeastTimeoutElapsed(start);
+
+        // And
+        start = System.currentTimeMillis();
+        Assert.assertNotNull(source.poll(Duration.ofSeconds(1)));
+        verifyLessThanTimeoutElapsed(start);
+    }
+
+    private static void verifyLessThanTimeoutElapsed(long start) {
+        Assert.assertTrue(System.currentTimeMillis() - start < 1000,
+                          "Elapsed time (" + (System.currentTimeMillis() - start) + ") should be less than timeout");
+    }
+
+    @Test
+    public void givenAlwaysErrorSource_whenPolling_thenErrorsImmediately() {
+        // Given
+        EventSource<Integer, String> source = new AlwaysErrors();
+
+        // When
+        long start = System.currentTimeMillis();
+        Assert.assertThrows(EventSourceException.class, () -> source.poll(Duration.ofSeconds(1)));
+
+        // Then
+        verifyLessThanTimeoutElapsed(start);
+    }
+}

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestBufferedEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestBufferedEventSource.java
@@ -49,19 +49,21 @@ public class TestBufferedEventSource {
             extends DummySource {
 
         @Override
-        protected void tryFillBuffer(Duration timeout) {
+        protected boolean tryFillBuffer(Duration timeout) {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException e) {
                 // Ignore
+                return true;
             }
+            return false;
         }
     }
 
     private static final class AlwaysErrors extends DummySource {
 
         @Override
-        protected void tryFillBuffer(Duration timeout) {
+        protected boolean tryFillBuffer(Duration timeout) {
             throw new EventSourceException("Failed");
         }
     }
@@ -77,7 +79,7 @@ public class TestBufferedEventSource {
         }
 
         @Override
-        protected void tryFillBuffer(Duration timeout) {
+        protected boolean tryFillBuffer(Duration timeout) {
             this.attemptCount++;
             if (this.attemptCount > this.yieldAfterAttempts) {
                 this.events.add(new KafkaEvent<>(new ConsumerRecord<>("test", 0, 0, 1, "test"), null));
@@ -86,8 +88,10 @@ public class TestBufferedEventSource {
                     Thread.sleep(100);
                 } catch (InterruptedException e) {
                     // Ignore
+                    return true;
                 }
             }
+            return false;
         }
     }
 

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSource.java
@@ -138,14 +138,13 @@ public class TestKafkaEventSource extends AbstractEventSourceTests<Integer, Stri
 
     @Test
     public void kafka_poll_failures_recoverable() {
-        EventSource<Integer, String> source = createSource(createSampleData(10));
+        EventSource<Integer, String> source = createSource(createOrGetSampleData(10));
         MockConsumer<Integer, String> mock = this.kafkaEventSource.getMockConsumer();
         mock.wakeup();
         Assert.assertNull(source.poll(Duration.ofSeconds(3)));
     }
 
     @Test
-    @SuppressWarnings("rawtypes")
     public void givenEmptyEventList_whenDeterminingCommitOffsets_thenEmptyMap() {
         // Given
         List<Event<?,?>> events = Collections.emptyList();

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSource.java
@@ -148,7 +148,7 @@ public class TestKafkaEventSource extends AbstractEventSourceTests<Integer, Stri
     @SuppressWarnings("rawtypes")
     public void givenEmptyEventList_whenDeterminingCommitOffsets_thenEmptyMap() {
         // Given
-        List<Event> events = Collections.emptyList();
+        List<Event<?,?>> events = Collections.emptyList();
 
         // When
         Map<TopicPartition, OffsetAndMetadata> offsets = KafkaEventSource.determineCommitOffsetsFromEvents(events);
@@ -157,8 +157,7 @@ public class TestKafkaEventSource extends AbstractEventSourceTests<Integer, Stri
         Assert.assertTrue(offsets.isEmpty());
     }
 
-    @SuppressWarnings("rawtypes")
-    private void generateKafkaEvents(List<Event> events, int count, String topic, int partition, long startingOffset) {
+    private void generateKafkaEvents(List<Event<?,?>> events, int count, String topic, int partition, long startingOffset) {
         for (int i = 0; i < count; i++) {
             ConsumerRecord<Long, String> record =
                     new ConsumerRecord<>(topic, partition, startingOffset + i, startingOffset + i,
@@ -168,7 +167,7 @@ public class TestKafkaEventSource extends AbstractEventSourceTests<Integer, Stri
     }
 
     @SuppressWarnings("rawtypes")
-    private void generateSimpleEvents(List<Event> events, int count) {
+    private void generateSimpleEvents(List<Event<?,?>> events, int count) {
         for (long i = 0; i < count; i++) {
             events.add(new SimpleEvent<>(Collections.emptyList(), i, "Event #" + i));
         }
@@ -178,7 +177,7 @@ public class TestKafkaEventSource extends AbstractEventSourceTests<Integer, Stri
     @SuppressWarnings("rawtypes")
     public void givenKafkaEventList_whenDeterminingCommitOffsets_thenExpectedOffsets() {
         // Given
-        List<Event> events = new ArrayList<>();
+        List<Event<?,?>> events = new ArrayList<>();
         generateKafkaEvents(events, 100, KafkaTestCluster.DEFAULT_TOPIC, 0, 0);
         generateKafkaEvents(events, 50, KafkaTestCluster.DEFAULT_TOPIC, 1, 50);
         generateKafkaEvents(events, 10, KafkaTestCluster.DEFAULT_TOPIC, 2, 100);
@@ -198,7 +197,7 @@ public class TestKafkaEventSource extends AbstractEventSourceTests<Integer, Stri
     @SuppressWarnings("rawtypes")
     public void givenNonKafkaEventList_whenDeterminingCommitOffsets_thenNoOffsets() {
         // Given
-        List<Event> events = new ArrayList<>();
+        List<Event<?,?>> events = new ArrayList<>();
         generateSimpleEvents(events, 100);
 
         // When
@@ -212,7 +211,7 @@ public class TestKafkaEventSource extends AbstractEventSourceTests<Integer, Stri
     @SuppressWarnings("rawtypes")
     public void givenMixedEventList_whenDeterminingCommitOffsets_thenExpectedOffsets() {
         // Given
-        List<Event> events = new ArrayList<>();
+        List<Event<?,?>> events = new ArrayList<>();
         generateKafkaEvents(events, 100, KafkaTestCluster.DEFAULT_TOPIC, 0, 0);
         generateKafkaEvents(events, 50, KafkaTestCluster.DEFAULT_TOPIC, 1, 200);
         generateSimpleEvents(events, 100);

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSource.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSource.java
@@ -67,7 +67,7 @@ public class TestKafkaEventSource extends AbstractEventSourceTests<Integer, Stri
         return new MockKafkaEventSource<>(DEFAULT_BOOTSTRAP_SERVERS, Set.of(TEST_TOPIC), TEST_GROUP,
                                           StringSerializer.class.getCanonicalName(),
                                           StringSerializer.class.getCanonicalName(), 100,
-                                          KafkaReadPolicies.fromBeginning(), true, events);
+                                          KafkaReadPolicies.fromBeginning(), true, true, events);
     }
 
     @Override

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceFromEarliest.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceFromEarliest.java
@@ -32,6 +32,6 @@ public class TestKafkaEventSourceFromEarliest extends TestKafkaEventSource {
         return new MockKafkaEventSource<>(DEFAULT_BOOTSTRAP_SERVERS, Set.of(TEST_TOPIC), TEST_GROUP,
                                           StringSerializer.class.getCanonicalName(),
                                           StringSerializer.class.getCanonicalName(), 100,
-                                          KafkaReadPolicies.fromEarliest(), true, events);
+                                          KafkaReadPolicies.fromEarliest(), true, true, events);
     }
 }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceFromLatest.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceFromLatest.java
@@ -32,6 +32,6 @@ public class TestKafkaEventSourceFromLatest extends TestKafkaEventSource {
         return new MockKafkaEventSource<>(DEFAULT_BOOTSTRAP_SERVERS, Set.of(TEST_TOPIC), TEST_GROUP,
                                           StringSerializer.class.getCanonicalName(),
                                           StringSerializer.class.getCanonicalName(), 100,
-                                          KafkaReadPolicies.fromLatest(), true, events);
+                                          KafkaReadPolicies.fromLatest(), true, true, events);
     }
 }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceFromOffset.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceFromOffset.java
@@ -32,6 +32,6 @@ public class TestKafkaEventSourceFromOffset extends TestKafkaEventSource {
                                           StringSerializer.class.getCanonicalName(),
                                           StringSerializer.class.getCanonicalName(), 100,
                                           KafkaReadPolicies.fromOffsets(Collections.emptyMap(), 0),
-                                          true, events);
+                                          true, true, events);
     }
 }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceManual.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceManual.java
@@ -31,6 +31,6 @@ public class TestKafkaEventSourceManual extends TestKafkaEventSource {
                                           StringSerializer.class.getCanonicalName(),
                                           StringSerializer.class.getCanonicalName(), 100,
                                           KafkaReadPolicies.manualFromBeginning(),
-                                          true, events);
+                                          true, true, events);
     }
 }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceProcessed.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceProcessed.java
@@ -30,9 +30,11 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class TestKafkaEventSourceProcessed extends TestKafkaEventSource {
     @Override
@@ -191,7 +193,7 @@ public class TestKafkaEventSourceProcessed extends TestKafkaEventSource {
             verifyNoCommittedOffsets(mock, partitions);
 
             // If we explicitly call processed then we should see committed offsets
-            source.processed(sink.get().stream().map(e -> (Event) e).toList());
+            source.processed(new ArrayList<>(sink.get()));
             verifyCommittedOffsets(mock, partition, partitions, 10_001);
         }
     }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceProcessed.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceProcessed.java
@@ -61,7 +61,7 @@ public class TestKafkaEventSourceProcessed extends TestKafkaEventSource {
 
     @Test(dataProvider = "batchSizes")
     public void kafka_processed_callback_01(int batchSize) {
-        EventSource<Integer, String> source = createSource(createSampleData(10_001));
+        EventSource<Integer, String> source = createSource(createOrGetSampleData(10_001));
         MockConsumer<Integer, String> mock = this.kafkaEventSource.getMockConsumer();
         TopicPartition partition = new TopicPartition(TEST_TOPIC, 0);
         Set<TopicPartition> partitions = Set.of(partition);
@@ -92,7 +92,7 @@ public class TestKafkaEventSourceProcessed extends TestKafkaEventSource {
 
     @Test(dataProvider = "batchSizes")
     public void kafka_processed_callback_01b(int batchSize) {
-        EventSource<Integer, String> source = createSource(createSampleData(10_001));
+        EventSource<Integer, String> source = createSource(createOrGetSampleData(10_001));
         MockConsumer<Integer, String> mock = this.kafkaEventSource.getMockConsumer();
         TopicPartition partition = new TopicPartition(TEST_TOPIC, 0);
         Set<TopicPartition> partitions = Set.of(partition);
@@ -153,7 +153,7 @@ public class TestKafkaEventSourceProcessed extends TestKafkaEventSource {
 
     @Test
     public void kafka_processed_callback_02() {
-        EventSource<Integer, String> source = createSource(createSampleData(10_001));
+        EventSource<Integer, String> source = createSource(createOrGetSampleData(10_001));
         MockConsumer<Integer, String> mock = this.kafkaEventSource.getMockConsumer();
         TopicPartition partition = new TopicPartition(TEST_TOPIC, 0);
         Set<TopicPartition> partitions = Set.of(partition);
@@ -174,7 +174,7 @@ public class TestKafkaEventSourceProcessed extends TestKafkaEventSource {
 
     @Test
     public void kafka_processed_callback_03() {
-        EventSource<Integer, String> source = createSource(createSampleData(10_001));
+        EventSource<Integer, String> source = createSource(createOrGetSampleData(10_001));
         MockConsumer<Integer, String> mock = this.kafkaEventSource.getMockConsumer();
         TopicPartition partition = new TopicPartition(TEST_TOPIC, 0);
         Set<TopicPartition> partitions = Set.of(partition);

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceProcessed.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceProcessed.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class TestKafkaEventSourceProcessed extends TestKafkaEventSource {
     @Override
@@ -43,7 +42,7 @@ public class TestKafkaEventSourceProcessed extends TestKafkaEventSource {
         return new MockKafkaEventSource<>(DEFAULT_BOOTSTRAP_SERVERS, Set.of(TEST_TOPIC), TEST_GROUP,
                                           StringSerializer.class.getCanonicalName(),
                                           StringSerializer.class.getCanonicalName(), 100,
-                                          KafkaReadPolicies.fromBeginning(), false, events);
+                                          KafkaReadPolicies.fromBeginning(), false, true, events);
     }
 
     @DataProvider(name = "batchSizes")

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceTombstones.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceTombstones.java
@@ -43,45 +43,103 @@ public class TestKafkaEventSourceTombstones {
     }
 
     private MockKafkaEventSource<Integer, String> createSource(Collection<Event<Integer, String>> events,
-                                                               int maxPollRecords, boolean autoCommit) {
+                                                               boolean autoCommit, boolean ignoreTombstones) {
         return new MockKafkaEventSource<>(TestKafkaEventSource.DEFAULT_BOOTSTRAP_SERVERS,
                                           Set.of(TestKafkaEventSource.TEST_TOPIC),
                                           TestKafkaEventSource.TEST_GROUP + "-ignore-tombstones",
                                           StringSerializer.class.getCanonicalName(),
-                                          StringSerializer.class.getCanonicalName(), maxPollRecords,
-                                          KafkaReadPolicies.fromBeginning(), autoCommit, events);
+                                          StringSerializer.class.getCanonicalName(), 100,
+                                          KafkaReadPolicies.fromBeginning(), autoCommit, ignoreTombstones, events);
     }
 
     @Test
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public void trailingTombstoneIgnoredWhenCommitting() {
-        try (MockKafkaEventSource<Integer, String> source =
-                createSource(List.of(new SimpleEvent<>(Collections.emptyList(), 0, "live"),
-                                     new SimpleEvent<>(Collections.emptyList(), 1, null)),
-                             100, false)){
+    public void givenTrailingTombstone_whenAutoCommitting_thenOffsetIncludesTrailingTombstone() {
+        // Given
+        try (MockKafkaEventSource<Integer, String> source = createSource(
+                List.of(new SimpleEvent<>(Collections.emptyList(), 0, "live"),
+                        new SimpleEvent<>(Collections.emptyList(), 1, null)), true, true)) {
             MockConsumer<Integer, String> consumer = source.getMockConsumer();
             TopicPartition partition = new TopicPartition(TestKafkaEventSource.TEST_TOPIC, 0);
 
+            // When
             Event<Integer, String> event = source.poll(Duration.ofSeconds(1));
             Assert.assertNotNull(event);
             Assert.assertEquals(event.key(), Integer.valueOf(0));
             Assert.assertEquals(event.value(), "live");
             Assert.assertNull(source.poll(Duration.ofSeconds(1)));
 
-            source.processed((List) List.of(event));
-
-            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Set.of(partition));
-            Assert.assertEquals(committed.get(partition).offset(), 2L,
-                                "The Offset should be past the ignored tombstones");
+            // Then
+            // Auto-commit will commit everything Kafka polled in the last batch including ignored tombstones so offset
+            // will be past the tombstone
+            verifyOffset(consumer, partition, 2L, "Auto-commit will be past the ignored tombstone");
         }
     }
 
-    private ConsumerRecords<Integer, String> records(TopicPartition partition, List<ConsumerRecord<Integer, String>> records) {
+    @Test
+    public void givenTrailingTombstone_whenManuallyCommitting_thenOffsetIgnoresTrailingTombstone() {
+        // Given
+        try (MockKafkaEventSource<Integer, String> source = createSource(
+                List.of(new SimpleEvent<>(Collections.emptyList(), 0, "live"),
+                        new SimpleEvent<>(Collections.emptyList(), 1, null)), false, true)) {
+            MockConsumer<Integer, String> consumer = source.getMockConsumer();
+            TopicPartition partition = new TopicPartition(TestKafkaEventSource.TEST_TOPIC, 0);
+
+            // When
+            Event<Integer, String> event = source.poll(Duration.ofSeconds(1));
+            Assert.assertNotNull(event);
+            Assert.assertEquals(event.key(), Integer.valueOf(0));
+            Assert.assertEquals(event.value(), "live");
+            Assert.assertNull(source.poll(Duration.ofSeconds(1)));
+
+            // Then
+            // However as the app code never sees the ignored tombstone when it manually commits the offset will be at
+            // the first ignored tombstone
+            source.processed(List.of(event));
+            verifyOffset(consumer, partition, 1L, "The Offset should be before the ignored tombstones");
+        }
+    }
+
+    @Test
+    public void givenTrailingTombstone_whenManuallyCommittingWithoutIgnoring_thenOffsetIncludesTrailingTombstone() {
+        // Given
+        try (MockKafkaEventSource<Integer, String> source = createSource(
+                List.of(new SimpleEvent<>(Collections.emptyList(), 0, "live"),
+                        new SimpleEvent<>(Collections.emptyList(), 1, null)), false, false)) {
+            MockConsumer<Integer, String> consumer = source.getMockConsumer();
+            TopicPartition partition = new TopicPartition(TestKafkaEventSource.TEST_TOPIC, 0);
+
+            // When
+            Event<Integer, String> event = source.poll(Duration.ofSeconds(1));
+            Assert.assertNotNull(event);
+            Assert.assertEquals(event.key(), Integer.valueOf(0));
+            Assert.assertEquals(event.value(), "live");
+            Event<Integer, String> tombstone = source.poll(Duration.ofSeconds(1));
+            Assert.assertNotNull(tombstone);
+            Assert.assertNull(tombstone.value());
+
+            // Then
+            // However as the app code never sees the ignored tombstone when it manually commits the offset will be at
+            // the first ignored tombstone
+            source.processed(List.of(event, tombstone));
+            verifyOffset(consumer, partition, 2L, "The Offset should be past the ignored tombstones");
+        }
+    }
+
+    private static void verifyOffset(MockConsumer<Integer, String> consumer, TopicPartition partition,
+                                     long expectedOffset, String message) {
+        Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Set.of(partition));
+        Assert.assertEquals(committed.get(partition).offset(), expectedOffset, message);
+    }
+
+    private ConsumerRecords<Integer, String> records(TopicPartition partition,
+                                                     List<ConsumerRecord<Integer, String>> records) {
         return new ConsumerRecords<>(Map.of(partition, records));
     }
 
     @Test
-    public void pollIgnoresLaterEventsIfBatchContainsTombstones() {
+    @SuppressWarnings("unchecked")
+    public void givenLeadingBatchOfTombstones_whenPolling_thenTombstoneBatchIsSkipped() {
+        // Given
         TopicPartition partition = new TopicPartition(TestKafkaEventSource.TEST_TOPIC, 0);
         List<ConsumerRecord<Integer, String>> tombstones = new ArrayList<>();
         // max.fetch.records is usually 100.
@@ -91,24 +149,21 @@ public class TestKafkaEventSourceTombstones {
         // If we add actual event _after_ it'll get ignored.
         ConsumerRecord<Integer, String> liveRecord =
                 new ConsumerRecord<>(partition.topic(), partition.partition(), 100L, 100, "live");
-
         KafkaConsumer<Integer, String> consumer = mock(KafkaConsumer.class);
         when(consumer.poll(any(Duration.class))).thenReturn(records(partition, tombstones),
                                                             records(partition, List.of(liveRecord)));
-
         KafkaReadPolicy<Integer, String> policy = mock(KafkaReadPolicy.class);
         when(policy.currentLag(any())).thenReturn(0L);
-
         MockitoKafkaEventSource.setMockConsumer(consumer);
-        try (MockitoKafkaEventSource<Integer, String> source =
-                new MockitoKafkaEventSource<>(TestKafkaEventSource.DEFAULT_BOOTSTRAP_SERVERS,
-                                              Set.of(TestKafkaEventSource.TEST_TOPIC),
-                                              TestKafkaEventSource.TEST_GROUP + "-ignored-tombstones",
-                                              IntegerDeserializer.class.getCanonicalName(),
-                                              StringDeserializer.class.getCanonicalName(), 100, policy, true)) {
+        try (MockitoKafkaEventSource<Integer, String> source = new MockitoKafkaEventSource<>(
+                TestKafkaEventSource.DEFAULT_BOOTSTRAP_SERVERS, Set.of(TestKafkaEventSource.TEST_TOPIC),
+                TestKafkaEventSource.TEST_GROUP + "-ignored-tombstones", IntegerDeserializer.class.getCanonicalName(),
+                StringDeserializer.class.getCanonicalName(), 100, policy, true)) {
+            // When
             Event<Integer, String> event = source.poll(Duration.ofSeconds(1));
-            Assert.assertNotNull(event,
-                                 "poll() should continue fetching until it finds an acrual event or times out");
+
+            // Then
+            Assert.assertNotNull(event, "poll() should continue fetching until it finds an actual event or times out");
             Assert.assertEquals(event.key(), Integer.valueOf(100));
             Assert.assertEquals(event.value(), "live");
         }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceTombstones.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/TestKafkaEventSourceTombstones.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka;
+
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.kafka.policies.KafkaReadPolicies;
+import io.telicent.smart.cache.sources.kafka.policies.KafkaReadPolicy;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
+import org.apache.kafka.clients.consumer.*;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.*;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestKafkaEventSourceTombstones {
+
+    @AfterMethod
+    public void cleanup() {
+        MockitoKafkaEventSource.reset();
+    }
+
+    private MockKafkaEventSource<Integer, String> createSource(Collection<Event<Integer, String>> events,
+                                                               int maxPollRecords, boolean autoCommit) {
+        return new MockKafkaEventSource<>(TestKafkaEventSource.DEFAULT_BOOTSTRAP_SERVERS,
+                                          Set.of(TestKafkaEventSource.TEST_TOPIC),
+                                          TestKafkaEventSource.TEST_GROUP + "-ignore-tombstones",
+                                          StringSerializer.class.getCanonicalName(),
+                                          StringSerializer.class.getCanonicalName(), maxPollRecords,
+                                          KafkaReadPolicies.fromBeginning(), autoCommit, events);
+    }
+
+    @Test
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public void trailingTombstoneIgnoredWhenCommitting() {
+        try (MockKafkaEventSource<Integer, String> source =
+                createSource(List.of(new SimpleEvent<>(Collections.emptyList(), 0, "live"),
+                                     new SimpleEvent<>(Collections.emptyList(), 1, null)),
+                             100, false)){
+            MockConsumer<Integer, String> consumer = source.getMockConsumer();
+            TopicPartition partition = new TopicPartition(TestKafkaEventSource.TEST_TOPIC, 0);
+
+            Event<Integer, String> event = source.poll(Duration.ofSeconds(1));
+            Assert.assertNotNull(event);
+            Assert.assertEquals(event.key(), Integer.valueOf(0));
+            Assert.assertEquals(event.value(), "live");
+            Assert.assertNull(source.poll(Duration.ofSeconds(1)));
+
+            source.processed((List) List.of(event));
+
+            Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(Set.of(partition));
+            Assert.assertEquals(committed.get(partition).offset(), 2L,
+                                "The Offset should be past the ignored tombstones");
+        }
+    }
+
+    private ConsumerRecords<Integer, String> records(TopicPartition partition, List<ConsumerRecord<Integer, String>> records) {
+        return new ConsumerRecords<>(Map.of(partition, records));
+    }
+
+    @Test
+    public void pollIgnoresLaterEventsIfBatchContainsTombstones() {
+        TopicPartition partition = new TopicPartition(TestKafkaEventSource.TEST_TOPIC, 0);
+        List<ConsumerRecord<Integer, String>> tombstones = new ArrayList<>();
+        // max.fetch.records is usually 100.
+        for (int i = 0; i < 100; i++) {
+            tombstones.add(new ConsumerRecord<>(partition.topic(), partition.partition(), i, i, null));
+        }
+        // If we add actual event _after_ it'll get ignored.
+        ConsumerRecord<Integer, String> liveRecord =
+                new ConsumerRecord<>(partition.topic(), partition.partition(), 100L, 100, "live");
+
+        KafkaConsumer<Integer, String> consumer = mock(KafkaConsumer.class);
+        when(consumer.poll(any(Duration.class))).thenReturn(records(partition, tombstones),
+                                                            records(partition, List.of(liveRecord)));
+
+        KafkaReadPolicy<Integer, String> policy = mock(KafkaReadPolicy.class);
+        when(policy.currentLag(any())).thenReturn(0L);
+
+        MockitoKafkaEventSource.setMockConsumer(consumer);
+        try (MockitoKafkaEventSource<Integer, String> source =
+                new MockitoKafkaEventSource<>(TestKafkaEventSource.DEFAULT_BOOTSTRAP_SERVERS,
+                                              Set.of(TestKafkaEventSource.TEST_TOPIC),
+                                              TestKafkaEventSource.TEST_GROUP + "-ignored-tombstones",
+                                              IntegerDeserializer.class.getCanonicalName(),
+                                              StringDeserializer.class.getCanonicalName(), 100, policy, true)) {
+            Event<Integer, String> event = source.poll(Duration.ofSeconds(1));
+            Assert.assertNotNull(event,
+                                 "poll() should continue fetching until it finds an acrual event or times out");
+            Assert.assertEquals(event.key(), Integer.valueOf(100));
+            Assert.assertEquals(event.value(), "live");
+        }
+    }
+}

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/serializers/TestDatasetDeserializer.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/serializers/TestDatasetDeserializer.java
@@ -36,7 +36,7 @@ public class TestDatasetDeserializer extends AbstractRdfDeserializerTests<Datase
         for (int g = 0; g < numGraphs; g++) {
             Node graphName = g == 0 ? Quad.defaultGraphIRI : NodeFactory.createURI("urn:graphs:" + g);
             for (int i = 0; i < size; i++) {
-                dataset.add(new Quad(graphName, NodeFactory.createURI("urn:subjects:" + i),
+                dataset.add(Quad.create(graphName, NodeFactory.createURI("urn:subjects:" + i),
                                      NodeFactory.createURI("urn:predicate"),
                                      NodeFactory.createLiteralString(Integer.toString(i))));
             }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/serializers/TestPayloadDeserializer.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/serializers/TestPayloadDeserializer.java
@@ -145,26 +145,26 @@ public class TestPayloadDeserializer {
     }
 
     @Test
-    public void givenPayloadSerializer_whenSerializingNullPayload_thenEmptyBytes() {
+    public void givenPayloadSerializer_whenSerializingNullPayload_thenNullBytes() {
         // Given
         try (RdfPayloadSerializer serializer = new RdfPayloadSerializer()) {
             // When
             byte[] data = serializer.serialize("test", null);
 
             // Then
-            Assert.assertEquals(data.length, 0);
+            Assert.assertNull(data);
         }
     }
 
     @Test
-    public void givenPayloadSerializer_whenSerializingNullPayloadAndHeaders_thenEmptyBytes() {
+    public void givenPayloadSerializer_whenSerializingNullPayloadAndHeaders_thenNull() {
         // Given
         try (RdfPayloadSerializer serializer = new RdfPayloadSerializer()) {
             // When
             byte[] data = serializer.serialize("test", new RecordHeaders(), null);
 
             // Then
-            Assert.assertEquals(data.length, 0);
+            Assert.assertNull(data);
         }
     }
 

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/serializers/TestPayloadDeserializer.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/serializers/TestPayloadDeserializer.java
@@ -57,7 +57,7 @@ public class TestPayloadDeserializer {
         for (int g = 0; g < numGraphs; g++) {
             Node graphName = g == 0 ? Quad.defaultGraphIRI : NodeFactory.createURI("urn:graphs:" + g);
             for (int i = 0; i < size; i++) {
-                dataset.add(new Quad(graphName, NodeFactory.createURI("urn:subjects:" + i),
+                dataset.add(Quad.create(graphName, NodeFactory.createURI("urn:subjects:" + i),
                                      NodeFactory.createURI("urn:predicate"),
                                      NodeFactory.createLiteralDT(Integer.toString(i), XSDDatatype.XSDinteger)));
             }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/serializers/TestPayloadDeserializerBadConfig.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/serializers/TestPayloadDeserializerBadConfig.java
@@ -28,9 +28,4 @@ public class TestPayloadDeserializerBadConfig extends TestPayloadDeserializer {
         deserializer.configure(BAD_PARSING_CONFIGURATION, false);
         return deserializer;
     }
-
-    @Override
-    protected boolean isEagerParsing() {
-        return false;
-    }
 }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/AbstractKafkaTombstoneTests.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/AbstractKafkaTombstoneTests.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka.tombstones;
+
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
+import io.telicent.smart.cache.sources.EventSource;
+import io.telicent.smart.cache.sources.kafka.BasicKafkaTestCluster;
+import io.telicent.smart.cache.sources.kafka.KafkaEventSource;
+import io.telicent.smart.cache.sources.kafka.KafkaTestCluster;
+import io.telicent.smart.cache.sources.kafka.Utils;
+import io.telicent.smart.cache.sources.kafka.sinks.KafkaSink;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
+import org.apache.kafka.common.serialization.*;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test suite that ensures that tombstones are correctly ignored or made visible per configuration, it also serves to
+ * validate that a given Kafka Serializer and Deserializer combination correctly handles {@code null} values
+ *
+ * @param <TValue> Value type
+ */
+public abstract class AbstractKafkaTombstoneTests<TValue> {
+    private static final AtomicInteger COUNTER = new AtomicInteger(0);
+    private BasicKafkaTestCluster kafka;
+
+    @BeforeClass
+    public void setup() {
+        Utils.logTestClassStarted(this.getClass());
+        this.kafka = new BasicKafkaTestCluster();
+        this.kafka.setup();
+    }
+
+    @AfterClass
+    public void teardown() {
+        this.kafka.teardown();
+        Utils.logTestClassFinished(this.getClass());
+    }
+
+    @AfterMethod
+    public void testCleanup() throws InterruptedException {
+        this.kafka.resetTestTopic();
+    }
+
+    protected abstract TValue exemplarValue();
+
+    protected abstract Class<? extends Deserializer<TValue>> valueDeserializerClass();
+
+    protected abstract Class<? extends Serializer<TValue>> valueSerializerClass();
+
+    protected <TKey> Event<TKey, TValue> event(TKey key, TValue value, Collection<EventHeader> headers) {
+        return new SimpleEvent<>(headers, key, value);
+    }
+
+    protected <TKey> Event<TKey, TValue> tombstone(TKey key) {
+        return new SimpleEvent<>(Collections.emptyList(), key, null);
+    }
+
+    protected <TKey> void insertTestEvents(Class<? extends Serializer<TKey>> keySerializerClass,
+                                           Class<? extends Serializer<TValue>> valueSerializerClass,
+                                           List<Event<TKey, TValue>> events) {
+        try (KafkaSink<TKey, TValue> sink = KafkaSink.<TKey, TValue>create()
+                                                     .bootstrapServers(this.kafka.getBootstrapServers())
+                                                     .topic(KafkaTestCluster.DEFAULT_TOPIC)
+                                                     .keySerializer(keySerializerClass)
+                                                     .valueSerializer(valueSerializerClass)
+                                                     .lingerMs(5)
+                                                     .build()) {
+            for (Event<TKey, TValue> event : events) {
+                sink.send(event);
+            }
+        }
+    }
+
+    private <TKey> KafkaEventSource<TKey, TValue> source(Class<? extends Deserializer<TKey>> keyDeserializerClass,
+                                                         Class<? extends Deserializer<TValue>> valueDeserializerClass,
+                                                         boolean ignoreTombstones) {
+        return KafkaEventSource.<TKey, TValue>create()
+                               .bootstrapServers(this.kafka.getBootstrapServers())
+                               .consumerConfig(this.kafka.getClientProperties())
+                               .topic(KafkaTestCluster.DEFAULT_TOPIC)
+                               .consumerGroup("tombstones-" + COUNTER.incrementAndGet())
+                               .keyDeserializer(keyDeserializerClass)
+                               .valueDeserializer(valueDeserializerClass)
+                               .autoCommit()
+                               .ignoreTombstones(ignoreTombstones)
+                               .build();
+    }
+
+    protected <TKey> List<Event<TKey, TValue>> consumeAll(Class<? extends Deserializer<TKey>> keyDeserializerClass,
+                                                          Class<? extends Deserializer<TValue>> valueDeserializerClass,
+                                                          boolean ignoreTombstones) {
+        EventSource<TKey, TValue> source =
+                source(keyDeserializerClass, valueDeserializerClass, ignoreTombstones);
+        List<Event<TKey, TValue>> events = new ArrayList<>();
+        try {
+            Event<TKey, TValue> next = source.poll(Duration.ofSeconds(5));
+            while (next != null) {
+                events.add(next);
+                next = source.poll(Duration.ofSeconds(3));
+            }
+
+            return events;
+        } finally {
+            source.close();
+        }
+
+    }
+
+    protected List<Event<String, TValue>> manyEvents(String baseKey, TValue value, int total) {
+        List<Event<String, TValue>> events = new ArrayList<>();
+        for (int i = 1; i <= total; i++) {
+            events.add(event(baseKey + "/" + i, value, List.of()));
+        }
+        return events;
+    }
+
+    protected void manyTombstones(List<String> keys, List<Event<String, TValue>> events) {
+        for (String key : keys) {
+            events.add(event(key, null, List.of()));
+        }
+    }
+
+    @Test
+    public void givenTopicWithTombstones_whenConsumingWithTombstonesIgnored_thenTombstonesAreNotReturned() {
+        // Given
+        UUID key = UUID.randomUUID();
+        insertTestEvents(UUIDSerializer.class, valueSerializerClass(),
+                         List.of(event(key, exemplarValue(), List.of()), tombstone(key)));
+
+        // When
+        List<Event<UUID, TValue>> events =
+                consumeAll(UUIDDeserializer.class, valueDeserializerClass(), true);
+
+        // Then
+        Assert.assertEquals(events.size(), 1);
+    }
+
+    @Test
+    public void givenTopicWithTombstones_whenConsumingWithTombstonesVisible_thenTombstonesAreReturned() {
+        // Given
+        UUID key = UUID.randomUUID();
+        insertTestEvents(UUIDSerializer.class, valueSerializerClass(),
+                         List.of(event(key, exemplarValue(), List.of()), tombstone(key)));
+
+        // When
+        List<Event<UUID, TValue>> events =
+                consumeAll(UUIDDeserializer.class, valueDeserializerClass(), false);
+
+        // Then
+        Assert.assertEquals(events.size(), 2);
+    }
+
+    @Test
+    public void givenTopicWithManyTombstones_whenConsumingWithTombstonesIgnored_thenTombstonesAreNotReturned() {
+        // Given
+        String baseKey = UUID.randomUUID().toString();
+        List<Event<String, TValue>> input = manyEvents(baseKey, exemplarValue(), 1_000);
+        manyTombstones(input.stream().map(Event::key).toList(), input);
+        insertTestEvents(StringSerializer.class, valueSerializerClass(), input);
+
+        // When
+        List<Event<String, TValue>> events =
+                consumeAll(StringDeserializer.class, valueDeserializerClass(),
+                           true);
+
+        // Then
+        Assert.assertEquals(events.size(), 1_000);
+    }
+
+    @Test
+    public void givenTopicWithManyTombstones_whenConsumingWithTombstonesVisible_thenTombstonesAreReturned() {
+        // Given
+        String baseKey = UUID.randomUUID().toString();
+        List<Event<String, TValue>> input = manyEvents(baseKey, exemplarValue(), 500);
+        manyTombstones(input.stream().map(Event::key).toList(), input);
+        insertTestEvents(StringSerializer.class, valueSerializerClass(), input);
+
+        // When
+        List<Event<String, TValue>> events =
+                consumeAll(StringDeserializer.class, valueDeserializerClass(),
+                           false);
+
+        // Then
+        Assert.assertEquals(events.size(), 1_000);
+    }
+}

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/Data.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/Data.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka.tombstones;
+
+public record Data(String key, Object value) {
+
+}

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/DataDeserializer.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/DataDeserializer.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka.tombstones;
+
+import io.telicent.smart.cache.sources.kafka.serializers.AbstractJacksonDeserializer;
+
+public class DataDeserializer extends AbstractJacksonDeserializer<Data> {
+
+    public DataDeserializer() {
+        super(Data.class);
+    }
+}

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/DataSerializer.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/DataSerializer.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka.tombstones;
+
+import io.telicent.smart.cache.sources.kafka.serializers.AbstractJacksonSerializer;
+
+public class DataSerializer extends AbstractJacksonSerializer<Data> {
+
+}

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/DockerTestKafkaTombstonesGraph.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/DockerTestKafkaTombstonesGraph.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka.tombstones;
+
+import io.telicent.smart.cache.sources.kafka.serializers.GraphDeserializer;
+import io.telicent.smart.cache.sources.kafka.serializers.GraphSerializer;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.sparql.graph.GraphFactory;
+
+public class DockerTestKafkaTombstonesGraph extends AbstractKafkaTombstoneTests<Graph> {
+
+    @Override
+    protected Graph exemplarValue() {
+        return GraphFactory.emptyGraph();
+    }
+
+    @Override
+    protected Class<GraphDeserializer> valueDeserializerClass() {
+        return GraphDeserializer.class;
+    }
+
+    @Override
+    protected Class<GraphSerializer> valueSerializerClass() {
+        return GraphSerializer.class;
+    }
+}

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/DockerTestKafkaTombstonesJackson.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/DockerTestKafkaTombstonesJackson.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka.tombstones;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+public class DockerTestKafkaTombstonesJackson extends AbstractKafkaTombstoneTests<Data> {
+
+    @Override
+    protected Data exemplarValue() {
+        return new Data("test", Map.of("flag", true, "number", 1234, "message", "hello"));
+    }
+
+    @Override
+    protected Class<? extends Deserializer<Data>> valueDeserializerClass() {
+        return DataDeserializer.class;
+    }
+
+    @Override
+    protected Class<? extends Serializer<Data>> valueSerializerClass() {
+        return DataSerializer.class;
+    }
+
+}

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/DockerTestKafkaTombstonesRdfPayload.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/tombstones/DockerTestKafkaTombstonesRdfPayload.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.kafka.tombstones;
+
+import io.telicent.smart.cache.payloads.RdfPayload;
+import io.telicent.smart.cache.sources.kafka.serializers.RdfPayloadDeserializer;
+import io.telicent.smart.cache.sources.kafka.serializers.RdfPayloadSerializer;
+import org.apache.jena.sparql.core.DatasetGraphFactory;
+
+public class DockerTestKafkaTombstonesRdfPayload extends AbstractKafkaTombstoneTests<RdfPayload> {
+
+    @Override
+    protected RdfPayload exemplarValue() {
+        return RdfPayload.of(DatasetGraphFactory.empty());
+    }
+
+    @Override
+    protected Class<RdfPayloadDeserializer> valueDeserializerClass() {
+        return RdfPayloadDeserializer.class;
+    }
+
+    @Override
+    protected Class<RdfPayloadSerializer> valueSerializerClass() {
+        return RdfPayloadSerializer.class;
+    }
+}

--- a/event-sources/event-sources-core/pom.xml
+++ b/event-sources/event-sources-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>event-sources</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Event Sources - Core API</name>

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventProcessedSink.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/projectors/sinks/events/EventProcessedSink.java
@@ -38,9 +38,8 @@ public class EventProcessedSink<TKey, TValue> implements Sink<Event<TKey, TValue
      */
     public static final int NO_BATCHING = 1;
 
-    @SuppressWarnings("rawtypes")
     @ToString.Exclude
-    private final Map<EventSource, List<Event<TKey, TValue>>> events = new HashMap<>();
+    private final Map<EventSource<?,?>, List<Event<?, ?>>> events = new HashMap<>();
     private final int batchSize;
 
     /**
@@ -54,7 +53,6 @@ public class EventProcessedSink<TKey, TValue> implements Sink<Event<TKey, TValue
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void send(Event<TKey, TValue> event) {
         // If the event has a source then report it as processed, this may not happen immediately if a batch size for
         // reporting has been configured
@@ -63,7 +61,7 @@ public class EventProcessedSink<TKey, TValue> implements Sink<Event<TKey, TValue
                 event.source().processed(List.of(event));
             } else {
                 // Add to a batch, potentially reporting that batch if the batch size has been reached
-                List<Event<TKey, TValue>> batch =
+                List<Event<?, ?>> batch =
                         this.events.computeIfAbsent(event.source(), k -> new ArrayList<>());
                 batch.add(event);
                 if (batch.size() >= this.batchSize) {
@@ -95,7 +93,6 @@ public class EventProcessedSink<TKey, TValue> implements Sink<Event<TKey, TValue
     }
 
     @Override
-    @SuppressWarnings({"rawtypes", "unchecked"})
     public void close() {
         // Nothing to do if batching was disabled
         if (this.batchSize == NO_BATCHING) {
@@ -103,7 +100,7 @@ public class EventProcessedSink<TKey, TValue> implements Sink<Event<TKey, TValue
         }
 
         // Upon close report any incomplete batches as processed
-        for (Map.Entry<EventSource, List<Event<TKey, TValue>>> entry : this.events.entrySet()) {
+        for (Map.Entry<EventSource<?,?>, List<Event<?, ?>>> entry : this.events.entrySet()) {
             if (!entry.getValue().isEmpty()) {
                 entry.getKey().processed(entry.getValue());
                 entry.getValue().clear();

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/CapturingEventSource.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/CapturingEventSource.java
@@ -89,7 +89,7 @@ public class CapturingEventSource<TKey, TValue> implements EventSource<TKey, TVa
     }
 
     @Override
-    public void processed(Collection<Event> processedEvents) {
+    public void processed(Collection<Event<?,?>> processedEvents) {
         this.underlying.processed(processedEvents);
     }
 }

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/Event.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/Event.java
@@ -114,8 +114,8 @@ public interface Event<TKey, TValue> {
     /**
      * Provides a reference back to the {@link EventSource} that produced this event instance
      * <p>
-     * This method <strong>intentionally</strong> returns an untyped reference to the original event source because the
-     * events type signature may have been modified as it moved through the processing pipeline (e.g. by callers
+     * This method <strong>intentionally</strong> returns a wildcard type reference to the original event source because
+     * the events type signature may have been modified as it moved through the processing pipeline (e.g. by callers
      * utilising the {@link #replaceKey(Object)}, {@link #replaceValue(Object)} or {@link #replace(Object, Object)}
      * methods) so the types it now holds may not be the types that it was initially produced from its source with.
      * </p>
@@ -126,6 +126,5 @@ public interface Event<TKey, TValue> {
      *
      * @return Event Source, or {@code null} if not associated with a source
      */
-    @SuppressWarnings("rawtypes")
-    EventSource source();
+    EventSource<?, ?> source();
 }

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/EventSource.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/EventSource.java
@@ -115,15 +115,15 @@ public interface EventSource<TKey, TValue> {
      * concrete implementation.
      * </p>
      * <p>
-     * The type signature of the {@code processedEvents} parameter is intentionally a raw type because events may have
-     * had their type signature changed in the course of processing them so their final type signature may not relate to
-     * their original type signature which would prevent callers invoking this method.
+     * The type signature of the {@code processedEvents} parameter is intentionally using a wildcard type reference
+     * because events may have had their type signature changed in the course of processing them so their final type
+     * signature may not relate to their original type signature which would otherwise prevent callers invoking this
+     * method.
      * </p>
      *
      * @param processedEvents A collection of events that have been processed.
      */
-    @SuppressWarnings("rawtypes")
-    void processed(Collection<Event> processedEvents);
+    void processed(Collection<Event<?, ?>> processedEvents);
 
     /**
      * Interrupts the event source, this is typically used when an application is shutting down, or otherwise closing

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/buffered/AbstractBufferedEventSource.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/buffered/AbstractBufferedEventSource.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.telicent.smart.cache.sources.kafka;
+package io.telicent.smart.cache.sources.buffered;
 
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.EventSource;
@@ -23,12 +23,28 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
- * An event source that uses an internal buffer
+ * An abstract event source implementation that uses an internal buffer.
  * <p>
  * The buffered events are stored as an intermediate type to allow derived implementations to store additional
- * information alongside the actual event.  For example the {@link KafkaEventSource} stores the actual
- * {@link org.apache.kafka.clients.consumer.ConsumerRecord} instances since it needs this information to be able to
- * reliably track committed offsets.
+ * information alongside the actual event.  Derived implementations are responsible for refilling the buffer when
+ * requested and handling any bookkeeping that might require.
+ * </p>
+ * <h3>Notes for Implementors</h3>
+ * <p>
+ * There are three key methods in this abstract class:
+ * </p>
+ * <ul>
+ *     <li>{@link #bufferExhausted()} which is called whenever the internal buffer is exhausted.  This allows an
+ *     implementation to do any internal bookkeeping such as committing offsets.</li>
+ *     <li>{@link #tryFillBuffer(Duration)} which is called after {@link #bufferExhausted()} and gives the
+ *     implementation an opportunity to refill the buffer.</li>
+ *     <li>{@link #decodeEvent(Object)} which is used to convert the intermediate event type into an actual concrete
+ *     {@link Event} instance.</li>
+ * </ul>
+ * <p>
+ * Please see the Javadoc on each of those methods for more detailed discussion.  Implementators may also need to
+ * override the {@link #availableImmediately()}, {@link #isExhausted()} and {@link #close()} methods appropriately
+ * depending on the event source they are exposing.
  * </p>
  *
  * @param <TIntermediate> Intermediate event type
@@ -120,6 +136,13 @@ public abstract class AbstractBufferedEventSource<TIntermediate, TKey, TValue> i
         return this.decodeEvent(events.poll());
     }
 
+    /**
+     * Calculates a new timeout based on elapsed time
+     *
+     * @param start   When the operation was started
+     * @param timeout The original timeout to reduce by the elapsed time
+     * @return Reduced timeout, or {@code null} if no time is remaining
+     */
     public static Duration updateTimeout(long start, Duration timeout) {
         long elapsed = System.currentTimeMillis() - start;
         long remainingTime = timeout.toMillis() - elapsed;

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/memory/InMemoryEventSource.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/memory/InMemoryEventSource.java
@@ -90,8 +90,7 @@ public class InMemoryEventSource<TKey, TValue> implements EventSource<TKey, TVal
     }
 
     @Override
-    @SuppressWarnings("rawtypes")
-    public void processed(Collection<Event> processedEvents) {
+    public void processed(Collection<Event<?,?>> processedEvents) {
         checkNotClosed();
         // No-op
     }

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/memory/SimpleEvent.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/memory/SimpleEvent.java
@@ -39,6 +39,7 @@ public class SimpleEvent<TKey, TValue> implements Event<TKey, TValue> {
     private final TKey key;
     private final TValue value;
     @ToString.Exclude
+    @SuppressWarnings("rawtypes")
     private final EventSource source;
 
     /**
@@ -60,6 +61,7 @@ public class SimpleEvent<TKey, TValue> implements Event<TKey, TValue> {
      * @param value   Value
      * @param source  Event source that originated this event
      */
+    @SuppressWarnings("rawtypes")
     public SimpleEvent(Collection<EventHeader> headers, TKey key, TValue value, EventSource source) {
         this.headers = CollectionUtils.isNotEmpty(headers) ? new ArrayList<>(headers) : Collections.emptyList();
 
@@ -127,6 +129,7 @@ public class SimpleEvent<TKey, TValue> implements Event<TKey, TValue> {
     }
 
     @Override
+    @SuppressWarnings("rawtypes")
     public EventSource source() {
         return this.source;
     }

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/AbstractEventSourceTests.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/AbstractEventSourceTests.java
@@ -16,13 +16,12 @@
 package io.telicent.smart.cache.sources;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 /**
  * An abstract suite of tests for event sources that verify that an arbitrary event source is able to fulfill the
@@ -32,6 +31,14 @@ import java.util.List;
  * @param <TValue> Value type
  */
 public abstract class AbstractEventSourceTests<TKey, TValue> {
+
+    private final Map<Integer, Collection<Event<TKey, TValue>>> sampleData = new HashMap<>();
+    private final static Map<Integer, List<String>> SAMPLE_STRINGS = new HashMap<>();
+
+    @AfterClass
+    public void sampleDataCacheTeardown() {
+        this.sampleData.clear();
+    }
 
     /**
      * Creates an empty event source for testing
@@ -54,6 +61,16 @@ public abstract class AbstractEventSourceTests<TKey, TValue> {
      * @param size Size of the sample data i.e. this method should return a collection of this size
      * @return Sample data
      */
+    protected final Collection<Event<TKey, TValue>> createOrGetSampleData(int size) {
+        return this.sampleData.computeIfAbsent(size, this::createSampleData);
+    }
+
+    /**
+     * Creates sample data
+     *
+     * @param size Size of the sample data i.e. this method should return a collection of this size
+     * @return Sample data
+     */
     protected abstract Collection<Event<TKey, TValue>> createSampleData(int size);
 
     /**
@@ -63,6 +80,10 @@ public abstract class AbstractEventSourceTests<TKey, TValue> {
      * @return Sample data
      */
     public static List<String> createSampleStrings(int size) {
+        return SAMPLE_STRINGS.computeIfAbsent(size, AbstractEventSourceTests::createSampleStringsInternal);
+    }
+
+    private static List<String> createSampleStringsInternal(int size) {
         List<String> data = new ArrayList<>();
         for (int i = 0; i < size; i++) {
             data.add("event-" + i);
@@ -139,7 +160,7 @@ public abstract class AbstractEventSourceTests<TKey, TValue> {
     @Test(timeOut = 10_000L)
     public void givenSingleItemSource_whenPolling_thenSingleItemIsReturned_andStatusReportedAccurately() {
         // Given
-        List<Event<TKey, TValue>> sampleData = new ArrayList<>(createSampleData(1));
+        List<Event<TKey, TValue>> sampleData = new ArrayList<>(createOrGetSampleData(1));
         EventSource<TKey, TValue> source = createSource(sampleData);
 
         try {
@@ -166,7 +187,7 @@ public abstract class AbstractEventSourceTests<TKey, TValue> {
     @Test(timeOut = 10_000L)
     public void givenSingleItemSource_whenClosed_thenNoFurtherEventsAvailable() {
         // Given
-        List<Event<TKey, TValue>> sampleData = new ArrayList<>(createSampleData(1));
+        List<Event<TKey, TValue>> sampleData = new ArrayList<>(createOrGetSampleData(1));
         EventSource<TKey, TValue> source = createSource(sampleData);
         Assert.assertFalse(source.isExhausted());
         if (guaranteesImmediateAvailability()) {
@@ -200,15 +221,14 @@ public abstract class AbstractEventSourceTests<TKey, TValue> {
     public Object[][] getTestSizes() {
         return new Object[][] {
                 { 100 },
-                { 10_000 },
-                { 100_000 }
+                { 10_000 }
         };
     }
 
     @Test(dataProvider = "sample-data-sizes")
     public void givenPopulatedEventSource_whenPolling_thenAllEventsAreReturned(int size) {
         // Given
-        List<Event<TKey, TValue>> sampleData = new ArrayList<>(this.createSampleData(size));
+        List<Event<TKey, TValue>> sampleData = new ArrayList<>(createOrGetSampleData(size));
         EventSource<TKey, TValue> source = createSource(sampleData);
 
         try {
@@ -234,7 +254,7 @@ public abstract class AbstractEventSourceTests<TKey, TValue> {
     @Test(dataProvider = "sample-data-sizes")
     public void givenPopulatedEventSource_whenPollingFirst10Items_then10ItemsAreReturned(int size) {
         // Given
-        List<Event<TKey, TValue>> sampleData = new ArrayList<>(this.createSampleData(size));
+        List<Event<TKey, TValue>> sampleData = new ArrayList<>(createOrGetSampleData(size));
         EventSource<TKey, TValue> source = createSource(sampleData);
         try {
             Assert.assertFalse(source.isExhausted());
@@ -277,7 +297,7 @@ public abstract class AbstractEventSourceTests<TKey, TValue> {
     @Test
     public void givenNonEmptyEventSource_whenReadingOneEvent_thenRemainingIsOneLessThanTotal_02() {
         // Given
-        EventSource<TKey, TValue> source = createSource(createSampleData(100));
+        EventSource<TKey, TValue> source = createSource(createOrGetSampleData(100));
 
         try {
             // When
@@ -294,7 +314,7 @@ public abstract class AbstractEventSourceTests<TKey, TValue> {
     public void givenNonEmptyEventSource_whenQueryingRemaining_thenRemainingIsTotal() {
         // Given
         long expected = 100L;
-        EventSource<TKey, TValue> source = createSource(createSampleData((int) expected));
+        EventSource<TKey, TValue> source = createSource(createOrGetSampleData((int) expected));
 
         try {
             // When and Then
@@ -321,7 +341,7 @@ public abstract class AbstractEventSourceTests<TKey, TValue> {
     @Test(dataProvider = "sample-data-sizes")
     public void givenNonEmptyEventSource_whenReadingRecords_thenRemainingIsAlwaysCorrect(long expected) {
         // Given
-        EventSource<TKey, TValue> source = createSource(createSampleData((int) expected));
+        EventSource<TKey, TValue> source = createSource(createOrGetSampleData((int) expected));
 
         try {
             // When and Then

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/buffered/TestBufferedEventSource.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/buffered/TestBufferedEventSource.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.telicent.smart.cache.sources.kafka;
+package io.telicent.smart.cache.sources.buffered;
 
 import io.telicent.smart.cache.sources.Event;
 import io.telicent.smart.cache.sources.EventSource;
 import io.telicent.smart.cache.sources.EventSourceException;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -28,9 +28,9 @@ import java.util.Collection;
 public class TestBufferedEventSource {
 
     private static abstract class DummySource
-            extends AbstractBufferedEventSource<KafkaEvent<Integer, String>, Integer, String> {
+            extends AbstractBufferedEventSource<SimpleEvent<Integer, String>, Integer, String> {
         @Override
-        protected Event<Integer, String> decodeEvent(KafkaEvent<Integer, String> internalEvent) {
+        protected Event<Integer, String> decodeEvent(SimpleEvent<Integer, String> internalEvent) {
             return internalEvent;
         }
 
@@ -56,7 +56,7 @@ public class TestBufferedEventSource {
                 // Ignore
                 return true;
             }
-            return false;
+            return true;
         }
     }
 
@@ -82,7 +82,7 @@ public class TestBufferedEventSource {
         protected boolean tryFillBuffer(Duration timeout) {
             this.attemptCount++;
             if (this.attemptCount > this.yieldAfterAttempts) {
-                this.events.add(new KafkaEvent<>(new ConsumerRecord<>("test", 0, 0, 1, "test"), null));
+                this.events.add(new SimpleEvent<>(null, 1, "test"));
             } else {
                 try {
                     Thread.sleep(100);
@@ -96,7 +96,7 @@ public class TestBufferedEventSource {
     }
 
     @Test
-    public void givenAlwaysEmptySource_whenPolling_thenWaitsForTimeoutBeforeReturningNull() {
+    public void givenAlwaysEmptySource_whenPolling_thenReturnsNullImmediately() {
         // Given
         EventSource<Integer, String> source = new AlwaysEmpty();
 
@@ -106,7 +106,7 @@ public class TestBufferedEventSource {
 
         // Then
         Assert.assertNull(event);
-        verifyAtLeastTimeoutElapsed(start);
+        verifyLessThanTimeoutElapsed(start);
     }
 
     private static void verifyAtLeastTimeoutElapsed(long start) {

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/memory/TestSimpleEvent.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/memory/TestSimpleEvent.java
@@ -250,7 +250,7 @@ public class TestSimpleEvent {
         }
 
         @Override
-        public void processed(Collection<Event> processedEvents) {
+        public void processed(Collection<Event<?,?>> processedEvents) {
             return;
         }
     }

--- a/event-sources/pom.xml
+++ b/event-sources/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>event-sources</artifactId>

--- a/jaxrs-base-server/pom.xml
+++ b/jaxrs-base-server/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jaxrs-base-server</artifactId>

--- a/jwt-auth-common/pom.xml
+++ b/jwt-auth-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <artifactId>jwt-auth-common</artifactId>
     <name>Telicent Smart Caches - JWT Authentication</name>

--- a/live-reporter/pom.xml
+++ b/live-reporter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <artifactId>live-reporter</artifactId>
     <name>Telicent Smart Caches - Live Reporter</name>

--- a/observability-core/pom.xml
+++ b/observability-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>observability-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.telicent.smart-caches</groupId>
     <artifactId>parent</artifactId>
-    <version>0.36.4-SNAPSHOT</version>
+    <version>0.37.0-SNAPSHOT</version>
     <modules>
         <module>projectors-core</module>
         <module>projector-driver</module>

--- a/projector-driver/pom.xml
+++ b/projector-driver/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Projectors - Driver</name>

--- a/projector-driver/src/test/java/io/smart/cache/projectors/driver/InfiniteEventSource.java
+++ b/projector-driver/src/test/java/io/smart/cache/projectors/driver/InfiniteEventSource.java
@@ -83,7 +83,7 @@ public class InfiniteEventSource implements EventSource<Integer, String> {
     }
 
     @Override
-    public void processed(Collection<Event> processedEvents) {
+    public void processed(Collection<Event<?,?>> processedEvents) {
         // No-op
     }
 

--- a/projectors-core/pom.xml
+++ b/projectors-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>parent</artifactId>
         <groupId>io.telicent.smart-caches</groupId>
-        <version>0.36.4-SNAPSHOT</version>
+        <version>0.37.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>Telicent Smart Caches - Projectors - Core API</name>


### PR DESCRIPTION
Improves `KafkaEventSource` behaviour so tombstone events (those with null values) which are used to apply "deletes" to a Kafka topic are ignored unless configured to not ignore them.  This allows an application to silently move past tombstone events without needing any application visible code changes.

This was some experimental work motivated by @danieldaviestelicent's recent investigation into Kafka crypto-shredding/tombstoning to understand what our current behaviour around tombstones was and to modify it to align with the vision of the Data Management work where deletions from Kafka (via tombstone events) should effectively be invisible to actual applications built atop these libraries.