### PR TITLE
[CORE-1254] Alter instance ID to be consistent across the app.

### DIFF
--- a/observability-core/pom.xml
+++ b/observability-core/pom.xml
@@ -16,6 +16,13 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>io.telicent.smart-caches</groupId>
+            <artifactId>configurator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>

--- a/observability-core/src/main/java/io/telicent/smart/cache/observability/TelicentMetrics.java
+++ b/observability-core/src/main/java/io/telicent/smart/cache/observability/TelicentMetrics.java
@@ -17,12 +17,14 @@ package io.telicent.smart.cache.observability;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
@@ -30,8 +32,13 @@ import java.util.concurrent.TimeUnit;
  * Entrypoint for Telicent related metrics
  */
 public class TelicentMetrics {
+    private static final String INSTANCE_ID_PROPERTY = "otel.service.instance.id";
+    private static final String INSTANCE_ID_ENV = "OTEL_SERVICE_INSTANCE_ID";
+    private static final String HOSTNAME_ENV = "HOSTNAME";
+    private static final String SHARED_INSTANCE_ID_PROPERTY = "telicent.metrics.instance.id";
 
     private static OpenTelemetry OTEL = null;
+    private static String INSTANCE_ID = null;
     private static final Object lock = new Object();
     private static final Map<String, Meter> METER_CACHE = new HashMap<>();
 
@@ -78,8 +85,63 @@ public class TelicentMetrics {
         set(null);
     }
 
+    /**
+     * Gets the process-wide instance identifier used for metric attributes.
+     * <p>
+     * This resolves once per JVM, preferring explicit runtime configuration if present.
+     * </p>
+     *
+     * @return Process-wide instance identifier
+     */
+    public static String getInstanceId() {
+        synchronized (lock) {
+            if (INSTANCE_ID == null) {
+                INSTANCE_ID = resolveInstanceId();
+            }
+            return INSTANCE_ID;
+        }
+    }
+
+    /**
+     * Gets metric attributes that identify the current process instance.
+     *
+     * @return Attributes including the shared instance identifier
+     */
+    public static Attributes getInstanceAttributes() {
+        return Attributes.of(AttributeKey.stringKey(AttributeNames.INSTANCE_ID), getInstanceId());
+    }
+
+    /**
+     * Gets metric attributes for a specific item type on the current process instance.
+     *
+     * @param itemsType Item type label
+     * @return Attributes including the shared instance identifier and item type
+     */
+    public static Attributes getMetricAttributes(String itemsType) {
+        return Attributes.of(AttributeKey.stringKey(AttributeNames.ITEMS_TYPE), itemsType,
+                             AttributeKey.stringKey(AttributeNames.INSTANCE_ID), getInstanceId());
+    }
+
     private static void resetCaches() {
         METER_CACHE.clear();
+    }
+
+    private static String resolveInstanceId() {
+        String configured = firstNonBlank(System.getProperty(INSTANCE_ID_PROPERTY), System.getenv(INSTANCE_ID_ENV),
+                                          System.getProperty(SHARED_INSTANCE_ID_PROPERTY),
+                                          System.getenv(HOSTNAME_ENV));
+        String resolved = configured != null ? configured : UUID.randomUUID().toString();
+        System.setProperty(SHARED_INSTANCE_ID_PROPERTY, resolved);
+        return resolved;
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
     }
 
     /**

--- a/observability-core/src/main/java/io/telicent/smart/cache/observability/TelicentMetrics.java
+++ b/observability-core/src/main/java/io/telicent/smart/cache/observability/TelicentMetrics.java
@@ -21,6 +21,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.Meter;
+import io.telicent.smart.cache.configuration.Configurator;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,7 +33,6 @@ import java.util.concurrent.TimeUnit;
  * Entrypoint for Telicent related metrics
  */
 public class TelicentMetrics {
-    private static final String INSTANCE_ID_PROPERTY = "otel.service.instance.id";
     private static final String INSTANCE_ID_ENV = "OTEL_SERVICE_INSTANCE_ID";
     private static final String HOSTNAME_ENV = "HOSTNAME";
     private static final String SHARED_INSTANCE_ID_PROPERTY = "telicent.metrics.instance.id";
@@ -127,21 +127,9 @@ public class TelicentMetrics {
     }
 
     private static String resolveInstanceId() {
-        String configured = firstNonBlank(System.getProperty(INSTANCE_ID_PROPERTY), System.getenv(INSTANCE_ID_ENV),
-                                          System.getProperty(SHARED_INSTANCE_ID_PROPERTY),
-                                          System.getenv(HOSTNAME_ENV));
-        String resolved = configured != null ? configured : UUID.randomUUID().toString();
+        String resolved = Configurator.get(new String[] { INSTANCE_ID_ENV, SHARED_INSTANCE_ID_PROPERTY, HOSTNAME_ENV }, UUID.randomUUID().toString());
         System.setProperty(SHARED_INSTANCE_ID_PROPERTY, resolved);
         return resolved;
-    }
-
-    private static String firstNonBlank(String... values) {
-        for (String value : values) {
-            if (value != null && !value.isBlank()) {
-                return value;
-            }
-        }
-        return null;
     }
 
     /**

--- a/observability-core/src/test/java/io/telicent/smart/cache/observability/TestTelicentMetrics.java
+++ b/observability-core/src/test/java/io/telicent/smart/cache/observability/TestTelicentMetrics.java
@@ -106,6 +106,16 @@ public class TestTelicentMetrics {
         TelicentMetrics.getMeter("test");
     }
 
+    @Test
+    public void test_instance_id_is_stable() {
+        String instanceId = TelicentMetrics.getInstanceId();
+        Assert.assertNotNull(instanceId);
+        Assert.assertFalse(instanceId.isBlank());
+        Assert.assertEquals(TelicentMetrics.getInstanceId(), instanceId);
+        Assert.assertEquals(TelicentMetrics.getInstanceAttributes().asMap().get(AttributeKey.stringKey(AttributeNames.INSTANCE_ID)),
+                            instanceId);
+    }
+
     private static void mockOpenTelemetry() {
         MetricExporter exporter = mock(MetricExporter.class);
         when(exporter.getDefaultAggregation(any())).thenReturn(Aggregation.defaultAggregation());

--- a/projector-driver/src/main/java/io/telicent/smart/cache/projectors/driver/ProjectorDriver.java
+++ b/projector-driver/src/main/java/io/telicent/smart/cache/projectors/driver/ProjectorDriver.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.function.Supplier;
 
 import static org.apache.commons.lang3.Strings.CS;
@@ -137,9 +136,7 @@ public class ProjectorDriver<TKey, TValue, TOutput> implements Runnable {
             this.stallAware = null;
         }
 
-        this.metricAttributes = Attributes.of(AttributeKey.stringKey(AttributeNames.ITEMS_TYPE), ITEM_TYPE_EVENTS,
-                                              AttributeKey.stringKey(AttributeNames.INSTANCE_ID),
-                                              UUID.randomUUID().toString());
+        this.metricAttributes = TelicentMetrics.getMetricAttributes(ITEM_TYPE_EVENTS);
         Meter meter = TelicentMetrics.getMeter(Library.NAME);
         this.stalls = meter.counterBuilder(DriverMetricNames.STALLS_TOTAL)
                            .setDescription(DriverMetricNames.STALLS_TOTAL_DESCRIPTION)

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/FilterSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/FilterSink.java
@@ -29,7 +29,6 @@ import io.telicent.smart.cache.projectors.sinks.builder.AbstractFilteringSinkBui
 import lombok.ToString;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.UUID;
 import java.util.function.Predicate;
 
 /**
@@ -68,9 +67,7 @@ public class FilterSink<T> extends AbstractTransformingSink<T, T> {
         super(destination);
         this.filter = filter != null ? filter : t -> true;
         if (StringUtils.isNotBlank(metricsLabel)) {
-            this.metricAttributes = Attributes.of(AttributeKey.stringKey(AttributeNames.ITEMS_TYPE), metricsLabel,
-                                                  AttributeKey.stringKey(AttributeNames.INSTANCE_ID),
-                                                  UUID.randomUUID().toString());
+            this.metricAttributes = TelicentMetrics.getMetricAttributes(metricsLabel);
             Meter meter = TelicentMetrics.getMeter(Library.NAME);
             //@formatter:off
             this.filteredMetric = meter.counterBuilder(MetricNames.ITEMS_FILTERED)

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressDuplicatesSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressDuplicatesSink.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -93,9 +92,7 @@ public class SuppressDuplicatesSink<T> extends AbstractTransformingSink<T, T> {
                            .setDescription(MetricNames.DUPLICATES_SUPPRESSED_DESCRIPTION)
                            .build();
             //@formatter:on
-            this.metricAttributes = Attributes.of(AttributeKey.stringKey(AttributeNames.ITEMS_TYPE), metricsLabel,
-                                                  AttributeKey.stringKey(AttributeNames.INSTANCE_ID),
-                                                  UUID.randomUUID().toString());
+            this.metricAttributes = TelicentMetrics.getMetricAttributes(metricsLabel);
         } else {
             this.suppressedMetric = null;
             this.metricAttributes = null;

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressUnmodifiedSink.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/sinks/SuppressUnmodifiedSink.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.Comparator;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -115,9 +114,7 @@ public class SuppressUnmodifiedSink<T, TKey, TValue> extends AbstractTransformin
                                          .setDescription(MetricNames.UNMODIFIED_SUPPRESSED_DESCRIPTION)
                                          .build();
             //@formatter:on
-            this.metricAttributes = Attributes.of(AttributeKey.stringKey(AttributeNames.ITEMS_TYPE), metricsLabel,
-                                                  AttributeKey.stringKey(AttributeNames.INSTANCE_ID),
-                                                  UUID.randomUUID().toString());
+            this.metricAttributes = TelicentMetrics.getMetricAttributes(metricsLabel);
         } else {
             this.suppressedMetric = null;
             this.metricAttributes = null;

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/utils/ThroughputTracker.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/utils/ThroughputTracker.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 
 import java.util.Locale;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -111,9 +110,7 @@ public class ThroughputTracker {
         this.metricsEnabled = StringUtils.isNotBlank(metricsLabel);
         ObservableDoubleGauge rateMetric;
         if (this.metricsEnabled) {
-            this.metricAttributes = Attributes.of(AttributeKey.stringKey(AttributeNames.ITEMS_TYPE), metricsLabel,
-                                                  AttributeKey.stringKey(AttributeNames.INSTANCE_ID),
-                                                  UUID.randomUUID().toString());
+            this.metricAttributes = TelicentMetrics.getMetricAttributes(metricsLabel);
             Meter meter = TelicentMetrics.getMeter(Library.NAME);
             //@formatter:off
             this.receivedMetric = meter.counterBuilder(MetricNames.ITEMS_RECEIVED)


### PR DESCRIPTION
Hostname sounds odd at first but for Kubernetes pods it will be the pod name, which is more useful. 