### PR TITLE
Change Maven Central waitUntil behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
         - Please see Javadoc on the `ignoreTombstones()` builder method for more details
     - Fixed some edge cases with various Kafka `Serializer`/`Deserializer` implementations around handling of `null`
       values
+- Build improvements:
+    - Maven Central publishing plugin changed to waitUntil validated as waitUntil published can exceed our configured
+      waitMaxTime if Maven Central is particularly busy or experiences an outage
+
 
 # 0.36.3
 

--- a/pom.xml
+++ b/pom.xml
@@ -921,7 +921,7 @@
                         <configuration>
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>true</autoPublish>
-                            <waitUntil>published</waitUntil>
+                            <waitUntil>validated</waitUntil>
                             <!-- Central Publishing can be much slower than old Nexus publishing process -->
                             <waitMaxTime>3600</waitMaxTime>
                         </configuration>


### PR DESCRIPTION
Changes the `waitUntil` condition on Maven Central publishing to be `validated` rather than `published`.  Validating the release is typically much faster than publishing it which can take a long time during periods of high demand.  If waiting for publishing fails then the rest of the release workflow fails (e.g. Docker Image publishing) and a new release has to be generated since Maven Central releases are idempotent and the Docker publishing step is dependent on the Maven release step so can't be triggered independently .

Therefore better to only wait for validation and then proceed onwards, this should also make release builds run faster.