### PR TITLE
[LAB-49] Adding optional, self-contained provenance records and helpers (with no behavioural changes).

### DIFF
--- a/docs/provenance/index.md
+++ b/docs/provenance/index.md
@@ -1,0 +1,159 @@
+# Provenance Capture - SPIKE
+
+The platform's events carry provenance/audit headers (see [Kafka headers](../event-sources/kafka.md) and
+`TelicentHeaders`) describing how a message reached a Smart Cache: `Request-ID`, `Input-Request-ID`, `Exec-Path`,
+`Distribution-Id` and `Security-Label`. These are normally consumed and discarded during ingest. Provenance capture
+records them **as data**, so that "where did this come from, when, via which path, under which label?" becomes a
+queryable question rather than something lost in the logs.
+
+This module provides the shared, dependency-free building blocks; the RDF-aware components (the
+[Fuseki-Kafka connector](#in-the-knowledge-graph) and the [catalogue updater](#in-the-catalogue)) turn them into
+PROV-O / DCAT triples.
+
+## Building blocks
+
+- **`ProvenanceRecord`** — an immutable snapshot of the provenance headers on an `Event`, plus an ingest timestamp.
+  It has no RDF dependency.
+
+  ```java
+  ProvenanceRecord prov = ProvenanceRecord.fromEvent(event);
+  prov.distributionId();   // "dist-1"
+  prov.execPathSteps();    // ["adapter", "mapper", "projector"]
+  prov.hasProvenance();    // true if any provenance header was present
+  ```
+
+- **`ProvenanceVocabulary`** — the shared PROV-O / DCAT term IRIs (as plain strings) and IRI-minting helpers, so every
+  component emits the same vocabulary. The model follows W3C PROV-O aligned with DCAT 3.
+
+## Enabling it
+
+Provenance capture is **opt-in** and disabled by default. Enable it with either:
+
+- Environment variable: `TELICENT_PROVENANCE_CAPTURE=true`
+- System property (takes precedence): `-Dtelicent.provenance.capture=true`
+
+The same switch governs both the Fuseki-Kafka connector and the catalogue updater, so a single setting turns provenance
+on across the platform. When disabled, behaviour and output are unchanged.
+
+## What it looks like
+
+### In the knowledge graph
+
+Suppose a `knowledge` topic event arrives with these headers:
+
+| Header | Value |
+|--------|-------|
+| `Distribution-Id` | `dist-1` |
+| `Request-ID` | `req-1` |
+| `Input-Request-ID` | `in-0` |
+| `Exec-Path` | `adapter,mapper` |
+| `Security-Label` | `clearance=secret` |
+
+With capture enabled, the data is applied as normal and, **in the same transaction**, a provenance record is written
+into the per-distribution provenance named graph `<http://telicent.io/provenance/dist-1>`:
+
+```turtle
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix tprov:   <http://telicent.io/provenance#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+# graph <http://telicent.io/provenance/dist-1>
+
+<http://telicent.io/provenance#activity/req-1>
+    a                     prov:Activity ;
+    prov:generatedAtTime  "2026-06-12T10:00:00Z"^^xsd:dateTime ;
+    prov:used             <http://telicent.io/provenance#distribution/dist-1> ;
+    tprov:requestId       "req-1" ;
+    tprov:inputRequestId  "in-0" ;
+    tprov:execPath        "adapter,mapper" ;
+    tprov:securityLabel   "clearance=secret" .
+
+<http://telicent.io/provenance#distribution/dist-1>
+    a                     dcat:Distribution ;
+    dcterms:identifier    "dist-1" .
+```
+
+The ingested data itself stays in its normal graph(s); provenance lives in its own named graph, so existing queries are
+unaffected unless they explicitly ask for it.
+
+### In the catalogue
+
+When the catalogue updater sees a `Distribution-Id` plus a `Data-Source-Reference` header (e.g.
+`kafka://ingest/source-A`) and capture is enabled, the catalogue entry is enriched so a user can trace the distribution
+back to its source:
+
+```turtle
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+@prefix tcat:    <http://telicent.io/catalog/Distribution#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+tcat:dist-1
+    rdf:type            dcat:Distribution, prov:Entity ;
+    dcterms:available   "2026-06-12T10:00:00Z"^^xsd:dateTime ;
+    dcterms:source      "kafka://ingest/source-A" ;
+    dcat:accessService  _:src_dist_1 ;
+    prov:wasDerivedFrom _:src_dist_1 .
+
+_:src_dist_1
+    rdf:type            dcat:DataService ;
+    dcterms:identifier  "kafka://ingest/source-A" .
+```
+
+With capture disabled (the default), or when no `Data-Source-Reference` is present, the catalogue output is exactly the
+legacy form (`dcat:Distribution` + `dcterms:available` only).
+
+## Querying it
+
+Get everything recorded for one distribution:
+
+```sparql
+SELECT ?p ?o
+WHERE { GRAPH <http://telicent.io/provenance/dist-1> { ?s ?p ?o } }
+```
+
+When, and via which pipeline, was a distribution's data ingested?
+
+```sparql
+PREFIX prov:  <http://www.w3.org/ns/prov#>
+PREFIX tprov: <http://telicent.io/provenance#>
+
+SELECT ?ingestedAt ?execPath
+WHERE {
+    GRAPH ?g {
+        ?activity a prov:Activity ;
+                  prov:generatedAtTime ?ingestedAt ;
+                  prov:used <http://telicent.io/provenance#distribution/dist-1> .
+        OPTIONAL { ?activity tprov:execPath ?execPath }
+    }
+}
+```
+
+What was ingested after a given time, across all distributions?
+
+```sparql
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?g ?activity ?ingestedAt
+WHERE {
+    GRAPH ?g { ?activity a prov:Activity ; prov:generatedAtTime ?ingestedAt }
+    FILTER (?ingestedAt > "2026-06-01T00:00:00Z"^^xsd:dateTime)
+}
+```
+
+## Notes and caveats
+
+- **Best-effort.** A failure to record provenance is logged and swallowed — it never fails or rolls back the ingest of
+  the actual data.
+- **Union default graph.** If a dataset is configured with `tdb2:unionDefaultGraph true`, the contents of all named
+  graphs (including provenance) appear in the default-graph view, so an unscoped query will also see provenance. Where
+  strict separation matters, exclude the provenance graph from the union or always query named graphs explicitly.
+- **Security labelling.** Provenance triples are currently written without an explicit ABAC label, so their visibility
+  follows the dataset default. A deliberate policy (e.g. label the provenance graph for auditors) is the recommended
+  next step.
+- **`Exec-Path` delimiter.** `ProvenanceRecord.execPathSteps()` assumes a comma delimiter; confirm against the canonical
+  `telicent-lib` provenance format before relying on it.

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/provenance/ProvenanceRecord.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/provenance/ProvenanceRecord.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.provenance;
+
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.TelicentHeaders;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * An immutable, dependency-free snapshot of the provenance/audit information carried by an {@link Event} as it is
+ * ingested into the platform.
+ * <p>
+ * The platform's Kafka messages carry a number of provenance & audit headers (see {@link TelicentHeaders}) describing how
+ * a message has flowed through the system. These headers are normally consumed and then discarded during ingest, which
+ * means the provenance cannot be queried after the fact. This record captures those values at the point of ingest so
+ * that downstream, RDF-aware components (for example the Fuseki-Kafka connector or the catalogue updater) can persist
+ * them as PROV-O / DCAT triples alongside the data they describe.
+ * </p>
+ * <p>
+ * This type intentionally has <strong>no RDF dependency</strong>. It simply holds the captured header values plus the
+ * ingest timestamp. Conversion into RDF is the responsibility of the RDF-aware modules, which can use
+ * {@link ProvenanceVocabulary} for a consistent vocabulary. Any field may be {@code null} if the corresponding header
+ * was absent — provenance headers are optional in the platform.
+ * </p>
+ *
+ * @param requestId      Value of the {@link TelicentHeaders#REQUEST_ID} header — uniquely identifies the request that
+ *                       produced this message. May be {@code null}.
+ * @param inputRequestId Value of the {@link TelicentHeaders#INPUT_REQUEST_ID} header — the id of the upstream message
+ *                       this one was derived from. May be {@code null}.
+ * @param execPath       Value of the {@link TelicentHeaders#EXEC_PATH} header — the list of services the message has
+ *                       traversed, as the raw header string. May be {@code null}. See {@link #execPathSteps()}.
+ * @param distributionId Value of the {@link TelicentHeaders#DISTRIBUTION_ID} header — links the data back to its
+ *                       catalogue (DCAT) distribution. May be {@code null}.
+ * @param securityLabel  Value of the {@link TelicentHeaders#SECURITY_LABEL} header — the default ABAC label applied to
+ *                       the data. May be {@code null}.
+ * @param ingestedAt     The instant at which this provenance was captured (i.e. when the data was ingested). Never
+ *                       {@code null}.
+ */
+public record ProvenanceRecord(String requestId, String inputRequestId, String execPath, String distributionId,
+                               String securityLabel, Instant ingestedAt) {
+
+    /**
+     * Canonical constructor.
+     *
+     * @throws NullPointerException if {@code ingestedAt} is {@code null}
+     */
+    public ProvenanceRecord {
+        Objects.requireNonNull(ingestedAt, "ingestedAt cannot be null");
+    }
+
+    /**
+     * Captures the provenance headers from the given event, timestamped with the current instant.
+     *
+     * @param event Event to capture provenance from
+     * @return Provenance record
+     * @throws NullPointerException if {@code event} is {@code null}
+     */
+    public static ProvenanceRecord fromEvent(Event<?, ?> event) {
+        return fromEvent(event, Instant.now());
+    }
+
+    /**
+     * Captures the provenance headers from the given event using a caller-supplied ingest timestamp.
+     * <p>
+     * The explicit-timestamp overload exists primarily so that callers operating on a batch of events can apply a single
+     * consistent ingest time, and so that tests are deterministic.
+     * </p>
+     *
+     * @param event      Event to capture provenance from
+     * @param ingestedAt The ingest timestamp to record
+     * @return Provenance record
+     * @throws NullPointerException if {@code event} or {@code ingestedAt} is {@code null}
+     */
+    public static ProvenanceRecord fromEvent(Event<?, ?> event, Instant ingestedAt) {
+        Objects.requireNonNull(event, "event cannot be null");
+        return new ProvenanceRecord(event.lastHeader(TelicentHeaders.REQUEST_ID),
+                                    event.lastHeader(TelicentHeaders.INPUT_REQUEST_ID),
+                                    event.lastHeader(TelicentHeaders.EXEC_PATH),
+                                    event.lastHeader(TelicentHeaders.DISTRIBUTION_ID),
+                                    event.lastHeader(TelicentHeaders.SECURITY_LABEL), ingestedAt);
+    }
+
+    /**
+     * Splits the {@link #execPath()} header into its individual steps.
+     * <p>
+     * NOTE: a comma is assumed to be the delimiter between steps. This matches the common rendering but
+     * <strong>should be confirmed against the canonical {@code telicent-lib} provenance format</strong> before this is
+     * relied upon in production; if the delimiter differs this is the single place to change it.
+     * </p>
+     *
+     * @return Ordered list of execution-path steps, trimmed and with empty entries removed; empty if no exec path is
+     * present
+     */
+    public List<String> execPathSteps() {
+        if (this.execPath == null || this.execPath.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(this.execPath.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList();
+    }
+
+    /**
+     * Indicates whether any provenance information was actually present on the event.
+     *
+     * @return {@code true} if at least one provenance header was captured, {@code false} if none were present
+     */
+    public boolean hasProvenance() {
+        return this.requestId != null || this.inputRequestId != null || this.execPath != null
+               || this.distributionId != null || this.securityLabel != null;
+    }
+}

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/provenance/ProvenanceRecord.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/provenance/ProvenanceRecord.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  * An immutable, dependency-free snapshot of the provenance/audit information carried by an {@link Event} as it is
  * ingested into the platform.
  * <p>
- * The platform's Kafka messages carry a number of provenance & audit headers (see {@link TelicentHeaders}) describing how
+ * The platform's Kafka messages carry a number of provenance and audit headers (see {@link TelicentHeaders}) describing how
  * a message has flowed through the system. These headers are normally consumed and then discarded during ingest, which
  * means the provenance cannot be queried after the fact. This record captures those values at the point of ingest so
  * that downstream, RDF-aware components (for example the Fuseki-Kafka connector or the catalogue updater) can persist

--- a/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/provenance/ProvenanceVocabulary.java
+++ b/event-sources/event-sources-core/src/main/java/io/telicent/smart/cache/sources/provenance/ProvenanceVocabulary.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.provenance;
+
+/**
+ * Shared, dependency-free vocabulary for representing Provenance information as RDF.
+ * <p>
+ * These are plain {@link String} IRI constants (and small IRI-minting helpers) rather than Apache Jena
+ * {@code Resource}/{@code Property} objects, deliberately, so that this vocabulary can live in the common
+ * {@code event-sources-core} module without forcing an RDF/Jena dependency onto it. RDF-aware modules (the
+ * Fuseki-Kafka connector, the catalogue updater, etc.) construct their own framework objects from these IRIs, ensuring
+ * every component emits provenance using the same terms.
+ * </p>
+ * <p>
+ * The model follows W3C PROV-O, aligned with DCAT 3 (the vocabulary already used by the Telicent catalogue), which is
+ * the recommended pairing because PROV and DCAT 3 are designed to interoperate. In outline: an ingest <em>Activity</em>
+ * (identified by the request id) <em>generates</em> the ingested data <em>Entity</em>, which is <em>derived from</em> a
+ * {@code dcat:Distribution}; the activity records the ingest time, security label and execution path.
+ * </p>
+ */
+public final class ProvenanceVocabulary {
+
+    private ProvenanceVocabulary() {
+    }
+
+    /** W3C PROV-O namespace. */
+    public static final String PROV_NS = "http://www.w3.org/ns/prov#";
+    /** W3C DCAT namespace. */
+    public static final String DCAT_NS = "http://www.w3.org/ns/dcat#";
+    /** Dublin Core terms namespace. */
+    public static final String DCTERMS_NS = "http://purl.org/dc/terms/";
+    /** XML Schema datatypes namespace. */
+    public static final String XSD_NS = "http://www.w3.org/2001/XMLSchema#";
+
+    /** Telicent provenance term/instance namespace (for concepts without a standard equivalent). */
+    public static final String TELICENT_PROV_NS = "http://telicent.io/provenance#";
+    /** Base IRI for the per-distribution named graph that holds captured provenance. */
+    public static final String TELICENT_PROV_GRAPH_BASE = "http://telicent.io/provenance/";
+
+    // ----- PROV-O classes -----
+    /** {@code prov:Entity}. */
+    public static final String PROV_ENTITY = PROV_NS + "Entity";
+    /** {@code prov:Activity}. */
+    public static final String PROV_ACTIVITY = PROV_NS + "Activity";
+
+    // ----- PROV-O properties -----
+    /** {@code prov:wasGeneratedBy} — links the data entity to the ingest activity. */
+    public static final String PROV_WAS_GENERATED_BY = PROV_NS + "wasGeneratedBy";
+    /** {@code prov:wasDerivedFrom} — links the data entity to the source distribution. */
+    public static final String PROV_WAS_DERIVED_FROM = PROV_NS + "wasDerivedFrom";
+    /** {@code prov:generatedAtTime} — the ingest timestamp ({@code xsd:dateTime}). */
+    public static final String PROV_GENERATED_AT_TIME = PROV_NS + "generatedAtTime";
+    /** {@code prov:wasAttributedTo} — the agent responsible (e.g. the asserting user, for write-back). */
+    public static final String PROV_WAS_ATTRIBUTED_TO = PROV_NS + "wasAttributedTo";
+    /** {@code prov:used} — an input used by the ingest activity (e.g. the upstream message). */
+    public static final String PROV_USED = PROV_NS + "used";
+
+    // ----- DCAT terms -----
+    /** {@code dcat:Distribution}. */
+    public static final String DCAT_DISTRIBUTION = DCAT_NS + "Distribution";
+    /** {@code dcat:DataService}. */
+    public static final String DCAT_DATA_SERVICE = DCAT_NS + "DataService";
+    /** {@code dcat:accessURL}. */
+    public static final String DCAT_ACCESS_URL = DCAT_NS + "accessURL";
+    /** {@code dcat:accessService} — links a distribution to the data service that serves it ("how" to reach it). */
+    public static final String DCAT_ACCESS_SERVICE = DCAT_NS + "accessService";
+
+    // ----- Dublin Core terms -----
+    /** {@code dcterms:source}. */
+    public static final String DCTERMS_SOURCE = DCTERMS_NS + "source";
+    /** {@code dcterms:identifier}. */
+    public static final String DCTERMS_IDENTIFIER = DCTERMS_NS + "identifier";
+
+    // ----- Telicent-specific provenance terms (no direct standard equivalent) -----
+    /** Property recording the ABAC security label that applied to the data at ingest. */
+    public static final String TELICENT_SECURITY_LABEL = TELICENT_PROV_NS + "securityLabel";
+    /** Property recording the raw execution-path header. */
+    public static final String TELICENT_EXEC_PATH = TELICENT_PROV_NS + "execPath";
+    /** Property recording the request id that produced the data. */
+    public static final String TELICENT_REQUEST_ID = TELICENT_PROV_NS + "requestId";
+    /** Property recording the input (upstream) request id the data was derived from. */
+    public static final String TELICENT_INPUT_REQUEST_ID = TELICENT_PROV_NS + "inputRequestId";
+
+    // ----- IRI minting helpers -----
+
+    /**
+     * Mints the IRI for the ingest activity identified by a request id.
+     * <p>
+     * Callers are responsible for ensuring the identifier is IRI-safe (platform request ids are UUIDs, which are). If
+     * identifiers from less controlled sources are ever used, percent-encode them before calling this.
+     * </p>
+     *
+     * @param requestId Request id
+     * @return Activity IRI
+     */
+    public static String activityIri(String requestId) {
+        return TELICENT_PROV_NS + "activity/" + requestId;
+    }
+
+    /**
+     * Mints the IRI for the catalogue distribution identified by a distribution id.
+     *
+     * @param distributionId Distribution id
+     * @return Distribution IRI
+     */
+    public static String distributionIri(String distributionId) {
+        return TELICENT_PROV_NS + "distribution/" + distributionId;
+    }
+
+    /**
+     * Mints the IRI of the named graph used to hold captured provenance for a given distribution.
+     *
+     * @param distributionId Distribution id
+     * @return Provenance named-graph IRI
+     */
+    public static String provenanceGraphIri(String distributionId) {
+        return TELICENT_PROV_GRAPH_BASE + distributionId;
+    }
+}

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/provenance/TestProvenanceRecord.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/provenance/TestProvenanceRecord.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.provenance;
+
+import io.telicent.smart.cache.sources.Event;
+import io.telicent.smart.cache.sources.EventHeader;
+import io.telicent.smart.cache.sources.Header;
+import io.telicent.smart.cache.sources.memory.SimpleEvent;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static io.telicent.smart.cache.sources.TelicentHeaders.DISTRIBUTION_ID;
+import static io.telicent.smart.cache.sources.TelicentHeaders.EXEC_PATH;
+import static io.telicent.smart.cache.sources.TelicentHeaders.INPUT_REQUEST_ID;
+import static io.telicent.smart.cache.sources.TelicentHeaders.REQUEST_ID;
+import static io.telicent.smart.cache.sources.TelicentHeaders.SECURITY_LABEL;
+
+public class TestProvenanceRecord {
+
+    private static Event<String, String> eventWith(EventHeader... headers) {
+        return new SimpleEvent<>(List.of(headers), "key", "value");
+    }
+
+    @Test
+    public void givenAllProvenanceHeaders_whenFromEvent_thenAllCaptured() {
+        // Given
+        Event<String, String> event = eventWith(new Header(REQUEST_ID, "req-1"),
+                                                 new Header(INPUT_REQUEST_ID, "in-1"),
+                                                 new Header(EXEC_PATH, "adapter, mapper, projector"),
+                                                 new Header(DISTRIBUTION_ID, "dist-1"),
+                                                 new Header(SECURITY_LABEL, "clearance=secret"));
+        Instant ts = Instant.parse("2026-06-12T10:00:00Z");
+
+        // When
+        ProvenanceRecord rec = ProvenanceRecord.fromEvent(event, ts);
+
+        // Then
+        Assert.assertEquals(rec.requestId(), "req-1");
+        Assert.assertEquals(rec.inputRequestId(), "in-1");
+        Assert.assertEquals(rec.execPath(), "adapter, mapper, projector");
+        Assert.assertEquals(rec.distributionId(), "dist-1");
+        Assert.assertEquals(rec.securityLabel(), "clearance=secret");
+        Assert.assertEquals(rec.ingestedAt(), ts);
+        Assert.assertTrue(rec.hasProvenance());
+    }
+
+    @Test
+    public void givenExecPathHeader_whenExecPathSteps_thenSplitTrimmedAndOrdered() {
+        // Given
+        Event<String, String> event = eventWith(new Header(EXEC_PATH, "adapter, mapper ,projector"));
+
+        // When
+        List<String> steps = ProvenanceRecord.fromEvent(event).execPathSteps();
+
+        // Then
+        Assert.assertEquals(steps, List.of("adapter", "mapper", "projector"));
+    }
+
+    @Test
+    public void givenNoHeaders_whenFromEvent_thenNullsEmptyStepsAndNoProvenance() {
+        // Given
+        Event<String, String> event = new SimpleEvent<>(List.of(), "key", "value");
+
+        // When
+        ProvenanceRecord rec = ProvenanceRecord.fromEvent(event);
+
+        // Then
+        Assert.assertNull(rec.requestId());
+        Assert.assertNull(rec.inputRequestId());
+        Assert.assertNull(rec.execPath());
+        Assert.assertNull(rec.distributionId());
+        Assert.assertNull(rec.securityLabel());
+        Assert.assertTrue(rec.execPathSteps().isEmpty());
+        Assert.assertFalse(rec.hasProvenance());
+        Assert.assertNotNull(rec.ingestedAt());
+    }
+
+    @Test
+    public void givenRepeatedHeader_whenFromEvent_thenLastValueWins() {
+        // Given - mirrors the platform rule that the last header value is the one that applies
+        Event<String, String> event = eventWith(new Header(DISTRIBUTION_ID, "dist-old"),
+                                                 new Header(DISTRIBUTION_ID, "dist-new"));
+
+        // When
+        ProvenanceRecord rec = ProvenanceRecord.fromEvent(event);
+
+        // Then
+        Assert.assertEquals(rec.distributionId(), "dist-new");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void givenNullEvent_whenFromEvent_thenThrows() {
+        // Given, When and Then
+        ProvenanceRecord.fromEvent(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void givenNullTimestamp_whenConstructing_thenThrows() {
+        // Given, When and Then
+        new ProvenanceRecord(null, null, null, null, null, null);
+    }
+}

--- a/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/provenance/TestProvenanceVocabulary.java
+++ b/event-sources/event-sources-core/src/test/java/io/telicent/smart/cache/sources/provenance/TestProvenanceVocabulary.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) Telicent Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.telicent.smart.cache.sources.provenance;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TestProvenanceVocabulary {
+
+    @Test
+    public void givenRequestId_whenMintingActivityIri_thenWithinTelicentNamespaceAndContainsId() {
+        // Given, When
+        String iri = ProvenanceVocabulary.activityIri("req-1");
+
+        // Then
+        Assert.assertTrue(iri.startsWith(ProvenanceVocabulary.TELICENT_PROV_NS), "should be in Telicent prov namespace");
+        Assert.assertTrue(iri.endsWith("req-1"), "should embed the request id");
+    }
+
+    @Test
+    public void givenDistributionId_whenMintingDistributionIri_thenWithinTelicentNamespaceAndContainsId() {
+        // Given, When
+        String iri = ProvenanceVocabulary.distributionIri("dist-1");
+
+        // Then
+        Assert.assertTrue(iri.startsWith(ProvenanceVocabulary.TELICENT_PROV_NS));
+        Assert.assertTrue(iri.endsWith("dist-1"));
+    }
+
+    @Test
+    public void givenDistributionId_whenMintingProvenanceGraphIri_thenUsesGraphBase() {
+        // Given, When
+        String iri = ProvenanceVocabulary.provenanceGraphIri("dist-1");
+
+        // Then
+        Assert.assertEquals(iri, ProvenanceVocabulary.TELICENT_PROV_GRAPH_BASE + "dist-1");
+    }
+
+    @Test
+    public void givenProvTerms_whenInspected_thenWithinProvNamespace() {
+        // Given, When and Then
+        Assert.assertTrue(ProvenanceVocabulary.PROV_ENTITY.startsWith(ProvenanceVocabulary.PROV_NS));
+        Assert.assertTrue(ProvenanceVocabulary.PROV_ACTIVITY.startsWith(ProvenanceVocabulary.PROV_NS));
+        Assert.assertTrue(ProvenanceVocabulary.PROV_WAS_GENERATED_BY.startsWith(ProvenanceVocabulary.PROV_NS));
+        Assert.assertTrue(ProvenanceVocabulary.PROV_WAS_DERIVED_FROM.startsWith(ProvenanceVocabulary.PROV_NS));
+    }
+
+    @Test
+    public void givenDcatTerms_whenInspected_thenWithinDcatNamespace() {
+        // Given, When and Then
+        Assert.assertTrue(ProvenanceVocabulary.DCAT_DISTRIBUTION.startsWith(ProvenanceVocabulary.DCAT_NS));
+        Assert.assertTrue(ProvenanceVocabulary.DCAT_DATA_SERVICE.startsWith(ProvenanceVocabulary.DCAT_NS));
+        Assert.assertTrue(ProvenanceVocabulary.DCAT_ACCESS_SERVICE.startsWith(ProvenanceVocabulary.DCAT_NS));
+    }
+}


### PR DESCRIPTION
To allow for a potential quick-win on the GUI side. Some corresponding tweaks to SC Docs and Jena Fuseki Kafka to follow that will be env var driven.

It's backwards compatible and has no impact and so can be removed/changed in future with minimal effort. 