### PR TITLE
Proper contract test suite for state stores (CORE-1317)

### DIFF
--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/IngestStatus.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/IngestStatus.java
@@ -20,6 +20,8 @@ import io.telicent.smart.cache.distribution.lifecycle.events.utils.PartitionOffs
 import lombok.*;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
+
 /**
  * An Ingest Status event is sent by a lifecycle-aware service to report where it has reached in processing data ingest
  * for one/more distributions.
@@ -33,7 +35,7 @@ import lombok.extern.jackson.Jacksonized;
 @EqualsAndHashCode
 @Builder
 @Jacksonized
-public class IngestStatus {
+public class IngestStatus implements Serializable {
     /**
      * Document format used when wrapping this into an {@link io.telicent.smart.cache.payloads.Envelope}
      */

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/LifecycleAcknowledgement.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/LifecycleAcknowledgement.java
@@ -20,6 +20,7 @@ import io.telicent.smart.cache.distribution.lifecycle.events.utils.ApplicationSt
 import lombok.*;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.UUID;
 
 /**
@@ -37,7 +38,7 @@ import java.util.UUID;
 @Builder
 @Jacksonized
 @JsonPropertyOrder({ "eventId", "distributionId", "state" })
-public class LifecycleAcknowledgement {
+public class LifecycleAcknowledgement implements Serializable {
 
     /**
      * Document format used when wrapping this into an {@link io.telicent.smart.cache.payloads.Envelope}

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/LifecycleAction.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/LifecycleAction.java
@@ -20,6 +20,7 @@ import io.telicent.smart.cache.distribution.lifecycle.events.utils.LifecycleStat
 import lombok.*;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
 import java.util.UUID;
 
 /**
@@ -41,7 +42,7 @@ import java.util.UUID;
 @EqualsAndHashCode
 @Jacksonized
 @JsonPropertyOrder({ "eventId", "distributionId", "datasetId", "state", "user" })
-public class LifecycleAction {
+public class LifecycleAction implements Serializable {
 
     /**
      * Document format used when wrapping this into an {@link io.telicent.smart.cache.payloads.Envelope}

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/listeners/DistributionLifecycleStateStoreSink.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/listeners/DistributionLifecycleStateStoreSink.java
@@ -201,6 +201,9 @@ public class DistributionLifecycleStateStoreSink extends AbstractLifecycleListen
 
         // Finally close any listeners which gives them opportunity to release any resources they are holding
         for (DistributionLifecycleListener listener : this.listeners) {
+            if (listener == null) {
+                continue;
+            }
             try {
                 listener.close();
             } catch (Throwable e) {

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/utils/ApplicationStateUpdate.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/utils/ApplicationStateUpdate.java
@@ -19,6 +19,8 @@ import io.telicent.smart.cache.distribution.lifecycle.ApplicationState;
 import lombok.*;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
+
 /**
  * Indicates the current state of a lifecycle aware service in processing a given
  * {@link io.telicent.smart.cache.distribution.lifecycle.events.LifecycleAction}.  This forms part of a
@@ -30,7 +32,7 @@ import lombok.extern.jackson.Jacksonized;
 @AllArgsConstructor
 @Builder
 @Jacksonized
-public class ApplicationStateUpdate {
+public class ApplicationStateUpdate implements Serializable {
     @NonNull
     private final ApplicationState app;
 }

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/utils/DistributionOffsets.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/utils/DistributionOffsets.java
@@ -21,6 +21,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -31,7 +32,7 @@ import java.util.Map;
 @NoArgsConstructor
 @ToString
 @EqualsAndHashCode
-public class DistributionOffsets {
+public class DistributionOffsets implements Serializable {
 
     private final Map<String, PartitionOffsets> distributions = new LinkedHashMap<>();
 

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/utils/LifecycleStateTransition.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/utils/LifecycleStateTransition.java
@@ -19,6 +19,8 @@ import io.telicent.smart.cache.distribution.lifecycle.DistributionLifecycleState
 import lombok.*;
 import lombok.extern.jackson.Jacksonized;
 
+import java.io.Serializable;
+
 /**
  * Indicates a distribution lifecycle state transition between two {@link DistributionLifecycleState}'s for a
  * distribution.  This forms part of a {@link io.telicent.smart.cache.distribution.lifecycle.events.LifecycleAction}
@@ -30,7 +32,7 @@ import lombok.extern.jackson.Jacksonized;
 @AllArgsConstructor
 @Builder
 @Jacksonized
-public class LifecycleStateTransition {
+public class LifecycleStateTransition implements Serializable {
     @NonNull
     private final DistributionLifecycleState from, to;
 

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/utils/PartitionOffsets.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/events/utils/PartitionOffsets.java
@@ -21,6 +21,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -31,7 +32,7 @@ import java.util.Map;
 @NoArgsConstructor
 @ToString
 @EqualsAndHashCode
-public class PartitionOffsets {
+public class PartitionOffsets implements Serializable {
 
     private final Map<String, Long> partitions = new LinkedHashMap<>();
 

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/AbstractDistributionLifecycleStore.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/AbstractDistributionLifecycleStore.java
@@ -22,6 +22,7 @@ import io.telicent.smart.cache.distribution.lifecycle.events.LifecycleAction;
 import io.telicent.smart.cache.distribution.lifecycle.store.apps.AbstractAppDistributionLifecycleStore;
 import io.telicent.smart.cache.distribution.lifecycle.store.global.AbstractGlobalDistributionLifecycleStore;
 import io.telicent.smart.cache.distribution.lifecycle.store.apps.AppDistributionLifecycleStoreFile;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -51,8 +52,26 @@ public abstract class AbstractDistributionLifecycleStore implements Distribution
      */
     protected final Map<String, DistributionLifecycleState> distributions = new ConcurrentHashMap<>();
 
+    /**
+     * Indicates whether the store is closed
+     */
+    protected volatile boolean closed = false;
+
+    /**
+     * Method that should be called from implementation methods to check the store hasn't been closed before beginning
+     * an operation
+     */
+    protected final void ensureNotClosed() {
+        if (this.closed) {
+            throw new IllegalStateException("State Store is closed");
+        }
+    }
+
     @Override
     public void add(LifecycleAction action) {
+        ensureNotClosed();
+        Objects.requireNonNull(action, "Action cannot be null");
+
         // Check that the action does not have an already known Event ID
         // Note that we specifically permit duplicate events to ensure idempotency
         if (this.events.containsKey(action.getEventId())) {
@@ -84,7 +103,7 @@ public abstract class AbstractDistributionLifecycleStore implements Distribution
      * @throws IllegalStateException Thrown if the target state is not a valid state based on our current known state
      *                               for the given application
      */
-    protected final ApplicationState getTargetState(LifecycleAcknowledgement ack, ApplicationState current) {
+    public static ApplicationState getTargetState(LifecycleAcknowledgement ack, ApplicationState current) {
         ApplicationState target = ack.getState().getApp();
 
         // Verify the state transition is legal
@@ -103,11 +122,21 @@ public abstract class AbstractDistributionLifecycleStore implements Distribution
 
     @Override
     public DistributionLifecycleState getLifecycleState(String distributionId) {
+        ensureNotClosed();
+        if (StringUtils.isBlank(distributionId)) {
+            throw new IllegalArgumentException("Distribution ID cannot be null/blank");
+        }
         return this.distributions.getOrDefault(distributionId, DistributionLifecycleState.Unregistered);
     }
 
     @Override
+    public void close() {
+        this.closed = true;
+    }
+
+    @Override
     public Map<String, DistributionLifecycleState> getLifecycleStates() {
+        ensureNotClosed();
         return Collections.unmodifiableMap(this.distributions);
     }
 }

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/DistributionLifecycleStateStore.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/DistributionLifecycleStateStore.java
@@ -26,6 +26,10 @@ import java.util.UUID;
 
 /**
  * The distribution lifecycle state store tracks the active lifecycle events and their acknowledgements
+ * <p>
+ * Note that as a general API contract after {@link #close()} has been called invoking any operation in this API
+ * <strong>MUST</strong> throw an {@link IllegalStateException} indicating the store is closed
+ * </p>
  */
 public interface DistributionLifecycleStateStore extends AutoCloseable {
 
@@ -36,7 +40,7 @@ public interface DistributionLifecycleStateStore extends AutoCloseable {
      * @throws NullPointerException  Thrown if the provided action is {@code null}
      * @throws IllegalStateException Thrown if the state transition represented by the action is not a legal transition,
      *                               or if the provided action has the same ID as an existing action in the state store
-     *                               and is not an exact duplicate of the existing action
+     *                               and is not an exact duplicate of the existing action, or if the store is closed
      */
     void add(LifecycleAction action);
 
@@ -52,7 +56,8 @@ public interface DistributionLifecycleStateStore extends AutoCloseable {
      * @throws NullPointerException     Thrown if the provided acknowledgement is {@code null}
      * @throws IllegalArgumentException Thrown if the application ID is {@code null}/blank
      * @throws IllegalStateException    Thrown if the acknowledgement is for an action not known to this store, or if
-     *                                  the acknowledgement represents an illegal state transition
+     *                                  the acknowledgement represents an illegal state transition, or if the store is
+     *                                  closed
      */
     void add(String application, LifecycleAcknowledgement ack);
 
@@ -65,6 +70,7 @@ public interface DistributionLifecycleStateStore extends AutoCloseable {
      * </p>
      *
      * @return Active events (if any)
+     * @throws IllegalStateException Thrown if the store is closed
      */
     List<LifecycleAction> activeEvents();
 
@@ -72,6 +78,7 @@ public interface DistributionLifecycleStateStore extends AutoCloseable {
      * Gets the states of all known distributions
      *
      * @return Distribution lifecycle states
+     * @throws IllegalStateException Thrown if the store is closed
      */
     Map<String, DistributionLifecycleState> getLifecycleStates();
 
@@ -82,6 +89,7 @@ public interface DistributionLifecycleStateStore extends AutoCloseable {
      * @return Current lifecycle state, <strong>MUST</strong> return {@link DistributionLifecycleState#Unregistered} if
      * not a known Distribution ID
      * @throws IllegalArgumentException Thrown if the distribution ID is {@code null} or blank
+     * @throws IllegalStateException    Thrown if the store is closed
      */
     DistributionLifecycleState getLifecycleState(String distributionId);
 
@@ -90,6 +98,8 @@ public interface DistributionLifecycleStateStore extends AutoCloseable {
      *
      * @param eventId Lifecycle Event ID
      * @return Map of applications to states, empty if not a known event
+     * @throws IllegalArgumentException Thrown if the Event ID is {@code null}
+     * @throws IllegalStateException    Thrown if the store is closed
      */
     Map<String, ApplicationState> getApplicationStates(UUID eventId);
 
@@ -105,17 +115,24 @@ public interface DistributionLifecycleStateStore extends AutoCloseable {
      * @return Current application state, or {@code null} if this application has no known acknowledgements for this
      * event
      * @throws IllegalArgumentException Thrown if the Event ID or Application ID are {@code null} or blank
+     * @throws IllegalStateException    Thrown if the store is closed
      */
     ApplicationState getApplicationState(UUID eventId, String application);
 
     /**
      * Requests that the state store actively flushes state to underlying persistent storage (if any)
+     *
+     * @throws IllegalStateException Thrown if the store is closed
      */
     default void flush() {
     }
 
     /**
      * Closes the state store, this includes flushing state to underlying persistent storage (if any)
+     * <p>
+     * Calling this multiple times should be safe and not result in any errors.  Once this has been called all other
+     * methods <strong>MUST</strong> throw an {@link IllegalStateException} indicating the store is closed.
+     * </p>
      */
     @Override
     void close();

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/DistributionLifecycleStateStore.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/DistributionLifecycleStateStore.java
@@ -90,6 +90,7 @@ public interface DistributionLifecycleStateStore extends AutoCloseable {
      *
      * @param eventId Lifecycle Event ID
      * @return Map of applications to states, empty if not a known event
+     * @throws IllegalArgumentException Thrown if the distribution ID is {@code null} or blank
      */
     Map<String, ApplicationState> getApplicationStates(UUID eventId);
 

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/DistributionLifecycleStateStore.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/DistributionLifecycleStateStore.java
@@ -33,13 +33,26 @@ public interface DistributionLifecycleStateStore extends AutoCloseable {
      * Adds a lifecycle action to the store
      *
      * @param action Lifecycle action
+     * @throws NullPointerException  Thrown if the provided action is {@code null}
+     * @throws IllegalStateException Thrown if the state transition represented by the action is not a legal transition,
+     *                               or if the provided action has the same ID as an existing action in the state store
+     *                               and is not an exact duplicate of the existing action
      */
     void add(LifecycleAction action);
 
     /**
      * Adds a lifecycle acknowledgement to the store
+     * <p>
+     * A state store may be application scoped in which case it only tracks acknowledgements pertaining to a single
+     * application and will discard acknowledgements for any other application.
+     * </p>
      *
-     * @param ack Lifecycle acknowledgement
+     * @param application Application ID of the application that sent the acknowledgement
+     * @param ack         Lifecycle acknowledgement
+     * @throws NullPointerException     Thrown if the provided acknowledgement is {@code null}
+     * @throws IllegalArgumentException Thrown if the application ID is {@code null}/blank
+     * @throws IllegalStateException    Thrown if the acknowledgement is for an action not known to this store, or if
+     *                                  the acknowledgement represents an illegal state transition
      */
     void add(String application, LifecycleAcknowledgement ack);
 
@@ -68,6 +81,7 @@ public interface DistributionLifecycleStateStore extends AutoCloseable {
      * @param distributionId Distribution ID
      * @return Current lifecycle state, <strong>MUST</strong> return {@link DistributionLifecycleState#Unregistered} if
      * not a known Distribution ID
+     * @throws IllegalArgumentException Thrown if the distribution ID is {@code null} or blank
      */
     DistributionLifecycleState getLifecycleState(String distributionId);
 
@@ -75,24 +89,30 @@ public interface DistributionLifecycleStateStore extends AutoCloseable {
      * Gets all application states for a given lifecycle event
      *
      * @param eventId Lifecycle Event ID
-     * @return Map of applications to states
+     * @return Map of applications to states, empty if not a known event
      */
     Map<String, ApplicationState> getApplicationStates(UUID eventId);
 
     /**
      * Gets the current application state for a given applications acknowledgement of a given lifecycle event
+     * <p>
+     * A state store may be application scoped in which case it only tracks states pertaining to a single application
+     * and will return {@code null} for any other application.
+     * </p>
      *
      * @param eventId     Lifecycle Event ID
      * @param application Application ID
      * @return Current application state, or {@code null} if this application has no known acknowledgements for this
      * event
+     * @throws IllegalArgumentException Thrown if the Event ID or Application ID are {@code null} or blank
      */
     ApplicationState getApplicationState(UUID eventId, String application);
 
     /**
-     * Requests that the state store flushes state to underlying persistent storage (if any)
+     * Requests that the state store actively flushes state to underlying persistent storage (if any)
      */
-    default void flush() { }
+    default void flush() {
+    }
 
     /**
      * Closes the state store, this includes flushing state to underlying persistent storage (if any)

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/apps/AbstractAppDistributionLifecycleStore.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/apps/AbstractAppDistributionLifecycleStore.java
@@ -59,6 +59,12 @@ public abstract class AbstractAppDistributionLifecycleStore
 
     @Override
     public ApplicationState getApplicationState(UUID eventId, String application) {
+        ensureNotClosed();
+        if (eventId == null) {
+            throw new IllegalArgumentException("Event ID cannot be null");
+        } else if (StringUtils.isBlank(application)) {
+            throw new IllegalArgumentException("Application ID cannot be null/blank");
+        }
         if (!Objects.equals(this.application, application)) {
             return null;
         }
@@ -67,6 +73,10 @@ public abstract class AbstractAppDistributionLifecycleStore
 
     @Override
     public Map<String, ApplicationState> getApplicationStates(UUID eventId) {
+        ensureNotClosed();
+        if (eventId == null) {
+            throw new IllegalArgumentException("Event ID cannot be null");
+        }
         ApplicationState state = this.appStates.get(eventId);
         if (state == null) {
             return Collections.emptyMap();
@@ -77,6 +87,11 @@ public abstract class AbstractAppDistributionLifecycleStore
 
     @Override
     public void add(String application, LifecycleAcknowledgement ack) {
+        ensureNotClosed();
+        Objects.requireNonNull(ack, "Acknowledgement cannot be null");
+        if (StringUtils.isBlank(application)) {
+            throw new IllegalArgumentException("Application ID cannot be null/blank");
+        }
         if (!Objects.equals(application, this.application)) {
             // Ignore any application other than ourselves
             return;
@@ -96,6 +111,7 @@ public abstract class AbstractAppDistributionLifecycleStore
 
     @Override
     public List<LifecycleAction> activeEvents() {
+        ensureNotClosed();
         return this.events.values().stream().filter(e -> {
             ApplicationState state = this.getApplicationState(e.getEventId(), this.application);
             if (state == null) {

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/apps/AppDistributionLifecycleStoreFile.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/apps/AppDistributionLifecycleStoreFile.java
@@ -233,6 +233,7 @@ public class AppDistributionLifecycleStoreFile extends AbstractAppDistributionLi
 
     @Override
     public void close() {
+        super.close();
         this.save();
     }
 

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/apps/AppDistributionLifecycleStoreFile.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/apps/AppDistributionLifecycleStoreFile.java
@@ -157,6 +157,7 @@ public class AppDistributionLifecycleStoreFile extends AbstractAppDistributionLi
      * {@link #tryRecoverStateFile(IOException, String, boolean)} for details.
      */
     private void load() {
+        ensureNotClosed();
         LifecycleStateFile state = null;
         if (this.stateFile.exists()) {
             try {
@@ -190,6 +191,7 @@ public class AppDistributionLifecycleStoreFile extends AbstractAppDistributionLi
      * file, see {@link #tryRecoverStateFile(IOException, String, boolean)} for details.
      */
     private void save() {
+        ensureNotClosed();
         LifecycleStateFile state = LifecycleStateFile.builder()
                                                      .application(this.application)
                                                      .actions(new TrackedActions().setActions(this.events))
@@ -217,7 +219,8 @@ public class AppDistributionLifecycleStoreFile extends AbstractAppDistributionLi
                 backupStateFile.delete();
             }
 
-            LOGGER.info("Wrote distribution lifecycle state file {} (size on disk {})", this.stateFile.getAbsolutePath(),
+            LOGGER.info("Wrote distribution lifecycle state file {} (size on disk {})",
+                        this.stateFile.getAbsolutePath(),
                         FileUtils.byteCountToDisplaySize(this.stateFile.length()));
 
         } catch (IOException e) {
@@ -228,13 +231,20 @@ public class AppDistributionLifecycleStoreFile extends AbstractAppDistributionLi
 
     @Override
     public void flush() {
+        ensureNotClosed();
         this.save();
     }
 
     @Override
     public void close() {
-        super.close();
-        this.save();
+        try {
+            // Only save once on the first time of being asked to close
+            if (!this.closed) {
+                this.save();
+            }
+        } finally {
+            super.close();
+        }
     }
 
 

--- a/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/global/AbstractGlobalDistributionLifecycleStore.java
+++ b/distribution-lifecycle/src/main/java/io/telicent/smart/cache/distribution/lifecycle/store/global/AbstractGlobalDistributionLifecycleStore.java
@@ -19,6 +19,7 @@ import io.telicent.smart.cache.distribution.lifecycle.ApplicationState;
 import io.telicent.smart.cache.distribution.lifecycle.events.LifecycleAcknowledgement;
 import io.telicent.smart.cache.distribution.lifecycle.events.LifecycleAction;
 import io.telicent.smart.cache.distribution.lifecycle.store.AbstractDistributionLifecycleStore;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,16 +42,30 @@ public abstract class AbstractGlobalDistributionLifecycleStore extends AbstractD
 
     @Override
     public ApplicationState getApplicationState(UUID eventId, String application) {
+        ensureNotClosed();
+        if (StringUtils.isBlank(application)) {
+            throw new IllegalArgumentException("Application ID cannot be null/blank");
+        }
         return getApplicationStates(eventId).get(application);
     }
 
     @Override
     public Map<String, ApplicationState> getApplicationStates(UUID eventId) {
+        ensureNotClosed();
+        if (eventId == null) {
+            throw new IllegalArgumentException("Event ID cannot be null");
+        }
         return Collections.unmodifiableMap(this.appStates.getOrDefault(eventId, Collections.emptyMap()));
     }
 
     @Override
     public void add(String application, LifecycleAcknowledgement ack) {
+        ensureNotClosed();
+        Objects.requireNonNull(ack, "Acknowledgement cannot be null");
+        if (StringUtils.isBlank(application)) {
+            throw new IllegalArgumentException("Application ID cannot be null/blank");
+        }
+
         // Don't permit acknowledgements for events we aren't aware of
         if (!this.events.containsKey(ack.getEventId())) {
             throw new IllegalStateException(
@@ -66,6 +81,7 @@ public abstract class AbstractGlobalDistributionLifecycleStore extends AbstractD
 
     @Override
     public List<LifecycleAction> activeEvents() {
+        ensureNotClosed();
         return this.events.values().stream().filter(e -> {
             Map<String, ApplicationState> states = this.getApplicationStates(e.getEventId());
             if (states.isEmpty()) {

--- a/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/events/listeners/TestDistributionLifecycleStateStoreSink.java
+++ b/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/events/listeners/TestDistributionLifecycleStateStoreSink.java
@@ -34,10 +34,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.time.Duration;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -118,7 +115,7 @@ public class TestDistributionLifecycleStateStoreSink {
             // When
             sink.send(Util.event(LifecycleAction.DOCUMENT_FORMAT,
                                  action(UUID.randomUUID(), "distro", DistributionLifecycleState.Active,
-                                   DistributionLifecycleState.Withdrawn)));
+                                        DistributionLifecycleState.Withdrawn)));
 
             // Then
             verify(store, times(1)).add(any());
@@ -157,8 +154,8 @@ public class TestDistributionLifecycleStateStoreSink {
         DistributionOffsets offsets = new DistributionOffsets();
         offsets.setOffsets("distro", partitionOffsets);
         IngestStatus status = IngestStatus.builder()
-                    .offsets(offsets)
-                    .build();
+                                          .offsets(offsets)
+                                          .build();
         try (DistributionLifecycleStateStoreSink sink = DistributionLifecycleStateStoreSink.builder()
                                                                                            .executor(
                                                                                                    Executors.newSingleThreadExecutor())
@@ -186,7 +183,7 @@ public class TestDistributionLifecycleStateStoreSink {
             // When
             sink.send(Util.event(LifecycleAction.DOCUMENT_FORMAT,
                                  action(UUID.randomUUID(), "distro", DistributionLifecycleState.Active,
-                                   DistributionLifecycleState.Withdrawn)));
+                                        DistributionLifecycleState.Withdrawn)));
 
             // Then
             verify(store, times(1)).add(any());
@@ -211,13 +208,13 @@ public class TestDistributionLifecycleStateStoreSink {
             // When
             sink.send(Util.event(LifecycleAction.DOCUMENT_FORMAT,
                                  action(UUID.randomUUID(), "distro", DistributionLifecycleState.Unregistered,
-                                   DistributionLifecycleState.Registered)));
+                                        DistributionLifecycleState.Registered)));
             sink.send(Util.event(LifecycleAction.DOCUMENT_FORMAT,
                                  action(UUID.randomUUID(), "distro", DistributionLifecycleState.Unregistered,
-                                   DistributionLifecycleState.Registered)));
+                                        DistributionLifecycleState.Registered)));
             sink.send(Util.event(LifecycleAction.DOCUMENT_FORMAT,
                                  action(UUID.randomUUID(), "distro", DistributionLifecycleState.Registered,
-                                   DistributionLifecycleState.Active)));
+                                        DistributionLifecycleState.Active)));
 
             // Then
             Assert.assertEquals(store.getLifecycleState("distro"), DistributionLifecycleState.Active);
@@ -246,7 +243,7 @@ public class TestDistributionLifecycleStateStoreSink {
             // When
             sink.send(Util.event(LifecycleAction.DOCUMENT_FORMAT,
                                  action(UUID.randomUUID(), "distro", DistributionLifecycleState.Unregistered,
-                                   DistributionLifecycleState.Registered)));
+                                        DistributionLifecycleState.Registered)));
 
             // Then
             Assert.assertEquals(store.getLifecycleState("distro"), DistributionLifecycleState.Registered);
@@ -273,13 +270,64 @@ public class TestDistributionLifecycleStateStoreSink {
             // When
             sink.send(Util.event(LifecycleAction.DOCUMENT_FORMAT,
                                  action(UUID.randomUUID(), "distro", DistributionLifecycleState.Unregistered,
-                                   DistributionLifecycleState.Registered)));
+                                        DistributionLifecycleState.Registered)));
 
             // Then
             Assert.assertEquals(store.getLifecycleState("distro"), DistributionLifecycleState.Registered);
             Assert.assertFalse(store.activeEvents().isEmpty());
             verify(executor, times(1)).submit(any(Runnable.class));
             verifyNoInteractions(listener);
+        }
+    }
+
+    @Test
+    public void givenStateStoreSinkWithNullListener_whenLifecycleActionEvents_thenListenerIgnored() throws
+            InterruptedException {
+        // Given
+        DistributionLifecycleStateStore store = new GlobalDistributionLifecycleStoreMemory();
+        DistributionLifecycleListener listener = mock(DistributionLifecycleListener.class);
+        List<DistributionLifecycleListener> listeners = new ArrayList<>();
+        listeners.add(listener);
+        listeners.add(null);
+        try (DistributionLifecycleStateStoreSink sink = DistributionLifecycleStateStoreSink.builder()
+                                                                                           .executor(
+                                                                                                   Executors.newSingleThreadExecutor())
+                                                                                           .stateStore(store)
+                                                                                           .listeners(listeners)
+                                                                                           .build()) {
+            // When
+            sink.send(Util.event(LifecycleAction.DOCUMENT_FORMAT,
+                                 action(UUID.randomUUID(), "distro", DistributionLifecycleState.Unregistered,
+                                        DistributionLifecycleState.Registered)));
+
+            // Then
+            Assert.assertEquals(store.getLifecycleState("distro"), DistributionLifecycleState.Registered);
+            Assert.assertFalse(store.activeEvents().isEmpty());
+
+            // And
+            // NB - Because listeners are fired on a background thread pool wait briefly to allow them time to execute
+            Thread.sleep(250);
+            verify(listener, times(1)).accept(any());
+        }
+    }
+
+    @Test
+    public void givenStateStoreSinkWithFailOnCloseListener_whenClosed_thenErrorSuppressed() {
+        // Given
+        DistributionLifecycleStateStore store = new GlobalDistributionLifecycleStoreMemory();
+        DistributionLifecycleListener listener = mock(DistributionLifecycleListener.class);
+        doThrow(new RuntimeException("Failed to close")).when(listener).close();
+        try (DistributionLifecycleStateStoreSink sink = DistributionLifecycleStateStoreSink.builder()
+                                                                                           .executor(
+                                                                                                   Executors.newSingleThreadExecutor())
+                                                                                           .stateStore(store)
+                                                                                           .listeners(List.of(listener))
+                                                                                           .build()) {
+            // When
+            sink.close();
+
+            // Then
+            verify(listener, times(1)).close();
         }
     }
 }

--- a/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/AbstractDistributionLifecycleStoreTests.java
+++ b/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/AbstractDistributionLifecycleStoreTests.java
@@ -72,7 +72,7 @@ public abstract class AbstractDistributionLifecycleStoreTests {
             store.add(appId, acknowledgement);
             // NB - If the store being tested is application scoped then it should only update app state for the
             //      configured test application, otherwise it should ignore the state updates
-            if (!this.isApplicationScoped() || (this.isApplicationScoped() && Objects.equals(appId, APP_ID))) {
+            if (!this.isApplicationScoped() || Objects.equals(appId, APP_ID)) {
                 Assert.assertEquals(store.getApplicationState(eventId, appId), state);
 
                 if (state != ApplicationState.Completed) {

--- a/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/AbstractDistributionLifecycleStoreTests.java
+++ b/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/AbstractDistributionLifecycleStoreTests.java
@@ -1,0 +1,517 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.distribution.lifecycle.store;
+
+import io.telicent.smart.cache.distribution.lifecycle.ApplicationState;
+import io.telicent.smart.cache.distribution.lifecycle.DistributionLifecycleState;
+import io.telicent.smart.cache.distribution.lifecycle.Util;
+import io.telicent.smart.cache.distribution.lifecycle.events.LifecycleAcknowledgement;
+import io.telicent.smart.cache.distribution.lifecycle.events.LifecycleAction;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * Abstract test suite for {@link DistributionLifecycleStateStore} implementations.
+ * <p>
+ * To test your implementation you <strong>MUST</strong> implement the {@link #newStore()} and {@link #reopenStore()}
+ * methods following the contract defined on that method Javadoc.  Test classes should also override the
+ * {@link #isPersistent()} and {@link #isApplicationScoped()} methods as appropriate since those control whether some
+ * tests are run/skipped.
+ * </p>
+ */
+public abstract class AbstractDistributionLifecycleStoreTests {
+    /**
+     * The default distribution ID used in many tests
+     */
+    public static final String DISTRIBUTION_ID = "distro";
+    /**
+     * The default application ID used in many tests
+     */
+    public static final String APP_ID = "test";
+
+    private static void verifyActiveEvents(DistributionLifecycleStateStore store) {
+        Assert.assertFalse(store.activeEvents().isEmpty());
+    }
+
+    private void transition(DistributionLifecycleStateStore store, String distroId,
+                            DistributionLifecycleState... states) {
+        DistributionLifecycleState last = store.getLifecycleState(distroId);
+        for (DistributionLifecycleState state : states) {
+            LifecycleAction action = Util.action(UUID.randomUUID(), distroId, last, state);
+            store.add(action);
+            last = state;
+            Assert.assertEquals(store.getLifecycleState(distroId), state);
+        }
+    }
+
+    private void acknowledge(DistributionLifecycleStateStore store, UUID eventId, String appId, String distroId,
+                             ApplicationState... states) {
+        Assert.assertNull(store.getApplicationState(eventId, appId));
+        for (ApplicationState state : states) {
+            LifecycleAcknowledgement acknowledgement = Util.ack(eventId, distroId, state);
+            store.add(appId, acknowledgement);
+            // NB - If the store being tested is application scoped then it should only update app state for the
+            //      configured test application, otherwise it should ignore the state updates
+            if (!this.isApplicationScoped() || (this.isApplicationScoped() && Objects.equals(appId, APP_ID))) {
+                Assert.assertEquals(store.getApplicationState(eventId, appId), state);
+
+                if (state != ApplicationState.Completed) {
+                    AbstractDistributionLifecycleStoreTests.verifyActiveEvents(store);
+                } else {
+                    Assert.assertTrue(store.activeEvents().isEmpty());
+                }
+            } else {
+                Assert.assertNull(store.getApplicationState(eventId, appId));
+            }
+        }
+    }
+
+    /**
+     * Creates a fresh new empty instance of a state store for testing, if the store is application scoped (see
+     * {@link #isApplicationScoped()}), then <strong>MUST</strong> be scoped to the application ID {@value #APP_ID}
+     *
+     * @return Fresh store instance scoped to the test application ID if appropriate
+     */
+    public abstract DistributionLifecycleStateStore newStore();
+
+    /**
+     * Reopens the store returned by the most recent invocation of {@link #newStore()}, if the store is application
+     * scoped (see * {@link #isApplicationScoped()}), then <strong>MUST</strong> be scoped to the application ID
+     * {@value #APP_ID}
+     * <p>
+     * If the store under test is not persistent, as indicated by {@link #isPersistent()}, then this method will not be
+     * called and tests that use it will be skipped.
+     * </p>
+     *
+     * @return Reopened store instance scoped to the test application ID if appropriate
+     */
+    public abstract DistributionLifecycleStateStore reopenStore();
+
+    /**
+     * Indicates whether the store implementation under test is persistent, if {@code false} then any test that would
+     * use {@link #reopenStore()} will be skipped for the implementation.
+     *
+     * @return True if a persistent state store, false otherwise
+     */
+    public boolean isPersistent() {
+        return true;
+    }
+
+    /**
+     * Indicates whether the implementation under test is application scoped, i.e. tracks application state for only a
+     * single application.  When {@code true} then some tests that try to track multiple application states will be
+     * skipped.
+     *
+     * @return True if application scoped store, false otherwise
+     */
+    public abstract boolean isApplicationScoped();
+
+    @Test
+    public void givenFreshStore_whenInspecting_thenEmpty() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            Assert.assertTrue(store.activeEvents().isEmpty());
+            Assert.assertTrue(store.getLifecycleStates().isEmpty());
+            Assert.assertTrue(store.getApplicationStates(UUID.randomUUID()).isEmpty());
+            Assert.assertNull(store.getApplicationState(UUID.randomUUID(), APP_ID));
+            Assert.assertEquals(store.getLifecycleState(DISTRIBUTION_ID), DistributionLifecycleState.Unregistered);
+        }
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void givenNullAction_whenAddingToStore_thenNPE() {
+        // Given
+        LifecycleAction action = null;
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.add(action);
+        }
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void givenNullAcknowledgement_whenAddingToStore_thenNPE() {
+        // Given
+        LifecycleAcknowledgement acknowledgement = null;
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.add(APP_ID, acknowledgement);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void givenNullDistributionId_whenCheckingState_thenIllegalArgument() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.getLifecycleState(null);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void givenEmptyDistributionId_whenCheckingState_thenIllegalArgument() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.getLifecycleState("");
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void givenBlankDistributionId_whenCheckingState_thenIllegalArgument() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.getLifecycleState("   ");
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void givenNullEventId_whenCheckingAppState_thenIllegalArgument() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.getApplicationState(null, APP_ID);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void givenNullAppId_whenCheckingAppState_thenIllegalArgument() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.getApplicationState(UUID.randomUUID(), null);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void givenEmptyAppId_whenCheckingAppState_thenIllegalArgument() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.getApplicationState(UUID.randomUUID(), "");
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void givenBlankAppId_whenCheckingAppState_thenIllegalArgument() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.getApplicationState(UUID.randomUUID(), "   ");
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void givenNullEventId_whenCheckingAppStates_thenIllegalArgument() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.getApplicationStates(null);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void givenAcknowledgementAndNullAppId_whenAddingToStore_thenIllegalArgument() {
+        // Given
+        UUID eventId = UUID.randomUUID();
+        LifecycleAction action = Util.action(eventId, DISTRIBUTION_ID, DistributionLifecycleState.Unregistered,
+                                             DistributionLifecycleState.Registered);
+        LifecycleAcknowledgement acknowledgement = Util.ack(eventId, DISTRIBUTION_ID, ApplicationState.Requested);
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.add(action);
+            store.add(null, acknowledgement);
+        }
+    }
+
+    @Test
+    public void givenAction_whenAddingToStore_thenUpdated() {
+        // Given
+        LifecycleAction action =
+                Util.action(UUID.randomUUID(), DISTRIBUTION_ID, DistributionLifecycleState.Unregistered,
+                            DistributionLifecycleState.Registered);
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When
+            store.add(action);
+
+            // Then
+            Assert.assertEquals(store.getLifecycleState(DISTRIBUTION_ID), DistributionLifecycleState.Registered);
+            AbstractDistributionLifecycleStoreTests.verifyActiveEvents(store);
+        }
+    }
+
+    private void requirePersistentStore() {
+        if (!this.isPersistent()) {
+            throw new SkipException("Test requires a persistent store");
+        }
+    }
+
+    @Test
+    public void givenPersistentStore_whenAddingAction_thenPersistCloseAndReopen() {
+        // Given
+        requirePersistentStore();
+
+        // When
+        givenAction_whenAddingToStore_thenUpdated();
+
+        // Then
+        try (DistributionLifecycleStateStore store = reopenStore()) {
+            Assert.assertEquals(store.getLifecycleState(DISTRIBUTION_ID), DistributionLifecycleState.Registered);
+            AbstractDistributionLifecycleStoreTests.verifyActiveEvents(store);
+        }
+    }
+
+    @Test
+    public void givenMultipleActions_whenAddingToStore_thenDistributionsInExpectedStates() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When
+            transition(store, DISTRIBUTION_ID, DistributionLifecycleState.Registered,
+                       DistributionLifecycleState.Active);
+            transition(store, "withdrawn", DistributionLifecycleState.Registered, DistributionLifecycleState.Active,
+                       DistributionLifecycleState.Withdrawn);
+            transition(store, "deleted", DistributionLifecycleState.Registered, DistributionLifecycleState.Deleted);
+
+            // Then
+            Map<String, DistributionLifecycleState> states = store.getLifecycleStates();
+            Assert.assertEquals(states.get(DISTRIBUTION_ID), DistributionLifecycleState.Active);
+            Assert.assertEquals(states.get("withdrawn"), DistributionLifecycleState.Withdrawn);
+            Assert.assertEquals(states.get("deleted"), DistributionLifecycleState.Deleted);
+        }
+    }
+
+    @Test
+    public void givenPersistentStore_whenAddingMultipleActions_thenPersistCloseAndReopen() {
+        // Given
+        requirePersistentStore();
+
+        // When
+        givenMultipleActions_whenAddingToStore_thenDistributionsInExpectedStates();
+
+        // Then
+        try (DistributionLifecycleStateStore store = reopenStore()) {
+            Map<String, DistributionLifecycleState> states = store.getLifecycleStates();
+            Assert.assertEquals(states.get(DISTRIBUTION_ID), DistributionLifecycleState.Active);
+            Assert.assertEquals(states.get("withdrawn"), DistributionLifecycleState.Withdrawn);
+            Assert.assertEquals(states.get("deleted"), DistributionLifecycleState.Deleted);
+        }
+    }
+
+    @Test
+    public void givenActionsForRepeatedTransition_whenAddingToStore_thenStateConsistent() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When
+            transition(store, DISTRIBUTION_ID, DistributionLifecycleState.Registered, DistributionLifecycleState.Active,
+                       DistributionLifecycleState.Active);
+
+            // Then
+            Assert.assertEquals(store.getLifecycleState(DISTRIBUTION_ID), DistributionLifecycleState.Active);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void givenActionsForIllegalTransition_whenAddingToStore_thenIllegalState() {
+        // Given
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            transition(store, DISTRIBUTION_ID, DistributionLifecycleState.Registered, DistributionLifecycleState.Active,
+                       DistributionLifecycleState.Deleted, DistributionLifecycleState.Active);
+        }
+    }
+
+    @Test
+    public void givenAction_whenAcknowledging_thenAppStateUpdated() {
+        // Given
+        UUID eventId = UUID.randomUUID();
+        LifecycleAction action = Util.action(eventId, DISTRIBUTION_ID, DistributionLifecycleState.Unregistered,
+                                             DistributionLifecycleState.Registered);
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.add(action);
+            Assert.assertNull(store.getApplicationState(eventId, APP_ID));
+            AbstractDistributionLifecycleStoreTests.verifyActiveEvents(store);
+            acknowledge(store, eventId, APP_ID, DISTRIBUTION_ID, ApplicationState.Requested,
+                        ApplicationState.InProgress, ApplicationState.Completed);
+        }
+    }
+
+    @Test
+    public void givenAction_whenAcknowledgingWithSameState_thenAppStateConsistent() {
+        // Given
+        UUID eventId = UUID.randomUUID();
+        LifecycleAction action = Util.action(eventId, DISTRIBUTION_ID, DistributionLifecycleState.Unregistered,
+                                             DistributionLifecycleState.Registered);
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.add(action);
+            Assert.assertNull(store.getApplicationState(eventId, APP_ID));
+            AbstractDistributionLifecycleStoreTests.verifyActiveEvents(store);
+            acknowledge(store, eventId, APP_ID, DISTRIBUTION_ID, ApplicationState.Requested,
+                        ApplicationState.Requested);
+        }
+    }
+
+    @Test
+    public void givenAction_whenAcknowledgingForMultipleApps_thenAppStatesUpdatedIndependently() {
+        requireNonApplicationScopedStore();
+
+        // Given
+        UUID eventId = UUID.randomUUID();
+        LifecycleAction action = Util.action(eventId, DISTRIBUTION_ID, DistributionLifecycleState.Unregistered,
+                                             DistributionLifecycleState.Registered);
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When
+            store.add(action);
+            AbstractDistributionLifecycleStoreTests.verifyActiveEvents(store);
+            acknowledge(store, eventId, APP_ID, DISTRIBUTION_ID, ApplicationState.Requested,
+                        ApplicationState.InProgress, ApplicationState.Completed);
+            acknowledge(store, eventId, "other", DISTRIBUTION_ID, ApplicationState.Requested,
+                        ApplicationState.InProgress, ApplicationState.Failed);
+            acknowledge(store, eventId, "another", DISTRIBUTION_ID, ApplicationState.Requested);
+
+            // Then
+            Map<String, ApplicationState> appStates = store.getApplicationStates(eventId);
+            Assert.assertEquals(appStates.get(APP_ID), ApplicationState.Completed);
+            Assert.assertEquals(appStates.get("other"), ApplicationState.Failed);
+            Assert.assertEquals(appStates.get("another"), ApplicationState.Requested);
+        }
+    }
+
+    private void requireNonApplicationScopedStore() {
+        if (this.isApplicationScoped()) {
+            throw new SkipException("Test only applicable to global state stores");
+        }
+    }
+
+    @Test
+    public void givenAppScopedStore_whenActionAcknowledgedForMultipleApps_thenOnlyAppScopeStateUpdated() {
+        requireApplicationScopedStore();
+
+        // Given
+        UUID eventId = UUID.randomUUID();
+        LifecycleAction action = Util.action(eventId, DISTRIBUTION_ID, DistributionLifecycleState.Unregistered,
+                                             DistributionLifecycleState.Registered);
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When
+            store.add(action);
+            AbstractDistributionLifecycleStoreTests.verifyActiveEvents(store);
+            acknowledge(store, eventId, APP_ID, DISTRIBUTION_ID, ApplicationState.Requested,
+                        ApplicationState.InProgress, ApplicationState.Completed);
+            acknowledge(store, eventId, "other", DISTRIBUTION_ID, ApplicationState.Requested,
+                        ApplicationState.InProgress, ApplicationState.Failed);
+            acknowledge(store, eventId, "another", DISTRIBUTION_ID, ApplicationState.Requested);
+
+            // Then
+            Map<String, ApplicationState> appStates = store.getApplicationStates(eventId);
+            Assert.assertEquals(appStates.get(APP_ID), ApplicationState.Completed);
+            Assert.assertNull(appStates.get("other"));
+            Assert.assertNull(appStates.get("another"));
+        }
+    }
+
+    private void requireApplicationScopedStore() {
+        if (!this.isApplicationScoped()) {
+            throw new SkipException("Test only applicable to application scoped state stores");
+        }
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void givenActionWithReusedId_whenAddingToStore_thenIllegalState() {
+        // Given
+        UUID eventId = UUID.randomUUID();
+        LifecycleAction action = Util.action(eventId, DISTRIBUTION_ID, DistributionLifecycleState.Unregistered,
+                                             DistributionLifecycleState.Registered);
+        LifecycleAction reusedId = Util.action(eventId, DISTRIBUTION_ID, DistributionLifecycleState.Registered,
+                                               DistributionLifecycleState.Active);
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When
+            store.add(action);
+
+            // Then
+            store.add(reusedId);
+        }
+    }
+
+    @Test
+    public void givenAction_whenAddingToStoreMoreThanOnce_thenOk() {
+        // Given
+        UUID eventId = UUID.randomUUID();
+        LifecycleAction action = Util.action(eventId, DISTRIBUTION_ID, DistributionLifecycleState.Unregistered,
+                                             DistributionLifecycleState.Registered);
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When
+            store.add(action);
+            store.add(action);
+
+            // Then
+            Assert.assertEquals(store.getLifecycleState(DISTRIBUTION_ID), DistributionLifecycleState.Registered);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void givenAcknowledgementForUnknownEvent_whenAddingToStore_thenIllegalState() {
+        // Given
+        LifecycleAcknowledgement acknowledgement =
+                Util.ack(UUID.randomUUID(), DISTRIBUTION_ID, ApplicationState.Requested);
+        try (DistributionLifecycleStateStore store = newStore()) {
+            // When and Then
+            store.add(APP_ID, acknowledgement);
+        }
+    }
+
+    private static Consumer<DistributionLifecycleStateStore> consumer(Consumer<DistributionLifecycleStateStore> c) {
+        return c;
+    }
+
+    @DataProvider(name = "interactions")
+    public static Object[][] interactions() {
+        return new Object[][] {
+                { consumer(DistributionLifecycleStateStore::activeEvents) },
+                { consumer(DistributionLifecycleStateStore::getLifecycleStates) },
+                { consumer(s -> s.getLifecycleState(DISTRIBUTION_ID)) },
+                { consumer(s -> s.getApplicationState(UUID.randomUUID(), APP_ID)) },
+                { consumer(s -> s.getApplicationStates(UUID.randomUUID())) },
+                {
+                        consumer(s -> s.add(
+                                Util.action(UUID.randomUUID(), DISTRIBUTION_ID, DistributionLifecycleState.Unregistered,
+                                            DistributionLifecycleState.Registered)))
+                },
+                {
+                        consumer(s -> s.add(APP_ID,
+                                            Util.ack(UUID.randomUUID(), DISTRIBUTION_ID, ApplicationState.Requested)))
+                }
+        };
+    }
+
+    @Test(dataProvider = "interactions", dataProviderClass = AbstractDistributionLifecycleStoreTests.class, expectedExceptions = IllegalStateException.class)
+    public void givenClosedStore_whenInteracting_thenIllegalState(Consumer<DistributionLifecycleStateStore> consumer) {
+        // Given
+        DistributionLifecycleStateStore store = newStore();
+        store.close();
+
+        // When and Then
+        consumer.accept(store);
+    }
+}

--- a/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/AbstractDistributionLifecycleStoreTests.java
+++ b/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/AbstractDistributionLifecycleStoreTests.java
@@ -118,6 +118,17 @@ public abstract class AbstractDistributionLifecycleStoreTests {
     }
 
     /**
+     * Indicates whether the store implementation is immediately persistent i.e. are changes in the store immediately
+     * persisted to underlying storage, or is an explicit {@link DistributionLifecycleStateStore#flush()} required to
+     * persist the store state.
+     *
+     * @return True if immediately persistent store, false otherwise
+     */
+    public boolean isImmediatelyPersistent() {
+        return false;
+    }
+
+    /**
      * Indicates whether the implementation under test is application scoped, i.e. tracks application state for only a
      * single application.  When {@code true} then some tests that try to track multiple application states will be
      * skipped.
@@ -501,7 +512,8 @@ public abstract class AbstractDistributionLifecycleStoreTests {
                 {
                         consumer(s -> s.add(APP_ID,
                                             Util.ack(UUID.randomUUID(), DISTRIBUTION_ID, ApplicationState.Requested)))
-                }
+                },
+                { consumer(DistributionLifecycleStateStore::flush) }
         };
     }
 
@@ -513,5 +525,78 @@ public abstract class AbstractDistributionLifecycleStoreTests {
 
         // When and Then
         consumer.accept(store);
+    }
+
+    @Test
+    public void givenClosedStored_whenClosingAgain_thenOk() {
+        // Given
+        DistributionLifecycleStateStore store = newStore();
+        store.close();
+
+        // When and Then
+        store.close();
+    }
+
+    private void requireImmediatePersistence() {
+        requirePersistentStore();
+        if (!this.isImmediatelyPersistent()) {
+            throw new SkipException("This test requires a persistent store with immediate persistence");
+        }
+    }
+
+    private void requireNonImmediatePersistence() {
+        requirePersistentStore();
+        if (this.isImmediatelyPersistent()) {
+            throw new SkipException("This test requires a persistent store without immediate persistence");
+        }
+    }
+
+    @Test
+    public void givenTwoInstancesOfImmediatelyPersistentStore_whenInteractingWithOne_thenStateUpdatedInOther() {
+        requireImmediatePersistence();
+
+        // Given
+        LifecycleAction action =
+                Util.action(UUID.randomUUID(), DISTRIBUTION_ID, DistributionLifecycleState.Unregistered,
+                            DistributionLifecycleState.Registered);
+        try (DistributionLifecycleStateStore store = newStore()) {
+            try (DistributionLifecycleStateStore otherStore = reopenStore()) {
+                // When
+                store.add(action);
+
+                // Then
+                Assert.assertEquals(store.getLifecycleState(DISTRIBUTION_ID), DistributionLifecycleState.Registered);
+                Assert.assertEquals(otherStore.getLifecycleState(DISTRIBUTION_ID),
+                                    DistributionLifecycleState.Registered);
+            }
+        }
+    }
+
+    @Test
+    public void givenTwoInstancesOfNonImmediatelyPersistentStore_whenInteractingWithOne_thenStateNotAffectedInOther_andFlushUpdatesPersistentState() {
+        requireNonImmediatePersistence();
+
+        // Given
+        LifecycleAction action =
+                Util.action(UUID.randomUUID(), DISTRIBUTION_ID, DistributionLifecycleState.Unregistered,
+                            DistributionLifecycleState.Registered);
+        try (DistributionLifecycleStateStore store = newStore()) {
+            try (DistributionLifecycleStateStore otherStore = reopenStore()) {
+                // When
+                store.add(action);
+
+                // Then
+                Assert.assertEquals(store.getLifecycleState(DISTRIBUTION_ID), DistributionLifecycleState.Registered);
+                Assert.assertEquals(otherStore.getLifecycleState(DISTRIBUTION_ID),
+                                    DistributionLifecycleState.Unregistered);
+
+                // And
+                store.flush();
+                try (DistributionLifecycleStateStore thirdStore = reopenStore()) {
+                    Assert.assertEquals(thirdStore.getLifecycleState(DISTRIBUTION_ID),
+                                        DistributionLifecycleState.Registered);
+                }
+            }
+        }
     }
 }

--- a/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/apps/TestAppDistributionLifecycleStoreFileContract.java
+++ b/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/apps/TestAppDistributionLifecycleStoreFileContract.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.distribution.lifecycle.store.apps;
+
+import io.telicent.smart.cache.distribution.lifecycle.store.AbstractDistributionLifecycleStoreTests;
+import io.telicent.smart.cache.distribution.lifecycle.store.DistributionLifecycleStateStore;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+public class TestAppDistributionLifecycleStoreFileContract extends AbstractDistributionLifecycleStoreTests {
+
+    private File stateFile;
+
+    @BeforeMethod
+    public void setup() throws IOException {
+        this.stateFile = Files.createTempFile("app-distro-state", ".json").toFile();
+        Assert.assertTrue(this.stateFile.delete());
+    }
+
+    @Override
+    public DistributionLifecycleStateStore newStore() {
+        return new AppDistributionLifecycleStoreFile(APP_ID, this.stateFile);
+    }
+
+    @Override
+    public DistributionLifecycleStateStore reopenStore() {
+        return newStore();
+    }
+
+    @Override
+    public boolean isApplicationScoped() {
+        return true;
+    }
+}

--- a/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/global/GlobalDistributionLifecycleStoreMemory.java
+++ b/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/global/GlobalDistributionLifecycleStoreMemory.java
@@ -21,7 +21,7 @@ package io.telicent.smart.cache.distribution.lifecycle.store.global;
  */
 public class GlobalDistributionLifecycleStoreMemory extends AbstractGlobalDistributionLifecycleStore {
     @Override
-    public void close() {
-        super.close();
+    public void flush() {
+        ensureNotClosed();
     }
 }

--- a/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/global/GlobalDistributionLifecycleStoreMemory.java
+++ b/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/global/GlobalDistributionLifecycleStoreMemory.java
@@ -22,6 +22,6 @@ package io.telicent.smart.cache.distribution.lifecycle.store.global;
 public class GlobalDistributionLifecycleStoreMemory extends AbstractGlobalDistributionLifecycleStore {
     @Override
     public void close() {
-        // No-op
+        super.close();
     }
 }

--- a/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/global/TestGlobalDistributionLifecycleStoreContract.java
+++ b/distribution-lifecycle/src/test/java/io/telicent/smart/cache/distribution/lifecycle/store/global/TestGlobalDistributionLifecycleStoreContract.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.distribution.lifecycle.store.global;
+
+import io.telicent.smart.cache.distribution.lifecycle.store.AbstractDistributionLifecycleStoreTests;
+import io.telicent.smart.cache.distribution.lifecycle.store.DistributionLifecycleStateStore;
+
+public class TestGlobalDistributionLifecycleStoreContract extends AbstractDistributionLifecycleStoreTests {
+    @Override
+    public DistributionLifecycleStateStore newStore() {
+        return new GlobalDistributionLifecycleStoreMemory();
+    }
+
+    @Override
+    public DistributionLifecycleStateStore reopenStore() {
+        throw new IllegalStateException("Non-persistent store cannot be reopened");
+    }
+
+    @Override
+    public boolean isApplicationScoped() {
+        return false;
+    }
+
+    @Override
+    public boolean isPersistent() {
+        return false;
+    }
+}


### PR DESCRIPTION
Adds a proper abstract contract test suite for
`DistributionLifecycleStateStore` implementation that validates all aspects of behaviour including bad inputs, application-scope, persistence etc.

Also makes model classes Serializable so they can work with JPA