### PR TITLE
Distribution Lifecycle State Machines (CORE-1275, CORE-1282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
       production and when used could cause Head of Line blocking
     - Added `AbstractLazyJacksonSerializer` and `AbstractLazyJacksonDeserializer` base classes for working with types
       derived from `LazyJacksonPayload`
+- New `distribution-lifecycle` module
+    - Adds a new `distribution-lifecycle` that provides APIs for implementing lifecycle aware services that are able to
+      receive and react to Distribution Lifecycle events
 
 # 0.37.0
 

--- a/distribution-lifecycle/pom.xml
+++ b/distribution-lifecycle/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.telicent.smart-caches</groupId>
+        <artifactId>parent</artifactId>
+        <version>0.37.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>distribution-lifecycle</artifactId>
+    <name>Telicent Smart Caches - Distribution Lifecycle</name>
+    <description>Library that provides APIs for synchronising distribution lifecycle state between lifecycle aware
+        services
+    </description>
+
+    <properties>
+        <license.header.path>${project.parent.basedir}</license.header.path>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.telicent.smart-caches</groupId>
+            <artifactId>event-sources-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/distribution-lifecycle/pom.xml
+++ b/distribution-lifecycle/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.telicent.smart-caches</groupId>
         <artifactId>parent</artifactId>
-        <version>0.37.1-SNAPSHOT</version>
+        <version>0.38.0-SNAPSHOT</version>
     </parent>
     <artifactId>distribution-lifecycle</artifactId>
     <name>Telicent Smart Caches - Distribution Lifecycle</name>
@@ -24,6 +24,22 @@
             <artifactId>event-sources-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${plugin.jacoco}</version>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/ApplicationState.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/ApplicationState.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.distribution.lifecycle;
+
+/**
+ * Possible Application States while processing a lifecycle event
+ */
+public enum ApplicationState {
+    /**
+     * Application has received the request to process a lifecycle event
+     */
+    Requested,
+    /**
+     * Application is in the process of applying a lifecycle event
+     */
+    InProgress,
+    /**
+     * Application has completed the application of a lifecycle event
+     */
+    Completed,
+    /**
+     * Application has failed to apply a lifecycle event
+     */
+    Failed;
+
+    /**
+     * Checks whether a transition from the current state to another is permitted
+     *
+     * @param target  Target state
+     * @return True if a legal transition, false otherwise
+     */
+    public boolean canTransition(ApplicationState target) {
+        return canTransition(this, target);
+    }
+
+    /**
+     * Checks whether a transition from one state to another is permitted
+     *
+     * @param current Current state
+     * @param target  Target state
+     * @return True if a legal transition, false otherwise
+     */
+    public static boolean canTransition(ApplicationState current, ApplicationState target) {
+        return switch (current) {
+            // Requested/Failed can transition to InProgress
+            case Requested, Failed -> target == InProgress;
+            // InProgress can transition to Completed/Failed
+            case InProgress -> target == Completed || target == Failed;
+            // Completed is the terminal state and no transitions are permitted
+            case Completed -> false;
+        };
+    }
+}

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/DistributionLifecycleState.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/DistributionLifecycleState.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.distribution.lifecycle;
+
+/**
+ * Possible Distribution Lifecycle states
+ */
+public enum DistributionLifecycleState {
+
+    /**
+     * Distribution is not yet known to the platform, its data <strong>MUST NOT</strong> be ingested.
+     */
+    Unregistered,
+    /**
+     * Distribution is registered with the platform, its data <strong>MUST</strong> be accepted for ingest but
+     * <strong>MUST NOT</strong> be visible to users.
+     */
+    Registered,
+    /**
+     * Distribution is active, its data <strong>MUST</strong> be accepted for ingest and <strong>MUST</strong> be
+     * visible to suitably authorised users.
+     */
+    Active,
+    /**
+     * Distribution is withdrawn, its data <strong>MUST</strong> continue to be accepted for ingest but
+     * <strong>MUST NOT</strong> be visible to end users.
+     */
+    Withdrawn,
+    /**
+     * Distribution is deleted, its data <strong>MUST NOT</strong> be ingested and <strong>MUST NOT</strong> be visible
+     * to users.  Also, a lifecycle aware service <strong>MUST</strong> actively start removing data belonging to that
+     * distribution from its persistent storage.
+     */
+    Deleted;
+
+    /**
+     * Checks whether a transition from the current state to another is permitted
+     *
+     * @param target  Target state
+     * @return True if legal transition, false otherwise
+     */
+    public boolean canTransition(DistributionLifecycleState target) {
+        return canTransition(this, target);
+    }
+
+    /**
+     * Checks whether a transition from one state to another is permitted
+     *
+     * @param current Current state
+     * @param target  Target state
+     * @return True if legal transition, false otherwise
+     */
+    public static boolean canTransition(DistributionLifecycleState current, DistributionLifecycleState target) {
+        return switch (current) {
+            // An Unregistered distribution can only transition to Registered
+            case Unregistered -> target == Registered;
+            // A Registered/Withdrawn distribution can either transition to Active/Deleted
+            case Registered, Withdrawn -> target == Active || target == Deleted;
+            // An Active distribution can transition to Withdrawn/Deleted
+            case Active -> target == Withdrawn || target == Deleted;
+            // A Deleted distribution is permanently deleted and cannot transition to another state
+            case Deleted -> false;
+        };
+    }
+}

--- a/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/TestApplicationState.java
+++ b/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/TestApplicationState.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.distribution.lifecycle;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestApplicationState {
+
+    @DataProvider
+    public Object[][] validTransitions() {
+        // The manually curated list of legal transitions, if you change ApplicationState#canTransition() in
+        // any way then this MUST be appropriately updated
+        return new Object[][] {
+                { ApplicationState.Requested, ApplicationState.InProgress },
+                { ApplicationState.InProgress, ApplicationState.Completed },
+                { ApplicationState.InProgress, ApplicationState.Failed },
+                { ApplicationState.Failed, ApplicationState.InProgress}
+        };
+    }
+
+    @DataProvider
+    public Object[][] invalidTransitions() {
+        // Calculate this as the negation of the validTransitions()
+        List<Object[]> legalTransitions = Arrays.stream(validTransitions()).toList();
+        List<Object[]> illegalTransitions = new ArrayList<>();
+        for (ApplicationState source : ApplicationState.values()) {
+            for (ApplicationState target : ApplicationState.values()) {
+                if (legalTransitions.stream().anyMatch(t -> t[0] == source && t[1] == target)) {
+                    continue;
+                }
+                illegalTransitions.add(new Object[] { source, target });
+            }
+        }
+        return illegalTransitions.toArray(new Object[0][]);
+    }
+
+    @Test(dataProvider = "validTransitions")
+    public void givenValidTransition_whenCheckingLegality_thenOk(ApplicationState source,
+                                                                 ApplicationState target) {
+        // Given and When
+        boolean legal = ApplicationState.canTransition(source, target);
+
+        // Then
+        Assert.assertTrue(legal);
+    }
+
+    @Test(dataProvider = "validTransitions")
+    public void givenValidTransition_whenCheckingLegalityOnSourceState_thenOk(ApplicationState source,
+                                                                 ApplicationState target) {
+        // Given and When
+        boolean legal = source.canTransition(target);
+
+        // Then
+        Assert.assertTrue(legal);
+    }
+
+    @Test(dataProvider = "invalidTransitions")
+    public void givenInvalidTransition_whenCheckingLegality_thenFails(ApplicationState source,
+                                                                      ApplicationState target) {
+        // Given and When
+        boolean legal = ApplicationState.canTransition(source, target);
+
+        // Then
+        Assert.assertFalse(legal);
+    }
+
+    @Test(dataProvider = "invalidTransitions")
+    public void givenInvalidTransition_whenCheckingLegalityOnSourceState_thenFails(ApplicationState source,
+                                                                      ApplicationState target) {
+        // Given and When
+        boolean legal = source.canTransition(target);
+
+        // Then
+        Assert.assertFalse(legal);
+    }
+}

--- a/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/TestDistributionLifecycleState.java
+++ b/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/TestDistributionLifecycleState.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.distribution.lifecycle;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestDistributionLifecycleState {
+
+    @DataProvider
+    public Object[][] validTransitions() {
+        // The manually curated list of legal transitions, if you change DistributionLifecycleState#canTransition() in
+        // any way then this MUST be appropriately updated
+        return new Object[][] {
+                { DistributionLifecycleState.Unregistered, DistributionLifecycleState.Registered },
+                { DistributionLifecycleState.Registered, DistributionLifecycleState.Active },
+                { DistributionLifecycleState.Registered, DistributionLifecycleState.Deleted },
+                { DistributionLifecycleState.Active, DistributionLifecycleState.Withdrawn },
+                { DistributionLifecycleState.Active, DistributionLifecycleState.Deleted },
+                { DistributionLifecycleState.Withdrawn, DistributionLifecycleState.Active },
+                { DistributionLifecycleState.Withdrawn, DistributionLifecycleState.Deleted }
+        };
+    }
+
+    @DataProvider
+    public Object[][] invalidTransitions() {
+        // Calculate this as the negation of the validTransitions()
+        List<Object[]> legalTransitions = Arrays.stream(validTransitions()).toList();
+        List<Object[]> illegalTransitions = new ArrayList<>();
+        for (DistributionLifecycleState source : DistributionLifecycleState.values()) {
+            for (DistributionLifecycleState target : DistributionLifecycleState.values()) {
+                if (legalTransitions.stream().anyMatch(t -> t[0] == source && t[1] == target)) {
+                    continue;
+                }
+                illegalTransitions.add(new Object[] { source, target });
+            }
+        }
+        return illegalTransitions.toArray(new Object[0][]);
+    }
+
+    @Test(dataProvider = "validTransitions")
+    public void givenValidTransition_whenCheckingLegality_thenOk(DistributionLifecycleState source,
+                                                                 DistributionLifecycleState target) {
+        // Given and When
+        boolean legal = DistributionLifecycleState.canTransition(source, target);
+
+        // Then
+        Assert.assertTrue(legal);
+    }
+
+    @Test(dataProvider = "validTransitions")
+    public void givenValidTransition_whenCheckingLegalityOnSourceState_thenOk(DistributionLifecycleState source,
+                                                                 DistributionLifecycleState target) {
+        // Given and When
+        boolean legal = source.canTransition(target);
+
+        // Then
+        Assert.assertTrue(legal);
+    }
+
+    @Test(dataProvider = "invalidTransitions")
+    public void givenInvalidTransition_whenCheckingLegality_thenFails(DistributionLifecycleState source,
+                                                                      DistributionLifecycleState target) {
+        // Given and When
+        boolean legal = DistributionLifecycleState.canTransition(source, target);
+
+        // Then
+        Assert.assertFalse(legal);
+    }
+
+    @Test(dataProvider = "invalidTransitions")
+    public void givenInvalidTransition_whenCheckingLegalityOnSourceState_thenFails(DistributionLifecycleState source,
+                                                                      DistributionLifecycleState target) {
+        // Given and When
+        boolean legal = source.canTransition(target);
+
+        // Then
+        Assert.assertFalse(legal);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>jwt-auth-common</module>
         <module>action-tracker</module>
         <module>benchmarks</module>
+        <module>distribution-lifecycle</module>
     </modules>
     <packaging>pom</packaging>
     <name>Telicent Smart Caches - Parent</name>


### PR DESCRIPTION
This is the first piece of starting to implement a common `distribution-lifecycle` module that we can use to implement and add the proposed Distribution Lifecycle functionality across our services.  For now this just creates a stub module with the two state machine enums representing the state machines described in the design document