### PR TITLE
[CORE-30] Adding optional aysnc file processing

### DIFF
--- a/docs/event-sources/file.md
+++ b/docs/event-sources/file.md
@@ -7,10 +7,13 @@ remove the extra complexity of Kafka.
 
 This event source works by taking in a source directory, scanning that for event files and sorting those into order.
 This operation happens **ONCE** when the source is created, i.e. this source will not actively see new event files that
-get added to the directory.  As events are polled from the source the next file is read in as an `Event` and returned.
-Once the detected files are exhausted the source reports itself as exhausted.  Each concrete implementation specifies
-its own logic as to which files within the source directory are considered to be events, usually by filtering upon file
-extension and name.
+get added to the directory.  By default the source preserves the original behaviour where the next file is parsed
+synchronously when `poll()` is called.  Optionally you can enable asynchronous parsing via an overload that takes an
+`asyncProcessing` flag, in which case a background parser thread reads those files and buffers the parsed events in
+memory ready for `poll()` calls.  If a malformed event file is encountered while using asynchronous parsing the failure
+is buffered in order and only surfaced when the caller polls that event slot.  Once the detected files are exhausted
+the source reports itself as exhausted.  Each concrete implementation specifies its own logic as to which files within
+the source directory are considered to be events, usually by filtering upon file extension and name.
 
 These event sources are designed to re-use the Kafka `Serializer` and `Deserializer` implementations from the
 [Kafka](kafka.md) event source.  This ensures that while there are some format specific differences in the actual
@@ -32,7 +35,8 @@ A more detailed description of each format is given [later](#supported-formats) 
 ## Behaviours
 
 - Bounded
-- Unbuffered
+- Unbuffered by default
+- Optional Buffered mode via `asyncProcessing=true`
 - Configurable Read Policy: No
 
 ## Parameters
@@ -56,6 +60,22 @@ EventSource<Integer, String> source
 
 It requires a directory from which events will be read as well as the deserializers for the key and
 value types.
+
+If you want the new asynchronous parsing mode you can use the overload that accepts the `asyncProcessing` flag:
+
+```java
+FileEventFormatProvider format = FileEventFormats.get(YamlFormat.NAME);
+EventSource<Integer, String> source
+    = format.createSource(new IntegerDeserializer(),
+                          new StringDeserializer(),
+                          new File("some-dir"),
+                          true);
+```
+
+When `asyncProcessing=true` there are two caveats to be aware of:
+
+- `availableImmediately()` reflects the in-memory parse buffer, so it may return `false` briefly after construction even when files are present.
+- `poll(Duration.ZERO)` may return `null` before the background parser has had time to parse the first event.
 
 The YAML format looks for files with a `.yaml` extension in the source directory that have a numeric portion in the
 filename e.g. `event-12345.yaml`.  Detected files are sorted based upon the numeric portion of the filename, in the

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/FileEventFormatProvider.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/FileEventFormatProvider.java
@@ -93,6 +93,24 @@ public interface FileEventFormatProvider {
                                                               Deserializer<TValue> valueDeserializer, File source);
 
     /**
+     * Creates a new directory event source for the format
+     *
+     * @param keyDeserializer   Key deserializer
+     * @param valueDeserializer Value deserializer
+     * @param source            Source directory
+     * @param asyncProcessing   Whether to parse files asynchronously in a background thread
+     * @param <TKey>            Key type
+     * @param <TValue>          Value type
+     * @return Event source
+     */
+    default <TKey, TValue> FileEventSource<TKey, TValue> createSource(Deserializer<TKey> keyDeserializer,
+                                                                      Deserializer<TValue> valueDeserializer,
+                                                                      File source,
+                                                                      boolean asyncProcessing) {
+        return createSource(keyDeserializer, valueDeserializer, source);
+    }
+
+    /**
      * Creates a new single file event source for the format
      *
      * @param keyDeserializer   Key deserializer
@@ -105,5 +123,23 @@ public interface FileEventFormatProvider {
     <TKey, TValue> FileEventSource<TKey, TValue> createSingleFileSource(Deserializer<TKey> keyDeserializer,
                                                                         Deserializer<TValue> valueDeserializer,
                                                                         File source);
+
+    /**
+     * Creates a new single file event source for the format
+     *
+     * @param keyDeserializer   Key deserializer
+     * @param valueDeserializer Value deserializer
+     * @param source            Source file
+     * @param asyncProcessing   Whether to parse the file asynchronously in a background thread
+     * @param <TKey>            Key type
+     * @param <TValue>          Value type
+     * @return Event source
+     */
+    default <TKey, TValue> FileEventSource<TKey, TValue> createSingleFileSource(Deserializer<TKey> keyDeserializer,
+                                                                                Deserializer<TValue> valueDeserializer,
+                                                                                File source,
+                                                                                boolean asyncProcessing) {
+        return createSingleFileSource(keyDeserializer, valueDeserializer, source);
+    }
 
 }

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/FileEventSource.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/FileEventSource.java
@@ -26,6 +26,7 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * An event source where the events are files on disk in a directory
@@ -37,12 +38,37 @@ public class FileEventSource<TKey, TValue> implements EventSource<TKey, TValue> 
 
     private static final Logger LOGGER = LoggerFactory.getLogger(FileEventSource.class);
 
-    private final List<File> events = new ArrayList<>();
+    protected static final class BufferedFileEvent<TKey, TValue> {
+        private final Event<TKey, TValue> event;
+        private final EventSourceException error;
+
+        private BufferedFileEvent(Event<TKey, TValue> event, EventSourceException error) {
+            this.event = event;
+            this.error = error;
+        }
+
+        private static <TKey, TValue> BufferedFileEvent<TKey, TValue> event(Event<TKey, TValue> event) {
+            return new BufferedFileEvent<>(event, null);
+        }
+
+        private static <TKey, TValue> BufferedFileEvent<TKey, TValue> error(EventSourceException error) {
+            return new BufferedFileEvent<>(null, error);
+        }
+    }
+
+    private final Object stateLock = new Object();
+    private final List<File> eventFiles = new ArrayList<>();
+    private final Queue<BufferedFileEvent<TKey, TValue>> bufferedEvents = new ArrayDeque<>();
     private final FileEventReader<TKey, TValue> eventReader;
-    private boolean closed = false;
+    private final boolean asyncProcessing;
+    private final int totalEvents;
+    private final AtomicInteger consumedEvents = new AtomicInteger();
+    private volatile boolean closed = false;
+    private volatile boolean parsingComplete = false;
+    private Thread parserThread;
 
     /**
-     * Creates a new file event source
+     * Creates a new file event source using the legacy synchronous per-poll parsing behaviour.
      *
      * @param sourceDir       Source directory containing the events
      * @param eventFileFilter Filter used to identify files that represent events
@@ -51,6 +77,20 @@ public class FileEventSource<TKey, TValue> implements EventSource<TKey, TValue> 
      */
     public FileEventSource(File sourceDir, FileFilter eventFileFilter, Comparator<File> fileComparator,
                            FileEventReader<TKey, TValue> reader) {
+        this(sourceDir, eventFileFilter, fileComparator, reader, false);
+    }
+
+    /**
+     * Creates a new file event source
+     *
+     * @param sourceDir         Source directory containing the events
+     * @param eventFileFilter   Filter used to identify files that represent events
+     * @param fileComparator    File comparator used to sort events into the desired order
+     * @param reader            File event reader to use to convert the files into events
+     * @param asyncProcessing   Whether to parse files asynchronously in a background thread
+     */
+    public FileEventSource(File sourceDir, FileFilter eventFileFilter, Comparator<File> fileComparator,
+                           FileEventReader<TKey, TValue> reader, boolean asyncProcessing) {
         Objects.requireNonNull(sourceDir, "Source directory cannot be null");
         Objects.requireNonNull(eventFileFilter, "Event filter filter cannot be null");
         Objects.requireNonNull(fileComparator, "File comparator cannot be null");
@@ -62,24 +102,57 @@ public class FileEventSource<TKey, TValue> implements EventSource<TKey, TValue> 
             throw new IllegalArgumentException(sourceDir.getAbsolutePath() + " is not a directory");
         }
         this.eventReader = reader;
-        this.events.addAll(obtainEventFiles(sourceDir,eventFileFilter));
-        this.events.sort(fileComparator);
+        this.asyncProcessing = asyncProcessing;
+
+        this.eventFiles.addAll(obtainEventFiles(sourceDir, eventFileFilter));
+        this.eventFiles.sort(fileComparator);
+        this.totalEvents = this.eventFiles.size();
+        this.parsingComplete = !this.asyncProcessing && this.eventFiles.isEmpty();
+
+        if (this.asyncProcessing) {
+            if (this.eventFiles.isEmpty()) {
+                this.parsingComplete = true;
+            } else {
+                startParserThread();
+            }
+        }
     }
 
     @Override
     public boolean availableImmediately() {
-        return !this.closed && !this.events.isEmpty();
+        synchronized (this.stateLock) {
+            if (this.closed) {
+                return false;
+            }
+            return this.asyncProcessing ? !this.bufferedEvents.isEmpty() : !this.eventFiles.isEmpty();
+        }
     }
 
     @Override
     public boolean isExhausted() {
-        return this.closed || this.events.isEmpty();
+        synchronized (this.stateLock) {
+            if (this.closed) {
+                return true;
+            }
+            if (!this.asyncProcessing) {
+                return this.eventFiles.isEmpty();
+            }
+            return this.parsingComplete && this.bufferedEvents.isEmpty();
+        }
     }
 
     @Override
     public void close() {
         this.closed = true;
-        this.events.clear();
+        synchronized (this.stateLock) {
+            this.eventFiles.clear();
+            this.bufferedEvents.clear();
+            this.parsingComplete = true;
+            this.stateLock.notifyAll();
+        }
+        if (this.parserThread != null) {
+            this.parserThread.interrupt();
+        }
     }
 
     @Override
@@ -92,30 +165,90 @@ public class FileEventSource<TKey, TValue> implements EventSource<TKey, TValue> 
         if (this.closed) {
             throw new IllegalStateException("Event source is closed");
         }
-        if (!this.events.isEmpty()) {
-            File f = this.events.remove(0);
-            try {
-                return this.eventReader.read(f);
-            } catch (IOException e) {
-                throw new EventSourceException("Failed to parse an Event from file " + f.getAbsolutePath(), e);
-            } catch (Throwable e) {
-                throw new EventSourceException("Invalid Event in file " + f.getAbsolutePath(), e);
+
+        return this.asyncProcessing ? pollAsync(timeout) : pollSynchronously();
+    }
+
+    private Event<TKey, TValue> pollSynchronously() {
+        File nextFile;
+        synchronized (this.stateLock) {
+            if (this.eventFiles.isEmpty()) {
+                return null;
             }
-        } else {
-            return null;
+            nextFile = this.eventFiles.remove(0);
         }
+
+        return readEvent(nextFile);
+    }
+
+    private Event<TKey, TValue> pollAsync(Duration timeout) {
+        BufferedFileEvent<TKey, TValue> bufferedEvent;
+        synchronized (this.stateLock) {
+            if (!this.bufferedEvents.isEmpty()) {
+                bufferedEvent = this.bufferedEvents.poll();
+            } else if (this.parsingComplete) {
+                return null;
+            } else {
+                long timeoutMillis = timeout.toMillis();
+                long start = System.currentTimeMillis();
+                while (!this.closed && this.bufferedEvents.isEmpty() && !this.parsingComplete) {
+                    long remainingWait = timeoutMillis - (System.currentTimeMillis() - start);
+                    if (remainingWait <= 0) {
+                        return null;
+                    }
+                    try {
+                        this.stateLock.wait(remainingWait);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return null;
+                    }
+                }
+
+                if (this.closed) {
+                    throw new IllegalStateException("Event source is closed");
+                }
+                if (this.bufferedEvents.isEmpty()) {
+                    return null;
+                }
+                bufferedEvent = this.bufferedEvents.poll();
+            }
+        }
+
+        this.consumedEvents.incrementAndGet();
+        if (bufferedEvent.error != null) {
+            throw bufferedEvent.error;
+        }
+        return bufferedEvent.event;
     }
 
     @Override
     public Long remaining() {
-        return (long) this.events.size();
+        synchronized (this.stateLock) {
+            if (this.closed) {
+                return 0L;
+            }
+            if (!this.asyncProcessing) {
+                return (long) this.eventFiles.size();
+            }
+            return (long) Math.max(0, this.totalEvents - this.consumedEvents.get());
+        }
     }
 
     @Override
-    public void processed(Collection<Event<?,?>> processedEvents) {
+    public void processed(Collection<Event<?, ?>> processedEvents) {
         // No-op
         LOGGER.trace("Received {} processed events in processed() callback, this is ignored by the FileEventSource",
                      processedEvents.size());
+    }
+
+    @Override
+    public void interrupt() {
+        if (this.parserThread != null) {
+            this.parserThread.interrupt();
+        }
+        synchronized (this.stateLock) {
+            this.stateLock.notifyAll();
+        }
     }
 
     /**
@@ -127,9 +260,65 @@ public class FileEventSource<TKey, TValue> implements EventSource<TKey, TValue> 
      */
     private List<File> obtainEventFiles(File sourceDir, FileFilter eventFileFilter) {
         File[] fileArray = sourceDir.listFiles(eventFileFilter);
-        if (null != fileArray) {
+        if (fileArray != null) {
             return Arrays.asList(fileArray);
         }
         return Collections.emptyList();
+    }
+
+    private void startParserThread() {
+        this.parserThread = new Thread(this::runParser, "file-event-source-parser");
+        this.parserThread.setDaemon(true);
+        this.parserThread.start();
+    }
+
+    private void runParser() {
+        try {
+            while (!this.closed) {
+                File nextFile;
+                synchronized (this.stateLock) {
+                    if (this.eventFiles.isEmpty()) {
+                        return;
+                    }
+                    nextFile = this.eventFiles.remove(0);
+                }
+
+                BufferedFileEvent<TKey, TValue> bufferedEvent = readBufferedEvent(nextFile);
+                synchronized (this.stateLock) {
+                    if (this.closed) {
+                        return;
+                    }
+                    this.bufferedEvents.add(bufferedEvent);
+                    this.stateLock.notifyAll();
+                }
+            }
+        } finally {
+            synchronized (this.stateLock) {
+                this.parsingComplete = true;
+                this.stateLock.notifyAll();
+            }
+        }
+    }
+
+    private BufferedFileEvent<TKey, TValue> readBufferedEvent(File file) {
+        try {
+            return BufferedFileEvent.event(this.eventReader.read(file));
+        } catch (IOException e) {
+            return BufferedFileEvent.error(
+                    new EventSourceException("Failed to parse an Event from file " + file.getAbsolutePath(), e));
+        } catch (Throwable e) {
+            return BufferedFileEvent.error(
+                    new EventSourceException("Invalid Event in file " + file.getAbsolutePath(), e));
+        }
+    }
+
+    private Event<TKey, TValue> readEvent(File file) {
+        try {
+            return this.eventReader.read(file);
+        } catch (IOException e) {
+            throw new EventSourceException("Failed to parse an Event from file " + file.getAbsolutePath(), e);
+        } catch (Throwable e) {
+            throw new EventSourceException("Invalid Event in file " + file.getAbsolutePath(), e);
+        }
     }
 }

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/SingleFileEventSource.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/SingleFileEventSource.java
@@ -34,8 +34,21 @@ public class SingleFileEventSource<TKey, TValue> extends FileEventSource<TKey, T
      */
     public SingleFileEventSource(File sourceFile,
                                  FileEventReaderWriter<TKey, TValue> reader) {
+        this(sourceFile, reader, false);
+    }
+
+    /**
+     * Creates a new single file event source
+     *
+     * @param sourceFile       Source file to use as the single event
+     * @param reader           File event reader to use to convert the files into events
+     * @param asyncProcessing  Whether to parse the file asynchronously in a background thread
+     */
+    public SingleFileEventSource(File sourceFile,
+                                 FileEventReaderWriter<TKey, TValue> reader,
+                                 boolean asyncProcessing) {
         super(sourceFile.getParentFile(),
               f -> Objects.equals(f.getAbsolutePath(), sourceFile.getAbsolutePath()),
-              Comparator.naturalOrder(), reader);
+              Comparator.naturalOrder(), reader, asyncProcessing);
     }
 }

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/rdf/RdfFileEventSource.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/rdf/RdfFileEventSource.java
@@ -34,7 +34,20 @@ public class RdfFileEventSource<TKey, TValue> extends FileEventSource<TKey, TVal
      */
     public RdfFileEventSource(File sourceDir, Deserializer<TKey> keyDeserializer,
                               Deserializer<TValue> valueDeserializer) {
+        this(sourceDir, keyDeserializer, valueDeserializer, false);
+    }
+
+    /**
+     * Creates a new file event source that reads RDF files directly
+     *
+     * @param sourceDir         Source directory containing the RDF files to treat as events
+     * @param keyDeserializer   Key deserializer
+     * @param valueDeserializer Value deserializer
+     * @param asyncProcessing   Whether to parse RDF files asynchronously in a background thread
+     */
+    public RdfFileEventSource(File sourceDir, Deserializer<TKey> keyDeserializer,
+                              Deserializer<TValue> valueDeserializer, boolean asyncProcessing) {
         super(sourceDir, new NumericallyNamedRdfFilter(), new NumericFilenameComparator(),
-              new RdfEventReaderWriter<>(keyDeserializer, valueDeserializer));
+              new RdfEventReaderWriter<>(keyDeserializer, valueDeserializer), asyncProcessing);
     }
 }

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/rdf/RdfFormat.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/rdf/RdfFormat.java
@@ -64,10 +64,27 @@ public class RdfFormat implements FileEventFormatProvider {
     }
 
     @Override
+    public <TKey, TValue> FileEventSource<TKey, TValue> createSource(Deserializer<TKey> keyDeserializer,
+                                                                     Deserializer<TValue> valueDeserializer,
+                                                                     File source,
+                                                                     boolean asyncProcessing) {
+        return new RdfFileEventSource<>(source, keyDeserializer, valueDeserializer, asyncProcessing);
+    }
+
+    @Override
     public <TKey, TValue> FileEventSource<TKey, TValue> createSingleFileSource(Deserializer<TKey> keyDeserializer,
                                                                                Deserializer<TValue> valueDeserializer,
                                                                                File source) {
         return new SingleFileEventSource<>(source, new RdfEventReaderWriter<>(keyDeserializer, valueDeserializer));
+    }
+
+    @Override
+    public <TKey, TValue> FileEventSource<TKey, TValue> createSingleFileSource(Deserializer<TKey> keyDeserializer,
+                                                                                Deserializer<TValue> valueDeserializer,
+                                                                                File source,
+                                                                                boolean asyncProcessing) {
+        return new SingleFileEventSource<>(source, new RdfEventReaderWriter<>(keyDeserializer, valueDeserializer),
+                                           asyncProcessing);
     }
 
     @Override

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/text/PlainTextFileEventSource.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/text/PlainTextFileEventSource.java
@@ -42,7 +42,18 @@ public class PlainTextFileEventSource<TKey, TValue> extends FileEventSource<TKey
      * @param valueDeserializer Value deserializer
      */
     public PlainTextFileEventSource(File sourceDir, Deserializer<TValue> valueDeserializer) {
+        this(sourceDir, valueDeserializer, false);
+    }
+
+    /**
+     * Creates a new file event source
+     *
+     * @param sourceDir         Source directory containing the events
+     * @param valueDeserializer Value deserializer
+     * @param asyncProcessing   Whether to parse event files asynchronously in a background thread
+     */
+    public PlainTextFileEventSource(File sourceDir, Deserializer<TValue> valueDeserializer, boolean asyncProcessing) {
         super(sourceDir, PLAINTEXT_FILTER, new NumericFilenameComparator(),
-              new PlainTextEventReaderWriter<>(valueDeserializer));
+              new PlainTextEventReaderWriter<>(valueDeserializer), asyncProcessing);
     }
 }

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/text/PlainTextFormat.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/text/PlainTextFormat.java
@@ -64,10 +64,27 @@ public class PlainTextFormat implements FileEventFormatProvider {
     }
 
     @Override
+    public <TKey, TValue> FileEventSource<TKey, TValue> createSource(Deserializer<TKey> keyDeserializer,
+                                                                     Deserializer<TValue> valueDeserializer,
+                                                                     File source,
+                                                                     boolean asyncProcessing) {
+        return new PlainTextFileEventSource<>(source, valueDeserializer, asyncProcessing);
+    }
+
+    @Override
     public <TKey, TValue> FileEventSource<TKey, TValue> createSingleFileSource(Deserializer<TKey> keyDeserializer,
                                                                                Deserializer<TValue> valueDeserializer,
                                                                                File source) {
         return new SingleFileEventSource<>(source, new PlainTextEventReaderWriter<>(valueDeserializer));
+    }
+
+    @Override
+    public <TKey, TValue> FileEventSource<TKey, TValue> createSingleFileSource(Deserializer<TKey> keyDeserializer,
+                                                                                Deserializer<TValue> valueDeserializer,
+                                                                                File source,
+                                                                                boolean asyncProcessing) {
+        return new SingleFileEventSource<>(source, new PlainTextEventReaderWriter<>(valueDeserializer),
+                                           asyncProcessing);
     }
 
     @Override

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/yaml/YamlFileEventSource.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/yaml/YamlFileEventSource.java
@@ -51,7 +51,20 @@ public class YamlFileEventSource<TKey, TValue> extends FileEventSource<TKey, TVa
      */
     public YamlFileEventSource(File sourceDir, Deserializer<TKey> keyDeserializer,
                                Deserializer<TValue> valueDeserializer) {
-        this(sourceDir, false, keyDeserializer, valueDeserializer);
+        this(sourceDir, false, keyDeserializer, valueDeserializer, false);
+    }
+
+    /**
+     * Creates a new file event source
+     *
+     * @param sourceDir         Source directory containing the events
+     * @param keyDeserializer   Key deserializer
+     * @param valueDeserializer Value deserializer
+     * @param asyncProcessing   Whether to parse event files asynchronously in a background thread
+     */
+    public YamlFileEventSource(File sourceDir, Deserializer<TKey> keyDeserializer,
+                               Deserializer<TValue> valueDeserializer, boolean asyncProcessing) {
+        this(sourceDir, false, keyDeserializer, valueDeserializer, asyncProcessing);
     }
 
     /**
@@ -64,8 +77,22 @@ public class YamlFileEventSource<TKey, TValue> extends FileEventSource<TKey, TVa
      */
     public YamlFileEventSource(File sourceDir, boolean gzip, Deserializer<TKey> keyDeserializer,
                                Deserializer<TValue> valueDeserializer) {
+        this(sourceDir, gzip, keyDeserializer, valueDeserializer, false);
+    }
+
+    /**
+     * Creates a new file event source
+     *
+     * @param sourceDir         Source directory containing the events
+     * @param gzip              Whether the event files are GZipped
+     * @param keyDeserializer   Key deserializer
+     * @param valueDeserializer Value deserializer
+     * @param asyncProcessing   Whether to parse event files asynchronously in a background thread
+     */
+    public YamlFileEventSource(File sourceDir, boolean gzip, Deserializer<TKey> keyDeserializer,
+                               Deserializer<TValue> valueDeserializer, boolean asyncProcessing) {
         super(sourceDir, selectFilter(gzip), new NumericFilenameComparator(),
-              selectReader(gzip, keyDeserializer, valueDeserializer));
+              selectReader(gzip, keyDeserializer, valueDeserializer), asyncProcessing);
     }
 
     private static FileFilter selectFilter(boolean gzip) {

--- a/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/yaml/YamlFormat.java
+++ b/event-sources/event-source-file/src/main/java/io/telicent/smart/cache/sources/file/yaml/YamlFormat.java
@@ -64,10 +64,27 @@ public class YamlFormat implements FileEventFormatProvider {
     }
 
     @Override
+    public <TKey, TValue> FileEventSource<TKey, TValue> createSource(Deserializer<TKey> keyDeserializer,
+                                                                     Deserializer<TValue> valueDeserializer,
+                                                                     File source,
+                                                                     boolean asyncProcessing) {
+        return new YamlFileEventSource<>(source, keyDeserializer, valueDeserializer, asyncProcessing);
+    }
+
+    @Override
     public <TKey, TValue> FileEventSource<TKey, TValue> createSingleFileSource(Deserializer<TKey> keyDeserializer,
                                                                                Deserializer<TValue> valueDeserializer,
                                                                                File source) {
         return new SingleFileEventSource<>(source, new YamlEventReaderWriter<>(keyDeserializer, valueDeserializer));
+    }
+
+    @Override
+    public <TKey, TValue> FileEventSource<TKey, TValue> createSingleFileSource(Deserializer<TKey> keyDeserializer,
+                                                                                Deserializer<TValue> valueDeserializer,
+                                                                                File source,
+                                                                                boolean asyncProcessing) {
+        return new SingleFileEventSource<>(source, new YamlEventReaderWriter<>(keyDeserializer, valueDeserializer),
+                                           asyncProcessing);
     }
 
     @Override

--- a/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/sources/file/TestFileEventFormatProviders.java
+++ b/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/sources/file/TestFileEventFormatProviders.java
@@ -128,4 +128,30 @@ public class TestFileEventFormatProviders {
 
         source.close();
     }
+
+    @Test(dataProvider = "formats")
+    public void create_async_source_01(String format) {
+        FileEventFormatProvider provider = FileEventFormats.get(format);
+        File workingDir = new File(Paths.get(".").toAbsolutePath().toString());
+        FileEventSource<Integer, String> source =
+                provider.createSource(Serdes.INTEGER_DESERIALIZER, Serdes.STRING_DESERIALIZER, workingDir, true);
+        Assert.assertFalse(source.availableImmediately());
+        Assert.assertTrue(source.isExhausted());
+        Assert.assertEquals(source.remaining(), 0L);
+
+        source.close();
+    }
+
+    @Test(dataProvider = "formats")
+    public void create_async_source_02(String format) {
+        FileEventFormatProvider provider = FileEventFormats.get(format);
+        File workingDir = new File(Paths.get("pom.xml").toAbsolutePath().toString());
+        FileEventSource<Integer, String> source =
+                provider.createSingleFileSource(Serdes.INTEGER_DESERIALIZER, Serdes.STRING_DESERIALIZER, workingDir,
+                                                true);
+        Assert.assertFalse(source.isExhausted());
+        Assert.assertEquals(source.remaining(), 1L);
+
+        source.close();
+    }
 }

--- a/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/sources/file/TestFileEventSource.java
+++ b/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/sources/file/TestFileEventSource.java
@@ -149,9 +149,9 @@ public class TestFileEventSource extends AbstractEventSourceTests<Integer, Strin
             Assert.assertTrue(source.availableImmediately());
             Event<Integer, String> event = source.poll(Duration.ofSeconds(1));
             Assert.assertEquals(event.key(), expectedKey);
-
             expectedKey++;
         }
+        Assert.assertEquals(expectedKey, 1_000);
         Assert.assertFalse(source.availableImmediately());
     }
 
@@ -188,6 +188,32 @@ public class TestFileEventSource extends AbstractEventSourceTests<Integer, Strin
         Assert.assertTrue(source.availableImmediately());
         Assert.assertFalse(source.isExhausted());
         Assert.assertEquals(source.remaining(), 4L);
+    }
+
+    @Test
+    public void async_file_event_source_09() throws IOException {
+        YamlEventReaderWriter<String, String> yaml = Serdes.YAML_STRING_STRING;
+        File tempDir = Files.createTempDirectory("yaml-events-with-error").toFile();
+        yaml.write(new SimpleEvent<>(Collections.emptyList(), "first", "value-1"), new File(tempDir, "event-1.yaml"));
+        Files.copy(new File("test-data", "malformed.yaml").toPath(), new File(tempDir, "event-2.yaml").toPath());
+        yaml.write(new SimpleEvent<>(Collections.emptyList(), "third", "value-3"), new File(tempDir, "event-3.yaml"));
+
+        EventSource<String, String> source =
+                new YamlFileEventSource<>(tempDir, Serdes.STRING_DESERIALIZER, Serdes.STRING_DESERIALIZER, true);
+
+        Event<String, String> first = source.poll(Duration.ofSeconds(1));
+        Assert.assertNotNull(first);
+        Assert.assertEquals(first.key(), "first");
+        Assert.assertEquals(source.remaining(), 2L);
+
+        Assert.assertThrows(EventSourceException.class, () -> source.poll(Duration.ofSeconds(1)));
+        Assert.assertEquals(source.remaining(), 1L);
+
+        Event<String, String> third = source.poll(Duration.ofSeconds(1));
+        Assert.assertNotNull(third);
+        Assert.assertEquals(third.key(), "third");
+        Assert.assertEquals(source.remaining(), 0L);
+        Assert.assertNull(source.poll(Duration.ofSeconds(1)));
     }
 
     @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = ".*cannot be null")

--- a/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/sources/file/text/TestPlaintextEventReaderWriter.java
+++ b/event-sources/event-source-file/src/test/java/io/telicent/smart/cache/sources/file/text/TestPlaintextEventReaderWriter.java
@@ -38,8 +38,9 @@ public class TestPlaintextEventReaderWriter {
                 new PlainTextFileEventSource<>(sourceDir, new DatasetGraphDeserializer());
         PlainTextEventReaderWriter<Integer, DatasetGraph> readerWriter =
                 new PlainTextEventReaderWriter<>(new DatasetGraphDeserializer(), new DatasetGraphSerializer());
-        while (!source.isExhausted()) {
-            Event<Integer, DatasetGraph> event = source.poll(Duration.ZERO);
+        int count = 0;
+        Event<Integer, DatasetGraph> event;
+        while ((event = source.poll(Duration.ofSeconds(1))) != null) {
             Assert.assertNull(event.key());
             Assert.assertNotNull(event.value());
 
@@ -47,7 +48,9 @@ public class TestPlaintextEventReaderWriter {
             Assert.assertEquals(event.value().stream().count(), 2);
 
             verifyRoundTrip(readerWriter, event);
+            count++;
         }
+        Assert.assertEquals(count, 3);
     }
 
     @Test(expectedExceptions = IOException.class, expectedExceptionsMessageRegExp = "Invalid header line.*")


### PR DESCRIPTION
Adding an optional parsing mode to FileEventSource so that file events can be pre-parsed in the background when requested, while keeping backward compatibility by default, and exposing file-source types and providers tonew mode.

Aslo added test coverage for sync/async paths and updated the documentation.