### PR TITLE
Improve runtime memory reporting (CORE-1147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 
-# 0.40.1
+# 0.40.2
+
+- Observability Improvements: 
+    - Printing runtime info now includes Max, Total and Free Memory
+    - CLI and JAX-RS servers will periodically report runtime memory information over the lifetime of the application
+
+# 0.40.1
 
 - Distribution Lifecycle
    - Improved API contract for `DistributionLifecycleStateStore` and added fuller contract test suite for
@@ -19,12 +25,14 @@
   - Added `DistributionLifecycleTracker` for tracking active distribution lifecycle state across partitions
   - Added `DistributionLifecycleTrackerRegistry` for managing multiple tracker instances
   - Added `DistributionLifecycleProjector` for projecting lifecycle events into a state store
-  - Added event listener implementations: `AcknowledgingListener`, `DistributionLifecycleStateStoreSink`, and `LoggingListener`
+  - Added event listener implementations: `AcknowledgingListener`, `DistributionLifecycleStateStoreSink`, and
+    `LoggingListener`
   - Fixed: active distribution events are now re-triggered on service restart
   - Added new utility classes `DocumentIdGenerator` and `HexGenerator`
   - Added unit tests for `DocumentIdGenerator` and `HexGenerator`
 - CLI improvements:
-  - Added `DistributionLifecycleTrackerOptions` to support configuring a distribution lifecycle tracker via CLI arguments and environment variables
+  - Added `DistributionLifecycleTrackerOptions` to support configuring a distribution lifecycle tracker via CLI
+    arguments and environment variables
 
 # 0.39.0
 - Build improvements:

--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/CliEnvironmentVariables.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/CliEnvironmentVariables.java
@@ -81,6 +81,21 @@ public class CliEnvironmentVariables {
      */
     public static final String ENABLE_RUNTIME_INFO = "ENABLE_RUNTIME_INFO";
     /**
+     * Environment variable that controls the interval in minutes at which memory information is reported during the
+     * life of the CLI command.
+     * <p>
+     * This only has an effect if {@link #ENABLE_RUNTIME_INFO} is not set to {@code false} and this variable is set to a
+     * positive non-zero value.
+     * </p>
+     * <p>
+     * Equivalent to specifying the {@code --memory-info-interval} option to a CLI command.
+     * </p>
+     * <p>
+     * See also {@link LoggingOptions}.
+     * </p>
+     */
+    public static final String MEMORY_INFO_INTERVAL = "MEMORY_INFO_INTERVAL";
+    /**
      * Environment variable that controls the lag reporting interval in seconds that is used for
      * {@link io.telicent.smart.cache.sources.kafka.KafkaEventSource} instances
      * <p>

--- a/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/LoggingOptions.java
+++ b/cli/cli-core/src/main/java/io/telicent/smart/cache/cli/options/LoggingOptions.java
@@ -19,8 +19,11 @@ import ch.qos.logback.classic.Level;
 import com.github.rvesse.airline.annotations.Option;
 import io.telicent.smart.cache.configuration.Configurator;
 import io.telicent.smart.cache.observability.RuntimeInfo;
+import io.telicent.smart.cache.projectors.utils.PeriodicAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
 
 /**
  * Provides common options related to controlling the application logging at runtime
@@ -33,7 +36,8 @@ public class LoggingOptions {
     @Option(name = {
             "--verbose", "--debug"
     }, arity = 0, description = "Specifies verbose mode i.e. increased logging verbosity. " + MULTIPLE_OPTIONS_BEHAVIOUR)
-    boolean verbose = Configurator.get(new String[] { CliEnvironmentVariables.VERBOSE, CliEnvironmentVariables.DEBUG }, Boolean::parseBoolean, false);
+    boolean verbose = Configurator.get(new String[] { CliEnvironmentVariables.VERBOSE, CliEnvironmentVariables.DEBUG },
+                                       Boolean::parseBoolean, false);
 
     @Option(name = { "--trace" }, arity = 0, description = "Specifies trace mode i.e. greatly increased logging verbosity. " + MULTIPLE_OPTIONS_BEHAVIOUR)
     boolean trace = Configurator.get(CliEnvironmentVariables.TRACE, Boolean::parseBoolean, false);
@@ -47,12 +51,15 @@ public class LoggingOptions {
     boolean showRuntimeInfo =
             Configurator.get(CliEnvironmentVariables.ENABLE_RUNTIME_INFO, Boolean::parseBoolean, true);
 
+    @Option(name = "--memory-info-interval", arity = 1, title = "Minutes", description = "When specified will print memory usage information every few minutes to provide a general overview of memory usage of the program over time, disabled via the --no-runtime-info option or setting this interval to a negative value.")
+    long memoryInfoInterval = Configurator.get(CliEnvironmentVariables.MEMORY_INFO_INTERVAL, Long::parseLong, 5L);
+
     /**
      * (Re-)configures logging based on the provided CLI options (if any)
      * <p>
      * This potentially overrides the root logger level set by any Logback configuration file the application is
      * providing.  However, since we are only changing the root logger level if an application has explicitly set the
-     * log level for another logger then that level continues to be honoured irregardless of what the user configures at
+     * log level for another logger then that level continues to be honoured regardless of what the user configures at
      * runtime via these options.
      * </p>
      */
@@ -79,6 +86,14 @@ public class LoggingOptions {
         } else if (this.quiet) {
             root.setLevel(Level.WARN);
             logger.warn("Logging set to WARN level as requested (--quiet supplied)");
+        }
+
+        // If enabled periodically log memory info
+        if (!this.quiet && this.showRuntimeInfo && this.memoryInfoInterval > 0) {
+            logger.info("Configured to report memory information every {} minutes", this.memoryInfoInterval);
+            PeriodicAction logMemory = new PeriodicAction(() -> RuntimeInfo.printMemoryInfo(logger),
+                                                          Duration.ofMinutes(this.memoryInfoInterval));
+            logMemory.autoTrigger();
         }
     }
 

--- a/jaxrs-base-server/pom.xml
+++ b/jaxrs-base-server/pom.xml
@@ -22,6 +22,12 @@
 
         <dependency>
             <groupId>io.telicent.smart-caches</groupId>
+            <artifactId>projectors-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.telicent.smart-caches</groupId>
             <artifactId>configurator</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/init/ServerRuntimeInfo.java
+++ b/jaxrs-base-server/src/main/java/io/telicent/smart/cache/server/jaxrs/init/ServerRuntimeInfo.java
@@ -15,10 +15,14 @@
  */
 package io.telicent.smart.cache.server.jaxrs.init;
 
+import io.telicent.smart.cache.configuration.Configurator;
 import io.telicent.smart.cache.observability.RuntimeInfo;
+import io.telicent.smart.cache.projectors.utils.PeriodicAction;
 import jakarta.servlet.ServletContextEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
 
 /**
  * A Servlet context initialiser that will print information about the servers runtime environment at startup
@@ -45,5 +49,26 @@ public class ServerRuntimeInfo implements ServerConfigInit {
 
         // Also dump LibraryVersion information
         RuntimeInfo.printLibraryVersions(LOGGER);
+
+        // Periodically log memory usage
+        long interval = Configurator.get("MEMORY_INFO_INTERVAL", Long::parseLong, 5L);
+        if (interval > 0) {
+            LOGGER.info("Configured to report memory information every {} minutes", interval);
+            PeriodicAction memoryReporter =
+                    new PeriodicAction(() -> RuntimeInfo.printMemoryInfo(LOGGER), Duration.ofMinutes(interval));
+            memoryReporter.autoTrigger();
+            sce.getServletContext().setAttribute(ServerRuntimeInfo.class.getCanonicalName(), memoryReporter);
+        } else {
+            LOGGER.info("Periodic memory reporting disabled");
+        }
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+        PeriodicAction memoryReporter =
+                (PeriodicAction) sce.getServletContext().getAttribute(ServerRuntimeInfo.class.getCanonicalName());
+        if (memoryReporter != null) {
+            memoryReporter.cancelAutoTrigger();
+        }
     }
 }

--- a/observability-core/src/main/java/io/telicent/smart/cache/observability/RuntimeInfo.java
+++ b/observability-core/src/main/java/io/telicent/smart/cache/observability/RuntimeInfo.java
@@ -40,13 +40,32 @@ public class RuntimeInfo {
      * @param logger Logger to output to
      */
     public static void printRuntimeInfo(Logger logger) {
-        double rawMemory = Runtime.getRuntime().maxMemory();
-        Pair<Double, String> memory = RuntimeInfo.parseMemory(rawMemory);
-        logger.info("Processors: {}", Runtime.getRuntime().availableProcessors());
-        logger.info("Memory:     {} {}", String.format("%.2f", memory.getKey()), memory.getValue());
-        logger.info("Java:       {}", System.getProperty("java.version"));
-        logger.info("OS:         {} {} {}", System.getProperty("os.name"), System.getProperty("os.version"),
+        logger.info("Processors:   {}", Runtime.getRuntime().availableProcessors());
+        printMemoryInfo(logger);
+        logger.info("Java:         {}", System.getProperty("java.version"));
+        logger.info("OS:           {} {} {}", System.getProperty("os.name"), System.getProperty("os.version"),
                     System.getProperty("os.arch"));
+    }
+
+    /**
+     * Prints information about maximum, total and free memory
+     * <p>
+     * While max memory is generally fixed for the lifetime of a Java process the total and free memory will vary as the
+     * application performs work and the JVM grows/shrinks the heap (depending on JVM settings).
+     * </p>
+     *
+     * @param logger Logger to output to
+     */
+    public static void printMemoryInfo(Logger logger) {
+        double rawMaxMemory = Runtime.getRuntime().maxMemory();
+        double rawTotalMemory = Runtime.getRuntime().totalMemory();
+        double rawFreeMemory = Runtime.getRuntime().freeMemory();
+        Pair<Double, String> maxMemory = RuntimeInfo.parseMemory(rawMaxMemory);
+        Pair<Double, String> totalMemory = RuntimeInfo.parseMemory(rawTotalMemory);
+        Pair<Double, String> freeMemory = RuntimeInfo.parseMemory(rawFreeMemory);
+        logger.info("Max Memory:   {} {}", String.format("%.2f", maxMemory.getKey()), maxMemory.getValue());
+        logger.info("Total Memory: {} {}", String.format("%.2f", totalMemory.getKey()), totalMemory.getValue());
+        logger.info("Free Memory:  {} {}", String.format("%.2f", freeMemory.getKey()), freeMemory.getValue());
     }
 
     /**

--- a/projectors-core/src/main/java/io/telicent/smart/cache/projectors/utils/PeriodicAction.java
+++ b/projectors-core/src/main/java/io/telicent/smart/cache/projectors/utils/PeriodicAction.java
@@ -17,10 +17,7 @@ package io.telicent.smart.cache.projectors.utils;
 
 import java.time.Duration;
 import java.util.Objects;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 
 /**
  * Represents an action that you only want to run at most once within any given interval.
@@ -172,7 +169,11 @@ public class PeriodicAction {
                 return;
             }
 
-            this.executor = Executors.newSingleThreadExecutor();
+            this.executor = Executors.newSingleThreadExecutor(r -> {
+                Thread t = new Thread(r);
+                t.setDaemon(true);
+                return t;
+            });
             this.runAutoTrigger = true;
             this.autoTrigger = this.executor.submit(() -> {
                 while (this.runAutoTrigger) {


### PR DESCRIPTION
Report Max, Total and Free memory separately rather than just Max which may be misleading.

Also adds periodic reporting (every 5 minutes) of memory usage to aid debugging/monitoring