### PR TITLE
[Minor] Reducing the constant kafka logging noise in tests

### DIFF
--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/KafkaTestCluster.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/KafkaTestCluster.java
@@ -96,11 +96,11 @@ public abstract class KafkaTestCluster {
         }
 
         try {
-            Utils.logStdOut("Starting Kafka Test Cluster...");
+            Utils.logVerboseStdOut("Starting Kafka Test Cluster...");
             long start = System.currentTimeMillis();
             this.kafka.start();
             Duration elapsed = Duration.ofMillis(System.currentTimeMillis() - start);
-            Utils.logStdOut("Kafka Test Cluster ready in %,d seconds!", elapsed.toSeconds());
+            Utils.logVerboseStdOut("Kafka Test Cluster ready in %,d seconds!", elapsed.toSeconds());
         } catch (ContainerLaunchException e) {
             System.err.println("Failed to launch Kafka container, see logs below:");
             System.err.println();
@@ -148,8 +148,8 @@ public abstract class KafkaTestCluster {
         CreateTopicsResult created = this.adminClient.createTopics(List.of(new NewTopic(topic, 1, (short) 1)));
         try {
             created.all().get(getDefaultTimeout(), TimeUnit.SECONDS);
-            Utils.logStdOut("Created Kafka test topic '%s' in %,d milliseconds", topic,
-                            Duration.ofMillis(System.currentTimeMillis() - start).toMillis());
+            Utils.logVerboseStdOut("Created Kafka test topic '%s' in %,d milliseconds", topic,
+                                   Duration.ofMillis(System.currentTimeMillis() - start).toMillis());
         } catch (Throwable e) {
             Utils.logStdOut("Failed to create Kafka test topic '%s': %s", topic, e.getMessage());
             throw new RuntimeException("Failed to create Kafka test topic '" + topic + "'", e);
@@ -166,12 +166,12 @@ public abstract class KafkaTestCluster {
         DeleteTopicsResult deleted = this.adminClient.deleteTopics(List.of(topic));
         try {
             deleted.all().get(getDefaultTimeout(), TimeUnit.SECONDS);
-            Utils.logStdOut("Deleted Kafka test topic '%s' in %,d milliseconds", topic,
-                            Duration.ofMillis(System.currentTimeMillis() - start).toMillis());
+            Utils.logVerboseStdOut("Deleted Kafka test topic '%s' in %,d milliseconds", topic,
+                                   Duration.ofMillis(System.currentTimeMillis() - start).toMillis());
         } catch (Throwable e) {
             if (e.getCause() instanceof UnknownTopicOrPartitionException) {
                 // Ignore and continue
-                Utils.logStdOut("Test asked to delete Kafka test topic '%s' that does not exist", topic);
+                Utils.logVerboseStdOut("Test asked to delete Kafka test topic '%s' that does not exist", topic);
             } else {
                 Utils.logStdOut("Failed to delete Kafka test topic '%s': %s", topic, e.getMessage());
                 throw new RuntimeException("Failed to delete Kafka test topic '" + topic + "'", e);
@@ -197,12 +197,12 @@ public abstract class KafkaTestCluster {
      */
     public void teardown() {
         if (this.kafka != null) {
-            Utils.logStdOut("Stopping Kafka Test Cluster...");
+            Utils.logVerboseStdOut("Stopping Kafka Test Cluster...");
             long start = System.currentTimeMillis();
             this.adminClient.close();
             this.kafka.stop();
             Duration elapsed = Duration.ofMillis(System.currentTimeMillis() - start);
-            Utils.logStdOut("Kafka Test Cluster stopped in %,d seconds!", elapsed.toSeconds());
+            Utils.logVerboseStdOut("Kafka Test Cluster stopped in %,d seconds!", elapsed.toSeconds());
         }
         this.adminClient = null;
     }

--- a/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/Utils.java
+++ b/event-sources/event-source-kafka/src/test/java/io/telicent/smart/cache/sources/kafka/Utils.java
@@ -32,6 +32,11 @@ import static org.mockito.Mockito.when;
 
 public class Utils {
 
+    /**
+     * System property that enables extra test logging to standard out.
+     */
+    public static final String VERBOSE_TEST_LOGGING_PROPERTY = "smart.cache.tests.verbose";
+
     private static final PrintStream STDOUT = System.out;
 
     private static final long PID = ProcessHandle.current().pid();
@@ -107,6 +112,22 @@ public class Utils {
         // Also note we explicitly captured the real stdout as some tests might redirect stdout temporarily and anything
         // being logged by this method is generally useful
         STDOUT.println("[PID " + PID + " @ " + Instant.now().toString() + "] " + String.format(message, args));
+    }
+
+    /**
+     * Logs a formatted message to standard out only when verbose test logging is enabled.
+     * <p>
+     * This is intended for routine lifecycle chatter that can be useful when debugging locally but is too noisy for
+     * normal Maven test output.
+     * </p>
+     *
+     * @param message Message format
+     * @param args    Format arguments
+     */
+    public static void logVerboseStdOut(String message, Object... args) {
+        if (Boolean.getBoolean(VERBOSE_TEST_LOGGING_PROPERTY)) {
+            logStdOut(message, args);
+        }
     }
 
     /**


### PR DESCRIPTION
It can be re-enabled via environment variable.

Tackling these type of messages which add little value
"
[PID 1019 @ 2026-05-08T09:31:47.999033Z] Created Kafka test topic 'tests' in 55 milliseconds
[PID 1019 @ 2026-05-08T09:31:48.221314Z] Deleted Kafka test topic 'tests' in 40 milliseconds
[PID 1019 @ 2026-05-08T09:31:48.251284Z] Created Kafka test topic 'tests' in 30 milliseconds
[PID 1019 @ 2026-05-08T09:31:48.288765Z] Deleted Kafka test topic 'tests' in 30 milliseconds
[PID 1019 @ 2026-05-08T09:31:48.319709Z] Created Kafka test topic 'tests' in 31 milliseconds
[PID 1020 @ 2026-05-08T09:31:48.741706Z] Deleted Kafka test topic 'tests' in 39 milliseconds
[PID 1020 @ 2026-05-08T09:31:48.773400Z] Created Kafka test topic 'tests' in 32 milliseconds
[PID 1019 @ 2026-05-08T09:31:49.756011Z] Deleted Kafka test topic 'tests' in 9 milliseconds
[PID 1019 @ 2026-05-08T09:31:49.792165Z] Created Kafka test topic 'tests' in 36 milliseconds
[PID 1020 @ 2026-05-08T09:31:50.197695Z] Deleted Kafka test topic 'tests' in 33 milliseconds
[PID 1020 @ 2026-05-08T09:31:50.229429Z] Created Kafka test topic 'tests' in 32 milliseconds
[PID 1020 @ 2026-05-08T09:31:50.438207Z] Deleted Kafka test topic 'tests' in 30 milliseconds
[PID 1020 @ 2026-05-08T09:31:50.473487Z] Created Kafka test topic 'tests' in 35 milliseconds
"